### PR TITLE
Docker Swarm does not support true/false as values for all parameters

### DIFF
--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -592,7 +592,7 @@ public interface DockerClient extends Closeable {
      * Show all containers. Only running containers are shown by default
      */
     public static ListContainersParam allContainers(final boolean all) {
-      return create("all", String.valueOf(all));
+      return create("all", all ? "1" : "0");
     }
 
     /**


### PR DESCRIPTION
Docker Swarm API currently doesn't support `/containers/json?all=true`, https://github.com/docker/swarm/blob/master/api/api.go#L122. For reasons unknown only `all=1` has been adopted.

Besides that, there's a chance the support for `all=[true|True]` will disappear from the main Docker API as well, https://github.com/docker/docker/commit/1bfa80bdd9ac05b01867492d2e6dda668aa7715c#diff-44a527ea72ea9572e1cf71c7f1e2a0f0R383.

Never the less, this is a non-breaking change in terms of backwards compatibility of the API.