### PR TITLE
Fix #98: Use jnr-unixsocket instead of junixsocket.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,9 +136,14 @@
       <version>4.3.5</version>
     </dependency>
     <dependency>
-      <groupId>de.gesellix</groupId>
-      <artifactId>unix-socket-factory</artifactId>
-      <version>2014-09-26T18-52-33</version>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-unixsocket</artifactId>
+      <version>0.4</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.4</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -282,7 +287,8 @@
               <include>javax.annotation:*</include>
               <include>javax.ws.rs:*</include>
               <include>org.glassfish.**</include>
-              <include>de.gesellix:unix-socket-factory</include>
+              <include>com.github.jnr:*</include>
+              <include>org.ow2.asm:*</include>
             </includes>
           </artifactSet>
           <relocations>

--- a/src/main/java/com/spotify/docker/client/ApacheUnixSocket.java
+++ b/src/main/java/com/spotify/docker/client/ApacheUnixSocket.java
@@ -21,10 +21,6 @@
 
 package com.spotify.docker.client;
 
-import com.google.common.collect.Queues;
-
-import org.newsclub.net.unix.AFUNIXSocket;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -32,11 +28,17 @@ import java.net.InetAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
+import java.nio.channels.Channels;
 import java.nio.channels.SocketChannel;
 import java.util.Queue;
 
