### PR TITLE
Adds support for event callbacks to the docker client

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -40,9 +40,6 @@ import com.spotify.docker.client.messages.Info;
 import com.spotify.docker.client.messages.ProgressMessage;
 import com.spotify.docker.client.messages.RemovedImage;
 import com.spotify.docker.client.messages.Version;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -65,16 +62,6 @@ import org.glassfish.jersey.jackson.JacksonFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.ResponseProcessingException;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -93,17 +80,33 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 
-import static com.google.common.base.Optional.*;
-import static com.google.common.base.Preconditions.*;
-import static com.google.common.base.Strings.*;
-import static com.google.common.collect.Maps.*;
-import static com.spotify.docker.client.CompressedDirectory.*;
-import static com.spotify.docker.client.ObjectMapperProvider.*;
-import static java.lang.System.*;
-import static java.nio.charset.StandardCharsets.*;
-import static java.util.concurrent.TimeUnit.*;
-import static javax.ws.rs.HttpMethod.*;
-import static javax.ws.rs.core.MediaType.*;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.ResponseProcessingException;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+
+import static com.google.common.base.Optional.fromNullable;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.Maps.newHashMap;
+import static com.spotify.docker.client.CompressedDirectory.delete;
+import static com.spotify.docker.client.ObjectMapperProvider.objectMapper;
+import static java.lang.System.getProperty;
+import static java.lang.System.getenv;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static javax.ws.rs.HttpMethod.DELETE;
+import static javax.ws.rs.HttpMethod.GET;
+import static javax.ws.rs.HttpMethod.POST;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
 
 public class DefaultDockerClient implements DockerClient, Closeable {
 
@@ -897,7 +900,8 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     }
 
     try {
-      CloseableHttpClient client = (CloseableHttpClient) ApacheConnectorProvider.getHttpClient(noTimeoutClient);
+      CloseableHttpClient client = (CloseableHttpClient) ApacheConnectorProvider
+              .getHttpClient(noTimeoutClient);
       CloseableHttpResponse response = client.execute(new HttpGet(resource.getUri()));
       return new EventStream(response, objectMapper());
     } catch (IOException exception) {

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -21,13 +21,12 @@
 
 package com.spotify.docker.client;
 
-import com.google.common.io.CharStreams;
-import com.google.common.net.HostAndPort;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.google.common.io.CharStreams;
+import com.google.common.net.HostAndPort;
 import com.spotify.docker.client.messages.AuthConfig;
 import com.spotify.docker.client.messages.Container;
 import com.spotify.docker.client.messages.ContainerConfig;
@@ -41,14 +40,19 @@ import com.spotify.docker.client.messages.Info;
 import com.spotify.docker.client.messages.ProgressMessage;
 import com.spotify.docker.client.messages.RemovedImage;
 import com.spotify.docker.client.messages.Version;
-
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.glassfish.hk2.api.MultiException;
 import org.glassfish.jersey.apache.connector.ApacheClientProperties;
@@ -61,6 +65,16 @@ import org.glassfish.jersey.jackson.JacksonFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.ResponseProcessingException;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -79,33 +93,17 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.ResponseProcessingException;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
-import static com.google.common.base.Optional.fromNullable;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.common.collect.Maps.newHashMap;
-import static com.spotify.docker.client.CompressedDirectory.delete;
-import static com.spotify.docker.client.ObjectMapperProvider.objectMapper;
-import static java.lang.System.getProperty;
-import static java.lang.System.getenv;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static javax.ws.rs.HttpMethod.DELETE;
-import static javax.ws.rs.HttpMethod.GET;
-import static javax.ws.rs.HttpMethod.POST;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
-import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
+import static com.google.common.base.Optional.*;
+import static com.google.common.base.Preconditions.*;
+import static com.google.common.base.Strings.*;
+import static com.google.common.collect.Maps.*;
+import static com.spotify.docker.client.CompressedDirectory.*;
+import static com.spotify.docker.client.ObjectMapperProvider.*;
+import static java.lang.System.*;
+import static java.nio.charset.StandardCharsets.*;
+import static java.util.concurrent.TimeUnit.*;
+import static javax.ws.rs.HttpMethod.*;
+import static javax.ws.rs.core.MediaType.*;
 
 public class DefaultDockerClient implements DockerClient, Closeable {
 
@@ -861,6 +859,49 @@ public class DefaultDockerClient implements DockerClient, Closeable {
         default:
           throw e;
       }
+    }
+  }
+
+  @Override
+  public EventStream events(EventsParam... params)
+          throws DockerException, InterruptedException {
+    WebTarget resource = noTimeoutResource()
+            .path("events");
+    final Map<String, String> filters = newHashMap();
+    for (EventsParam param : params) {
+      if (param instanceof EventsFilterParam) {
+        filters.put(param.name(), param.value());
+      } else {
+        resource = resource.queryParam(param.name(), param.value());
+      }
+    }
+
+    try {
+      if (!filters.isEmpty()) {
+        final StringWriter writer = new StringWriter();
+        final JsonGenerator generator = objectMapper().getFactory().createGenerator(writer);
+        generator.writeStartObject();
+        for (Map.Entry<String, String> entry : filters.entrySet()) {
+          generator.writeArrayFieldStart(entry.getKey());
+          generator.writeString(entry.getValue());
+          generator.writeEndArray();
+        }
+        generator.writeEndObject();
+        generator.close();
+        // We must URL encode the string, otherwise Jersey chokes on the double-quotes in the json.
+        final String encoded = URLEncoder.encode(writer.toString(), UTF_8.name());
+        resource = resource.queryParam("filters", encoded);
+      }
+    } catch (IOException exception) {
+      throw new DockerException(exception);
+    }
+
+    try {
+      CloseableHttpClient client = (CloseableHttpClient) ApacheConnectorProvider.getHttpClient(noTimeoutClient);
+      CloseableHttpResponse response = client.execute(new HttpGet(resource.getUri()));
+      return new EventStream(response, objectMapper());
+    } catch (IOException exception) {
+      throw new DockerException(exception);
     }
   }
 

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -435,6 +435,14 @@ public interface DockerClient extends Closeable {
   LogStream logs(String containerId, LogsParameter... params)
       throws DockerException, InterruptedException;
 
+  /**
+   * Watches the docker API for events.
+   *
+   * @param params The parameters to apply to the events request
+   * @return An event stream
+   */
+  EventStream events(EventsParam... params)
+          throws DockerException, InterruptedException;
 
   /**
    * Sets up an exec instance in a running container id.
@@ -690,4 +698,65 @@ public interface DockerClient extends Closeable {
       super(name, value);
     }
   }
+
+  /**
+   * Parameters for {@link #events(EventsParam...)}
+   */
+  public static class EventsParam {
+
+    private final String name;
+    private final String value;
+
+    protected EventsParam(final String name, final String value) {
+      this.name = name;
+      this.value = value;
+    }
+
+    /**
+     * Parameter name.
+     */
+    public String name() {
+      return name;
+    }
+
+    /**
+     * Parameter value.
+     */
+    public String value() {
+      return value;
+    }
+
+    /**
+     * Filter events until the given timestamp
+     */
+    public static EventsParam until(Long until) {
+      return new EventsParam("until", String.valueOf(until));
+    }
+
+    /**
+     * Filter events since the given timestamp
+     */
+    public static EventsParam since(Long since) {
+      return new EventsParam("since", String.valueOf(since));
+    }
+
+    /**
+     * Apply filters to the returned events
+     */
+    public static EventsParam filter(String name, String value) {
+      return new EventsFilterParam(name, value);
+    }
+
+  }
+
+  /**
+   * Filter parameter for {@link #events(EventsParam...)}. This should be used by
+   * EventsParam only.
+   */
+  static class EventsFilterParam extends EventsParam {
+    public EventsFilterParam(String name, String value) {
+      super(name, value);
+    }
+  }
+
 }

