### PR TITLE
Document how to run tests faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ Maven
 </dependency>
 ```
 
+Testing
+-------
+
+If running the tests are slow, like on the order of tens of minutes instead of the expected minutes,
+check how many stopped containers you have with `docker ps -a`. If you have a lot, remove them
+with `docker rm $(docker ps -a -q)`. Your tests should run faster now.
+
 
 Releasing
 ---------


### PR DESCRIPTION
We don't know how many stopped containers are on the build machine.
Documenting this will help people who wonder why their tests are so
slow.

Fixes #84
