### PR TITLE
Don't remove stopped test containers after tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,9 @@ Maven
 Testing
 -------
 
-If running the tests are slow, like on the order of tens of minutes instead of the expected minutes,
-check how many stopped containers you have with `docker ps -a`. If you have a lot, remove them
-with `docker rm $(docker ps -a -q)`. Your tests should run faster now.
-
+You can run tests on their own with `mvn test`. Note that the tests start and stop a large number of
+containers, so the list of containers you see with `docker ps -a` will start to get pretty long
+after many test runs. You may find it helpful to occassionally issue `docker rm $(docker ps -aq)`.
 
 Releasing
 ---------

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -135,12 +135,11 @@ public class DefaultDockerClientTest {
   @After
   public void tearDown() throws Exception {
     // Remove containers
-    final List<Container> containers = sut.listContainers(DockerClient.ListContainersParam.allContainers());
+    final List<Container> containers = sut.listContainers();
     for (Container container : containers) {
       final ContainerInfo info = sut.inspectContainer(container.id());
       if (info != null && info.name().contains(nameTag)) {
         sut.killContainer(info.id());
-        sut.removeContainer(info.id());
       }
     }
 


### PR DESCRIPTION
We were removing all the stopped test containers (i.e., `docker rm`) in the
test tear-down. This is slow and also gets rid of useful debugging info, so
don't do it.
