### PR TITLE
Adding getters on Container.PortMapping

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/Container.java
+++ b/src/main/java/com/spotify/docker/client/messages/Container.java
@@ -155,6 +155,22 @@ public class Container {
     @JsonProperty("Type") private String type;
     @JsonProperty("IP") private String ip;
 
+    public String getIp() {
+      return ip;
+    }
+    
+    public int getPrivatePort() {
+      return privatePort;
+    }
+    
+    public int getPublicPort() {
+      return publicPort;
+    }
+    
+    public String getType() {
+      return type;
+    }
+    
     @Override
     public boolean equals(final Object o) {
       if (this == o) {


### PR DESCRIPTION
Adding getters on the Container.PortMapping attributes. This is particularly interesting when clients need to consume the Port Mappings. In the current code, the only mean to extract the IP address, private/public ports and type are by parsing the result of the call to the Container.PortMapping#toString() method, which is a bit of a hack (and maybe not reliable in the long term) :-/
