### PR TITLE
ProgressStream and LogReader now read entire input stream

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -591,6 +591,8 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     try (ProgressStream pull = request(POST, ProgressStream.class, resource,
                                        resource.request(APPLICATION_JSON_TYPE))) {
       pull.tail(handler, POST, resource.getUri());
+    } catch (IOException e) {
+      throw new DockerException(e);
     }
   }
 
@@ -617,6 +619,8 @@ public class DefaultDockerClient implements DockerClient, Closeable {
              request(POST, ProgressStream.class, resource,
                      resource.request(APPLICATION_JSON_TYPE).header("X-Registry-Auth", "null"))) {
       push.tail(handler, POST, resource.getUri());
+    } catch (IOException e) {
+      throw new DockerException(e);
     }
   }
 


### PR DESCRIPTION
When processing a json stream, Jersey will not release the connection until
the entire input stream is read. This is a problem for our ProgressHandler
classes because if they receive an error from docker, they throw an exception
and stop reading. This causes Jersey to never release the connection, so you
will exhaust the connection pool if you encounter enough errors.

We had been calling close on the input stream, but this doesn't release the
connection because the stream we get from Jersey is of type UnCloseableInputStream,
where close is a no-op. So we now read the entire object instead.
