### PR TITLE
Adding missing attributes to ContainerState

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/ContainerState.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerState.java
@@ -37,6 +37,8 @@ public class ContainerState {
   @JsonProperty("ExitCode") private Integer exitCode;
   @JsonProperty("StartedAt") private Date startedAt;
   @JsonProperty("FinishedAt") private Date finishedAt;
+  @JsonProperty("Error") private String error;
+  @JsonProperty("OOMKilled") private Boolean oomKilled;
 
   public Boolean running() {
     return running;
@@ -64,6 +66,14 @@ public class ContainerState {
 
   public Date finishedAt() {
     return finishedAt == null ? null : new Date(finishedAt.getTime());
+  }
+
+  public String error() {
+    return error;
+  }
+
+  public Boolean oomKilled() {
+    return oomKilled;
   }
 
   @Override
@@ -98,6 +108,12 @@ public class ContainerState {
     if (startedAt != null ? !startedAt.equals(that.startedAt) : that.startedAt != null) {
       return false;
     }
+    if (error != null ? !error.equals(that.error) : that.error != null) {
+      return false;
+    }
+    if (oomKilled != null ? !oomKilled.equals(that.oomKilled) : that.oomKilled != null) {
+      return false;
+    }
 
     return true;
   }
@@ -111,6 +127,8 @@ public class ContainerState {
     result = 31 * result + (exitCode != null ? exitCode.hashCode() : 0);
     result = 31 * result + (startedAt != null ? startedAt.hashCode() : 0);
     result = 31 * result + (finishedAt != null ? finishedAt.hashCode() : 0);
+    result = 31 * result + (error != null ? error.hashCode() : 0);
+    result = 31 * result + (oomKilled != null ? oomKilled.hashCode() : 0);
     return result;
   }
 
@@ -124,6 +142,8 @@ public class ContainerState {
         .add("exitCode", exitCode)
         .add("startedAt", startedAt)
         .add("finishedAt", finishedAt)
+        .add("error", error)
+        .add("oomKilled", oomKilled)
         .toString();
   }
 }

--- a/src/test/java/com/spotify/docker/client/messages/ContainerStateTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/ContainerStateTest.java
@@ -42,6 +42,8 @@ public class ContainerStateTest {
     assertThat(containerState.pid(), is(27629));
     assertThat(containerState.startedAt(), is(new Date(1412236798929L)));
     assertThat(containerState.finishedAt(), is(new Date(-62135769600000L)));
+    assertThat(containerState.error(), is("this is an error"));
+    assertThat(containerState.oomKilled(), is(false));
 
   }
 

--- a/src/test/resources/fixtures/container-state-random.json
+++ b/src/test/resources/fixtures/container-state-random.json
@@ -1,1 +1,1 @@
-{"ExitCode":0,"FinishedAt":"0001-01-01T00:00:00Z","Paused":false,"Pid":27629,"Restarting":false,"Running":true,"StartedAt":"2014-10-02T07:59:58.929064724Z"}
+{"Error": "this is an error", "ExitCode":0,"FinishedAt":"0001-01-01T00:00:00Z", "OOMKilled": false, "Paused":false,"Pid":27629,"Restarting":false,"Running":true,"StartedAt":"2014-10-02T07:59:58.929064724Z"}


### PR DESCRIPTION
These attributes are available as of Docker 1.5, remote API 1.17.
We include them here to prepare for future upgrades.