### PR TITLE
Enable client to be run on windows OS.

### DIFF
--- a/src/test/java/com/spotify/docker/client/CompressedDirectoryTest.java
+++ b/src/test/java/com/spotify/docker/client/CompressedDirectoryTest.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.net.URL;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,8 +44,9 @@ public class CompressedDirectoryTest {
 
   @Test
   public void testFile() throws Exception {
-    final String dockerDirectory = Resources.getResource("dockerDirectory").getPath();
-    final File file = CompressedDirectory.create(dockerDirectory);
+    // note: Paths.get(someURL.toUri()) is the platform-neutral way to convert a URL to a Path
+    final URL dockerDirectory = Resources.getResource("dockerDirectory");
+    final File file = CompressedDirectory.create(Paths.get(dockerDirectory.toURI()));
     try (BufferedInputStream fileIn = new BufferedInputStream(new FileInputStream(file));
          GzipCompressorInputStream gzipIn = new GzipCompressorInputStream(fileIn);
          TarArchiveInputStream tarIn = new TarArchiveInputStream(gzipIn)) {


### PR DESCRIPTION
The motivation behind this change is to be able to use the spotify docker maven plugin on my local dev environment (a windows machine).

CompressedDirectory currently obtains PosixFileAttributes to preserve file permissions when building the tar. When executed on a windows FS, this throws an UnsupportedOperationException. Have made this code more tolerant if executed on Windows.

Initial unit test on the class was failing on windows. My change enabled it to pass. I also had to modify the way in which the test instance was constructed because URL.getPath() did not generate a valid windows file path.
