### PR TITLE
Throw exceptions for image/container not found

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -405,12 +405,12 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       final WebTarget resource = resource()
           .path("containers").path(containerId).path("pause");
       request(POST, resource, resource.request());
-    } catch (WebApplicationException e) {
-      switch (e.getResponse().getStatus()) {
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
         case 404:
           throw new ContainerNotFoundException(containerId, e);
         default:
-          throw new DockerException(e);
+          throw e;
       }
     }
   }
@@ -424,12 +424,12 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       final WebTarget resource = resource()
           .path("containers").path(containerId).path("unpause");
       request(POST, resource, resource.request());
-    } catch (WebApplicationException e) {
-      switch (e.getResponse().getStatus()) {
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
         case 404:
           throw new ContainerNotFoundException(containerId, e);
         default:
-          throw new DockerException(e);
+          throw e;
       }
     }
   }
@@ -449,12 +449,12 @@ public class DefaultDockerClient implements DockerClient, Closeable {
           .path("restart")
           .queryParam("t", String.valueOf(secondsToWaitBeforeRestart));
       request(POST, resource, resource.request());
-    } catch (WebApplicationException e) {
-      switch (e.getResponse().getStatus()) {
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
         case 404:
           throw new ContainerNotFoundException(containerId, e);
         default:
-          throw new DockerException(e);
+          throw e;
       }
     }
   }
@@ -465,12 +465,12 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     try {
       final WebTarget resource = resource().path("containers").path(containerId).path("kill");
       request(POST, resource, resource.request());
-    } catch (WebApplicationException e) {
-      switch (e.getResponse().getStatus()) {
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
         case 404:
           throw new ContainerNotFoundException(containerId, e);
         default:
-          throw new DockerException(e);
+          throw e;
       }
     }
   }
@@ -483,14 +483,14 @@ public class DefaultDockerClient implements DockerClient, Closeable {
           .path("containers").path(containerId).path("stop")
           .queryParam("t", String.valueOf(secondsToWaitBeforeKilling));
       request(POST, resource, resource.request());
-    } catch (WebApplicationException e) {
-      switch (e.getResponse().getStatus()) {
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
         case 304: // already stopped, so we're cool
           return;
         case 404:
           throw new ContainerNotFoundException(containerId, e);
         default:
-          throw new DockerException(e);
+          throw e;
       }
     }
   }
@@ -529,12 +529,12 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       request(DELETE, resource, resource
           .queryParam("v", String.valueOf(removeVolumes))
           .request(APPLICATION_JSON_TYPE));
-    } catch (WebApplicationException e) {
-      switch (e.getResponse().getStatus()) {
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
         case 404:
-          throw new ContainerNotFoundException(containerId);
+          throw new ContainerNotFoundException(containerId, e);
         default:
-          throw new DockerException(e);
+          throw e;
       }
     }
   }
@@ -785,12 +785,12 @@ public class DefaultDockerClient implements DockerClient, Closeable {
           .queryParam("force", String.valueOf(force))
           .queryParam("noprune", String.valueOf(noPrune));
       return request(DELETE, REMOVED_IMAGE_LIST, resource, resource.request(APPLICATION_JSON_TYPE));
-    } catch (WebApplicationException e) {
-      switch (e.getResponse().getStatus()) {
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
         case 404:
           throw new ImageNotFoundException(image);
         default:
-          throw new DockerException(e);
+          throw e;
       }
     }
   }
@@ -862,7 +862,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
                        final Invocation.Builder request)
       throws DockerException, InterruptedException {
     try {
-      request.async().method(method).get();
+      request.async().method(method, String.class).get();
     } catch (ExecutionException | MultiException e) {
       throw propagate(method, resource, e);
     }
@@ -874,7 +874,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
                        final Entity<?> entity)
       throws DockerException, InterruptedException {
     try {
-      request.async().method(method, entity).get();
+      request.async().method(method, entity, String.class).get();
     } catch (ExecutionException | MultiException e) {
       throw propagate(method, resource, e);
     }

--- a/src/main/java/com/spotify/docker/client/LoggingPullHandler.java
+++ b/src/main/java/com/spotify/docker/client/LoggingPullHandler.java
@@ -39,7 +39,7 @@ public class LoggingPullHandler implements ProgressHandler {
   @Override
   public void progress(ProgressMessage message) throws DockerException {
     if (message.error() != null) {
-      if (message.error().contains("404")) {
+      if (message.error().contains("404") || message.error().contains("not found")) {
         throw new ImageNotFoundException(image, message.toString());
       } else {
         throw new ImagePullFailedException(image, message.toString());


### PR DESCRIPTION
In some cases we were not throwing exceptions for a number of methods when
an image or container was not found. There were a few causes:
1. The response from Docker for pulls of nonexistent images changed. Now we
   check for both the old and new responses.
2. We were expecting Jersey to throw an exception for all 404 responses.
   However, Jersey doesn't process the response status code or throw
   exceptions for responses where we don't specify a response entity. This
   is the case for requests that we expect to return an empty response.
   
   We now tell Jersey to unmarshal those responses into a java.lang.Object
   (which ends up being `null`) so that it will also process the response
   status and throw a WebApplicationException on 404, 500, etc.
3. Many DefaultDockerClient methods were trying to catch a
   WebApplicationException when calling DefaultDockerClient.request(), but
   request() never throws a WebApplicationException. It always wraps them
   in DockerRequestException. Those methods are now fixed.

Fixes #101.
