### PR TITLE
Change DefaultDockerClient constructor to protected

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -171,7 +171,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   /**
    * Create a new client using the configuration of the builder.
    */
-  private DefaultDockerClient(final Builder builder) {
+  protected DefaultDockerClient(final Builder builder) {
     URI originalUri = checkNotNull(builder.uri, "uri");
 
     if ((builder.dockerCertificates != null) && !originalUri.getScheme().equals("https")) {


### PR DESCRIPTION
The constructor of DefaultDockerClient that accepts a Builder was private.
By changing it to protected, classes that extend DefaultDockerClient can
use `super(builder)` with a modified builder to change the client config.
