### PR TITLE
Callers can now pass StatusMessageHandler to pull method

### DIFF
--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -106,6 +106,15 @@ public interface DockerClient {
       throws DockerException, InterruptedException;
 
   /**
+   * Pull a docker container image, using a custom ProgressMessageHandler
+   *
+   * @param image The image to pull.
+   * @param handler The handler to use for processing each progress message received from Docker.
+   */
+  void pull(String image, ProgressHandler handler)
+      throws DockerException, InterruptedException;
+
+  /**
    * Tag a docker image.
    *
    * @param image The image to tag.

--- a/src/main/java/com/spotify/docker/client/LoggingProgressHandler.java
+++ b/src/main/java/com/spotify/docker/client/LoggingProgressHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client;
+
+import com.spotify.docker.client.messages.ProgressMessage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LoggingProgressHandler implements ProgressHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(LoggingProgressHandler.class);
+
+  private final String image;
+
+  public LoggingProgressHandler(String image) {
+    this.image = image;
+  }
+
+  @Override
+  public void progress(ProgressMessage message) throws DockerException {
+    if (message.error() != null) {
+      if (message.error().contains("404")) {
+        throw new ImageNotFoundException(image, message.toString());
+      } else {
+        throw new ImagePullFailedException(image, message.toString());
+      }
+    }
+
+    log.info("pull {}: {}", image, message);
+  }
+
+}

--- a/src/main/java/com/spotify/docker/client/ProgressHandler.java
+++ b/src/main/java/com/spotify/docker/client/ProgressHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client;
+
+import com.spotify.docker.client.messages.ProgressMessage;
+
+/**
+ * Handler for processing progress messages received from Docker during pull, push and build
+ * operations.
+ */
+public interface ProgressHandler {
+
+  /**
+   * This method will be called for each progress message received from Docker.
+   *
+   * @param message the message to process
+   * @throws DockerException
+   */
+  void progress(ProgressMessage message) throws DockerException;
+
+}

--- a/src/main/java/com/spotify/docker/client/messages/ProgressDetail.java
+++ b/src/main/java/com/spotify/docker/client/messages/ProgressDetail.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client.messages;
+
+import com.google.common.base.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ProgressDetail {
+
+  @JsonProperty private long current;
+  @JsonProperty private long start;
+  @JsonProperty private long total;
+
+  public long current() {
+    return current;
+  }
+
+  public long start() {
+    return start;
+  }
+
+  public long total() {
+    return total;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("current", current)
+        .add("start", start)
+        .add("total", total)
+        .toString();
+  }
+
+}

--- a/src/main/java/com/spotify/docker/client/messages/ProgressMessage.java
+++ b/src/main/java/com/spotify/docker/client/messages/ProgressMessage.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client.messages;
+
+import com.google.common.base.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ProgressMessage {
+
+  @JsonProperty private String id;
+  @JsonProperty private String status;
+  @JsonProperty private String stream;
+  @JsonProperty private String error;
+  @JsonProperty private String progress;
+  @JsonProperty private ProgressDetail progressDetail;
+
+  public String id() {
+    return id;
+  }
+
+  public String status() {
+    return status;
+  }
+
+  public String stream() {
+    return stream;
+  }
+
+  public String error() {
+    return error;
+  }
+
+  public String progress() {
+    return progress;
+  }
+
+  public ProgressDetail progressDetail() {
+    return progressDetail;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("id", id)
+        .add("status", status)
+        .add("stream", stream)
+        .add("error", error)
+        .add("progress", progress)
+        .add("progressDetail", progressDetail)
+        .toString();
+  }
+
+}


### PR DESCRIPTION
This allows callers to define how they want to handle status messages
received from docker during the pull. If the caller does not provide
a handler, a default one will be used which logs each message.
