### PR TITLE
Increase connection pool size & add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,25 @@ final DockerClient docker = new DefaultDockerClient.builder()
     .build();
 ```
 
+### Connection pooling
+
+We use the [Apache HTTP client](https://hc.apache.org/) under the covers, with a shared connection
+pool per instance of the Docker client. The default size of this pool is 100 connections, so each
+instance of the Docker client can only have 100 concurrent requests in flight.
+
+If you plan on waiting on more than 100 containers at a time (`DockerClient.waitContainer`), or
+otherwise need a higher number of concurrent requests, you can modify the connection pool size:
+
+```java
+final DockerClient docker = DefaultDockerClient.fromEnv()
+    .connectionPoolSize(SOME_LARGE_NUMBER)
+    .build()
+```
+
+Note that the connect timeout is also applied to acquiring a connection from the pool. If the pool
+is exhausted and it takes too long to acquire a new connection for a request, we throw a
+`DockerTimeoutException` instead of just waiting forever on a connection becoming available.
+
 Maven
 -----
 

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -119,7 +119,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
 
   private static final long DEFAULT_CONNECT_TIMEOUT_MILLIS = SECONDS.toMillis(5);
   private static final long DEFAULT_READ_TIMEOUT_MILLIS = SECONDS.toMillis(30);
-  private static final int DEFAULT_CONNECTION_POOL_SIZE = 20;
+  private static final int DEFAULT_CONNECTION_POOL_SIZE = 100;
 
   private static final ClientConfig DEFAULT_CONFIG = new ClientConfig(
       ObjectMapperProvider.class,


### PR DESCRIPTION
- Increase the default connection pool size to 100 connections.
- Add documentation in `README.md` about the connection pool.
