### PR TITLE
Fix test image to be all lowercase for Docker v1.3

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -286,7 +286,7 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testBuildName() throws Exception {
-    final String imageName = "testBuildName";
+    final String imageName = "test-build-name";
     final String dockerDirectory = Resources.getResource("dockerDirectory").getPath();
     final String imageId = sut.build(Paths.get(dockerDirectory), imageName);
     final ImageInfo info = sut.inspectImage(imageName);


### PR DESCRIPTION
Docker v1.3.0 requires all image names to be entirely lowercase.
