### PR TITLE
Add operating system to Info message

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/Info.java
+++ b/src/main/java/com/spotify/docker/client/messages/Info.java
@@ -28,6 +28,7 @@ public class Info {
   @JsonProperty("Driver") private String storageDriver;
   @JsonProperty("ExecutionDriver") private String executionDriver;
   @JsonProperty("KernelVersion") private String kernelVersion;
+  @JsonProperty("OperatingSystem") private String operatingSystem;
   @JsonProperty("Debug") private int debug;
   @JsonProperty("NFd") private int fileDescriptors;
   @JsonProperty("NGoroutines") private int goroutines;
@@ -55,6 +56,10 @@ public class Info {
 
   public String kernelVersion() {
     return kernelVersion;
+  }
+
+  public String operatingSystem() {
+    return operatingSystem;
   }
 
   public boolean debug() {

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -266,6 +266,7 @@ public class DefaultDockerClientTest {
     assertThat(info.executionDriver(), not(isEmptyOrNullString()));
     assertThat(info.initPath(), not(isEmptyOrNullString()));
     assertThat(info.kernelVersion(), not(isEmptyOrNullString()));
+    assertThat(info.operatingSystem(), not(isEmptyOrNullString()));
     assertThat(info.storageDriver(), not(isEmptyOrNullString()));
     assertThat(info.sockets(), not(empty()));
     assertThat(info.memoryLimit(), not(nullValue()));


### PR DESCRIPTION
You can now do this:

    dockerClient.info().operatingSystem()