+import jnr.unixsocket.UnixSocketAddress;
+import jnr.unixsocket.UnixSocketChannel;
+
+import com.google.common.collect.Queues;
+
 /**
- * Provides a socket that wraps an org.newsclub.net.unix.AFUNIXSocket and delays setting options
+ * Provides a socket that wraps an jnr.unixsocket.UnixSocketChannel and delays setting options
  * until the socket is connected. This is necessary because the Apache HTTP client attempts to
  * set options prior to connecting the socket, which doesn't work for Unix sockets since options
  * are being set on the underlying file descriptor. Until the socket is connected, the file
@@ -47,75 +49,78 @@ import java.util.Queue;
  */
 public class ApacheUnixSocket extends Socket {
 
-  private final AFUNIXSocket inner;
+  private final UnixSocketChannel inner;
 
   private final Queue<SocketOptionSetter> optionsToSet = Queues.newArrayDeque();
 
   public ApacheUnixSocket() throws IOException {
-    this.inner = AFUNIXSocket.newInstance();
+    this.inner = UnixSocketChannel.open();
   }
 
   @Override
   public void connect(final SocketAddress endpoint) throws IOException {
-    inner.connect(endpoint);
-    setAllSocketOptions();
+    if (endpoint instanceof UnixSocketAddress) {
+      inner.connect((UnixSocketAddress) endpoint);
+      setAllSocketOptions();
+    }
   }
 
   @Override
   public void connect(final SocketAddress endpoint, final int timeout) throws IOException {
-    inner.connect(endpoint, timeout);
-    setAllSocketOptions();
+    if (endpoint instanceof UnixSocketAddress) {
+      inner.connect((UnixSocketAddress) endpoint);
+      setAllSocketOptions();
+    }
   }
 
   @Override
   public void bind(final SocketAddress bindpoint) throws IOException {
-    inner.bind(bindpoint);
-    setAllSocketOptions();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public InetAddress getInetAddress() {
-    return inner.getInetAddress();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public InetAddress getLocalAddress() {
-    return inner.getLocalAddress();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public int getPort() {
-    return inner.getPort();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public int getLocalPort() {
-    return inner.getLocalPort();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public SocketAddress getRemoteSocketAddress() {
-    return inner.getRemoteSocketAddress();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public SocketAddress getLocalSocketAddress() {
-    return inner.getLocalSocketAddress();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public SocketChannel getChannel() {
-    return inner.getChannel();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public InputStream getInputStream() throws IOException {
-    return inner.getInputStream();
+    return Channels.newInputStream(inner);
   }
 
   @Override
   public OutputStream getOutputStream() throws IOException {
-    return inner.getOutputStream();
+    return Channels.newOutputStream(inner);
   }
 
   private void setSocketOption(final SocketOptionSetter s) throws SocketException {
@@ -136,52 +141,36 @@ public class ApacheUnixSocket extends Socket {
 
   @Override
   public void setTcpNoDelay(final boolean on) throws SocketException {
-    setSocketOption(new SocketOptionSetter() {
-      @Override
-      public void run() throws SocketException {
-        inner.setTcpNoDelay(on);
-      }
-    });
   }
 
   @Override
   public boolean getTcpNoDelay() throws SocketException {
-    return inner.getTcpNoDelay();
+    return false;
   }
 
   @Override
   public void setSoLinger(final boolean on, final int linger) throws SocketException {
-    setSocketOption(new SocketOptionSetter() {
-      @Override
-      public void run() throws SocketException {
-        inner.setSoLinger(on, linger);
-      }
-    });
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public int getSoLinger() throws SocketException {
-    return inner.getSoLinger();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public void sendUrgentData(final int data) throws IOException {
-    inner.sendUrgentData(data);
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public void setOOBInline(final boolean on) throws SocketException {
-    setSocketOption(new SocketOptionSetter() {
-      @Override
-      public void run() throws SocketException {
-        inner.setOOBInline(on);
-      }
-    });
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public boolean getOOBInline() throws SocketException {
-    return inner.getOOBInline();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
@@ -201,32 +190,22 @@ public class ApacheUnixSocket extends Socket {
 
   @Override
   public synchronized void setSendBufferSize(final int size) throws SocketException {
-    setSocketOption(new SocketOptionSetter() {
-      @Override
-      public void run() throws SocketException {
-        inner.setSendBufferSize(size);
-      }
-    });
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public synchronized int getSendBufferSize() throws SocketException {
-    return inner.getSendBufferSize();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public synchronized void setReceiveBufferSize(final int size) throws SocketException {
-    setSocketOption(new SocketOptionSetter() {
-      @Override
-      public void run() throws SocketException {
-        inner.setReceiveBufferSize(size);
-      }
-    });
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public synchronized int getReceiveBufferSize() throws SocketException {
-    return inner.getReceiveBufferSize();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
@@ -246,17 +225,12 @@ public class ApacheUnixSocket extends Socket {
 
   @Override
   public void setTrafficClass(final int tc) throws SocketException {
-    setSocketOption(new SocketOptionSetter() {
-      @Override
-      public void run() throws SocketException {
-        inner.setTrafficClass(tc);
-      }
-    });
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public int getTrafficClass() throws SocketException {
-    return inner.getTrafficClass();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
@@ -266,7 +240,7 @@ public class ApacheUnixSocket extends Socket {
 
   @Override
   public boolean getReuseAddress() throws SocketException {
-    return inner.getReuseAddress();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
@@ -286,7 +260,7 @@ public class ApacheUnixSocket extends Socket {
 
   @Override
   public String toString() {
-    return inner.toString();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
@@ -296,28 +270,28 @@ public class ApacheUnixSocket extends Socket {
 
   @Override
   public boolean isBound() {
-    return inner.isBound();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public boolean isClosed() {
-    return inner.isClosed();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public boolean isInputShutdown() {
-    return inner.isInputShutdown();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public boolean isOutputShutdown() {
-    return inner.isOutputShutdown();
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
   public void setPerformancePreferences(final int connectionTime, final int latency,
                                         final int bandwidth) {
-    inner.setPerformancePreferences(connectionTime, latency, bandwidth);
+    throw new UnsupportedOperationException("Unimplemented");
   }
 
   interface SocketOptionSetter {

--- a/src/main/java/com/spotify/docker/client/UnixConnectionSocketFactory.java
+++ b/src/main/java/com/spotify/docker/client/UnixConnectionSocketFactory.java
@@ -26,7 +26,6 @@ import org.apache.http.annotation.Immutable;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.protocol.HttpContext;
-import org.newsclub.net.unix.AFUNIXSocketAddress;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,6 +33,8 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.net.URI;
+
+import jnr.unixsocket.UnixSocketAddress;
 
 /**
  * Provides a ConnectionSocketFactory for connecting Apache HTTP clients to Unix sockets.
@@ -74,7 +75,7 @@ public class UnixConnectionSocketFactory implements ConnectionSocketFactory {
                               final InetSocketAddress localAddress,
                               final HttpContext context) throws IOException {
     try {
-      socket.connect(new AFUNIXSocketAddress(socketFile), connectTimeout);
+      socket.connect(new UnixSocketAddress(socketFile), connectTimeout);
     } catch (SocketTimeoutException e) {
       throw new ConnectTimeoutException(e, null, remoteAddress.getAddress());
     }


### PR DESCRIPTION
A few notes :

- I've run the tests and noticed intermitent failure of testSsl locally for me with or without this change.
- On the test instance, testContainerWithHostConfig also seemed to have failed for me, but passed on a re-trigger.
- commons-lang:commons-lang:2.4 was already an indirect dependency brought in by the unix-socket-factory artifact and it is in fact a build-time dependency for DefaultDockerClientTest so it should be listed.
- All of the classes marked unimplemented do not seem to be used by the underlying API currently.