### PR TITLE
Add Info.memoryLimit() and Info.swapLimit()

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/Info.java
+++ b/src/main/java/com/spotify/docker/client/messages/Info.java
@@ -40,6 +40,8 @@ public class Info {
   @JsonProperty("NEventsListener") private int eventsListener;
   @JsonProperty("InitPath") private String initPath;
   @JsonProperty("Sockets") private List<String> sockets;
+  @JsonProperty("MemoryLimit") private Boolean memoryLimit;
+  @JsonProperty("SwapLimit") private Boolean swapLimit;
 
   public int containers() {
     return containers;
@@ -83,6 +85,14 @@ public class Info {
 
   public List<String> sockets() {
     return sockets;
+  }
+
+  public boolean memoryLimit() {
+    return memoryLimit;
+  }
+
+  public boolean swapLimit() {
+    return swapLimit;
   }
 
   @Override
@@ -132,6 +142,14 @@ public class Info {
                               : info.storageDriver != null) {
       return false;
     }
+    if (memoryLimit != null ? !memoryLimit.equals(info.memoryLimit)
+                            : info.memoryLimit != null) {
+      return false;
+    }
+    if (swapLimit != null ? !swapLimit.equals(info.swapLimit)
+                            : info.swapLimit != null) {
+      return false;
+    }
 
     return true;
   }
@@ -149,6 +167,8 @@ public class Info {
     result = 31 * result + eventsListener;
     result = 31 * result + (initPath != null ? initPath.hashCode() : 0);
     result = 31 * result + (sockets != null ? sockets.hashCode() : 0);
+    result = 31 * result + (memoryLimit != null ? memoryLimit.hashCode() : 0);
+    result = 31 * result + (swapLimit != null ? swapLimit.hashCode() : 0);
     return result;
   }
 
@@ -166,6 +186,8 @@ public class Info {
            ", eventsListener=" + eventsListener +
            ", initPath='" + initPath + '\'' +
            ", sockets=" + sockets +
+           ", memoryLimit=" + memoryLimit +
+           ", swapLimit=" + swapLimit +
            '}';
   }
 }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -217,6 +217,8 @@ public class DefaultDockerClientTest {
     assertThat(info.kernelVersion(), not(isEmptyOrNullString()));
     assertThat(info.storageDriver(), not(isEmptyOrNullString()));
     assertThat(info.sockets(), not(empty()));
+    assertThat(info.memoryLimit(), not(nullValue()));
+    assertThat(info.swapLimit(), not(nullValue()));
   }
 
   @Test


### PR DESCRIPTION
This allows a client to inspect whether the Docker instance supports memory
and swap limits via cgroups.
