### PR TITLE
Appease findbugs - do not have an empty catch clause

### DIFF
--- a/src/main/java/com/spotify/docker/client/CompressedDirectory.java
+++ b/src/main/java/com/spotify/docker/client/CompressedDirectory.java
@@ -122,10 +122,11 @@ class CompressedDirectory {
       return false;
     }
 
-    boolean deleted = false;
+    boolean deleted;
     try {
       deleted = file.delete();
     } catch (Exception ignored) {
+      deleted = false;
     }
 
     if (!deleted) {


### PR DESCRIPTION
Some versions of findbugs error out if we don't
do anything with this exception.