### PR TITLE
Set longer read timeout for tests

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -134,6 +134,7 @@ public class DefaultDockerClientTest {
   @Before
   public void setup() throws Exception {
     final DefaultDockerClient.Builder builder = DefaultDockerClient.fromEnv();
+    builder.readTimeoutMillis(120000);
     dockerEndpoint = builder.uri();
 
     sut = builder.build();


### PR DESCRIPTION
- On our build agent, DefaultDockerClientTest.testSsl()
  takes longer than the default 30 seconds read timeout to complete
  the dockerSslDirectory's Dockerfile.
- Increase the read timeout for tests to 60 seconds.
