### PR TITLE
Change unrouteable address for testConnectTimeout

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -629,9 +629,9 @@ public class DefaultDockerClientTest {
 
   @Test(expected = DockerTimeoutException.class)
   public void testConnectTimeout() throws Exception {
-    // Attempt to connect to an unroutable ip address -> connect will time out.
+    // Attempt to connect to reserved IP -> should timeout
     try (final DefaultDockerClient connectTimeoutClient = DefaultDockerClient.builder()
-        .uri("http://172.31.255.1:2375")
+        .uri("http://240.0.0.1:2375")
         .connectTimeoutMillis(100)
         .readTimeoutMillis(NO_TIMEOUT)
         .build()) {


### PR DESCRIPTION
Some networks actually try to route the unroutable private IP address that
was being used by testConnectTimeout (172.31.255.1), and then report a
connection refused instead of a timeout, causing the test to fail.

Instead switch to the address 240.0.0.1, which is reserved for future use
and is routable, but is effectively a black hole.
