### PR TITLE
Fix Javadoc warning for PosixFileAttributeView

### DIFF
--- a/src/main/java/com/spotify/docker/client/CompressedDirectory.java
+++ b/src/main/java/com/spotify/docker/client/CompressedDirectory.java
@@ -38,6 +38,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.EnumSet;


### PR DESCRIPTION
PosixFileAttributeView was referenced in the Javadoc, but
the class was not imported which caused this build warning:

`warning - Tag @see: reference not found: PosixFileAttributeView#name()`
