### PR TITLE
portsAsString method added to display container port info

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/Container.java
+++ b/src/main/java/com/spotify/docker/client/messages/Container.java
@@ -17,16 +17,16 @@
 
 package com.spotify.docker.client.messages;
 
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableList;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import java.util.Iterator;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.util.List;
-
-import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
-import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 public class Container {
@@ -41,6 +41,40 @@ public class Container {
   @JsonProperty("SizeRw") private Long sizeRw;
   @JsonProperty("SizeRootFs") private Long sizeRootFs;
 
+  /**
+   * This method returns port information the way that <code>docker ps</code> does:
+   * <code>0.0.0.0:5432->5432/tcp</code> or <code>6379/tcp</code>
+   * 
+   * It should not be used to extract detailed information of ports. To do so,
+   * please refer to {@link com.spotify.docker.client.PortBinding} 
+   * 
+   * @see com.spotify.docker.client.PortBinding
+   * 
+   * @return port information as docker ps does.
+   */
+  public String portsAsString() {
+      StringBuilder sb = new StringBuilder();
+      if (this.ports != null) {
+          for (PortMapping port : this.ports) {
+             if (sb.length() > 0) {
+                 sb.append(", ");
+             }
+             if (port.ip != null) {
+                 sb.append(port.ip).append(":");
+             }
+             if (port.publicPort > 0) {
+                 sb.append(port.privatePort).append("->").append(port.publicPort);
+             } else {
+                 sb.append(port.privatePort);
+             }
+             sb.append("/").append(port.type);
+          }
+      }
+  
+      return sb.toString();
+  }
+  
+  
   public String id() {
     return id;
   }

--- a/src/test/java/com/spotify/docker/client/messages/ContainerTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/ContainerTest.java
@@ -1,0 +1,40 @@
+package com.spotify.docker.client.messages;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import com.spotify.docker.client.ObjectMapperProvider;
+
+public class ContainerTest {
+
+	@Rule
+	  public ExpectedException expectedException = ExpectedException.none();
+
+	  private ObjectMapper objectMapper;
+
+	  @Before
+	  public void setUp() throws Exception {
+	    objectMapper = new ObjectMapperProvider().getContext(Container.class);
+	  }
+
+	  @Test
+	  public void testLoadFromFixture() throws Exception {
+	    Container container = objectMapper
+	        .readValue(fixture("fixtures/container-ports-as-string.json"), Container.class);
+	    assertThat(container.portsAsString(), is("0.0.0.0:80->88/tcp"));  
+	  }	 
+      
+	  private static String fixture(String filename) throws IOException {
+          return Resources.toString(Resources.getResource(filename), Charsets.UTF_8).trim();
+	  }
+}

--- a/src/test/resources/fixtures/container-ports-as-string.json
+++ b/src/test/resources/fixtures/container-ports-as-string.json
@@ -1,0 +1,1 @@
+{"Id":"1009","Names": ["test", "ports"], "Image":"ports as string test", "Command": "test", "Created": 1, "Status": "testing", "Ports":[{"PrivatePort": 80, "PublicPort":88, "Type":"tcp", "IP":"0.0.0.0"}]}


### PR DESCRIPTION
as discussed in the issue https://github.com/spotify/docker-client/issues/150 this change returns a String with the ports info the way `docker ps` does.

Docker ps:

`0.0.0.0:5432->5432/tcp`

Note that portBinding displays the information the other way around

`0.0.0.0:5432/tcp->5432`

this is because PortBinding doesn't contain the `type` property.
