### PR TITLE
Stop test-docker-ssl container gracefully

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -780,6 +780,8 @@ public class DefaultDockerClientTest {
     final DockerClient c = new DefaultDockerClient(URI.create(format("https://%s:%s", host, port)),
                                                    certs);
     assertThat(c.ping(), equalTo("OK"));
+
+    sut.stopContainer(containerId, 10);
   }
 
   private String randomName() {


### PR DESCRIPTION
Stop the container gracefully so that Docker cleans up after itself.
Otherwise, future iterations of the same test fail since we run out of
loopback devices.
