### PR TITLE
TravisCI: Test Unix socket support

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -22,6 +22,12 @@ case "$1" in
 
     VERBOSE=1 sekexe/run "docker -d -H tcp://0.0.0.0:2375" &
 
+    if [ $UNIX_SOCKETS == "yes" ]
+    then
+      socat UNIX-LISTEN:/tmp/docker.sock,fork TCP4:$HOST_IP:2375 &
+      export DOCKER_HOST=unix:///tmp/docker.sock
+    fi
+
     while ! docker info; do sleep 1; done
 
     ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ before_install:
 
 before_script:
   - . .travis.sh before_script
+
+env:
+  - UNIX_SOCKETS=no
+  - UNIX_SOCKETS=yes


### PR DESCRIPTION
Rather than just running all tests against an HTTP endpoint, run two
workers in parallel -- with one using HTTP and the other using Unix
sockets.
