### PR TITLE
Mitigate dependency on de.gesellix:unix-socket-factory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,7 @@
               <include>javax.annotation:*</include>
               <include>javax.ws.rs:*</include>
               <include>org.glassfish.**</include>
+              <include>de.gesellix:unix-socket-factory</include>
             </includes>
           </artifactSet>
           <relocations>


### PR DESCRIPTION
We depend on some of the native Unix sockets libraries included with the
de.gesellix:unix-socket-factory artifact. Unfortunately, this package is
only in Bintray and not Maven Central, so it's causing problems for users
who don't have the Bintray repository.

To mitigate this:
1. Included the de.gesellix stuff in the shaded uber-JAR. Since we're
   building a shaded JAR already, we might as well pop this in there to
   get rid of the depenedency on Bintray for consumers.
2. Only register the UnixConnectionSocketFactory when Unix sockets are
   actually being used. Before, we would try to create and register the
   socket factory on all OS's, even when the Docker URI being used was
   HTTP/HTTPS. This was stupid and pointless.

Fixes #70.
