### PR TITLE
CircleCI: Ensure correct level of parallelism

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -2,6 +2,14 @@
 
 case "$1" in
   pre_machine)
+    # ensure correct level of parallelism
+    expected_nodes=2
+    if [ "$CIRCLE_NODE_TOTAL" -ne "$expected_nodes" ]
+    then
+        echo "Parallelism is set to ${CIRCLE_NODE_TOTAL}x, but we need ${expected_nodes}x."
+        exit 1
+    fi
+
     # have docker bind to both localhost and unix socket
     docker_opts='DOCKER_OPTS="$DOCKER_OPTS -H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock"'
     sudo sh -c "echo '$docker_opts' >> /etc/default/docker"


### PR DESCRIPTION
This setting got flipped in CircleCI somehow and caused build failures.

Add a check for it at the very beginning of the build and print an
informative message in case it happens again.