--- a/src/main/java/com/spotify/docker/client/EventReader.java
+++ b/src/main/java/com/spotify/docker/client/EventReader.java
@@ -1,10 +1,29 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.docker.client;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spotify.docker.client.messages.Event;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/spotify/docker/client/EventReader.java
+++ b/src/main/java/com/spotify/docker/client/EventReader.java
@@ -1,0 +1,62 @@
+package com.spotify.docker.client;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.docker.client.messages.Event;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public class EventReader implements Closeable {
+
+  private static final Logger log = LoggerFactory.getLogger(LogReader.class);
+  private final ObjectMapper objectMapper;
+  private final CloseableHttpResponse response;
+  private JsonParser parser;
+
+  private volatile boolean closed;
+
+  public EventReader(final CloseableHttpResponse response, final ObjectMapper objectMapper) {
+    this.response = response;
+    this.objectMapper = objectMapper;
+  }
+
+  public Event nextMessage() throws IOException {
+    if (this.parser == null) {
+      this.parser = objectMapper.getFactory().createParser(response.getEntity().getContent());
+    }
+
+    // If the parser is closed, there's no new event
+    if (this.parser.isClosed()) {
+      return null;
+    }
+
+    // Read tokens until we get a start object
+    if (parser.nextToken() == null) {
+      return null;
+    }
+
+    return parser.readValueAs(Event.class);
+  }
+
+  @Override
+  protected void finalize() throws Throwable {
+    super.finalize();
+    if (!closed) {
+      log.warn(this + " not closed properly");
+      close();
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    closed = true;
+    response.close();
+  }
+
+}

--- a/src/main/java/com/spotify/docker/client/EventStream.java
+++ b/src/main/java/com/spotify/docker/client/EventStream.java
@@ -25,20 +25,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.spotify.docker.client.messages.Event;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.core.Response;
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
-
-import static com.google.common.base.Charsets.*;
 
 public class EventStream extends AbstractIterator<Event> implements Closeable {
 

--- a/src/main/java/com/spotify/docker/client/EventStream.java
+++ b/src/main/java/com/spotify/docker/client/EventStream.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
+import com.google.common.collect.AbstractIterator;
+import com.spotify.docker.client.messages.Event;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+
+import static com.google.common.base.Charsets.*;
+
+public class EventStream extends AbstractIterator<Event> implements Closeable {
+
+  private static final Logger log = LoggerFactory.getLogger(EventStream.class);
+
+  private final EventReader reader;
+  private volatile boolean closed;
+
+  EventStream(final CloseableHttpResponse response, final ObjectMapper objectMapper) {
+    this.reader = new EventReader(response, objectMapper);
+  }
+
+  @Override
+  protected void finalize() throws Throwable {
+    super.finalize();
+    if (!closed) {
+      log.warn(this + " not closed properly");
+      close();
+    }
+  }
+
+  @Override
+  protected Event computeNext() {
+    final Event event;
+    try {
+      event = reader.nextMessage();
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+    if (event == null) {
+      return endOfData();
+    }
+    return event;
+  }
+
+  @Override
+  public void close() {
+    closed = true;
+    try {
+      reader.close();
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+}

--- a/src/main/java/com/spotify/docker/client/messages/Event.java
+++ b/src/main/java/com/spotify/docker/client/messages/Event.java
@@ -50,7 +50,7 @@ public class Event {
   }
 
   public Date time() {
-    return time;
+    return time == null ? null : new Date(time.getTime());
   }
 
 }

--- a/src/main/java/com/spotify/docker/client/messages/Event.java
+++ b/src/main/java/com/spotify/docker/client/messages/Event.java
@@ -1,0 +1,34 @@
+package com.spotify.docker.client.messages;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Date;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.*;
+
+@JsonAutoDetect(fieldVisibility = ANY, setterVisibility = NONE, getterVisibility = NONE)
+public class Event {
+
+  @JsonProperty("status") private String status;
+  @JsonProperty("id") private String id;
+  @JsonProperty("from") private String from;
+  @JsonProperty("time") private Date time;
+
+  public String status() {
+    return status;
+  }
+
+  public String id() {
+    return id;
+  }
+
+  public String from() {
+    return from;
+  }
+
+  public Date time() {
+    return time;
+  }
+
+}

--- a/src/main/java/com/spotify/docker/client/messages/Event.java
+++ b/src/main/java/com/spotify/docker/client/messages/Event.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.docker.client.messages;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -5,7 +26,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Date;
 
-import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.*;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
 @JsonAutoDetect(fieldVisibility = ANY, setterVisibility = NONE, getterVisibility = NONE)
 public class Event {

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -979,6 +979,8 @@ public class DefaultDockerClientTest {
     while (eventStream.hasNext()) {
       eventStream.next();
     }
+
+    eventStream.close();
   }
 
   @Test

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -21,12 +21,12 @@
 
 package com.spotify.docker.client;
 
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.SettableFuture;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.spotify.docker.client.DockerClient.AttachParameter;
 import com.spotify.docker.client.messages.AuthConfig;
 import com.spotify.docker.client.messages.Container;
@@ -42,7 +42,6 @@ import com.spotify.docker.client.messages.Info;
 import com.spotify.docker.client.messages.ProgressMessage;
 import com.spotify.docker.client.messages.RemovedImage;
 import com.spotify.docker.client.messages.Version;
-
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
@@ -97,7 +96,7 @@ import static com.spotify.docker.client.messages.RemovedImage.Type.UNTAGGED;
 import static java.lang.Long.toHexString;
 import static java.lang.String.format;
 import static java.lang.System.getenv;
-import static org.apache.commons.lang.StringUtils.*;
+import static org.apache.commons.lang.StringUtils.containsIgnoreCase;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.anyOf;


### PR DESCRIPTION
This commit adds support for streaming events from the Docker API.

A few notes about the PR that kind of suck:

 - I wasn't able to find a way to abort a request in the Jersey Client, which makes it impossible to close a streaming request to the Docker API (the stream is terminated by the client, and simply closing the InputStream from Jersey does nothing as it internally just waits for an EOF). Long story short: I had to use the Apache HttpClient directly
 - The events API can either be streaming or not, depending on whether or not the "until" param is set (and, if it's set, what value it's set to)
 - The tests could be flaky, and may need to be addressed (although they're reliable on my machine, they do include dates which I don't like)

Open to suggestions on ways to clean this up