### PR TITLE
Add authentication X-Registry-Config to build api for SSL support on private repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,13 @@
           </findbugsXmlOutputDirectory>
           <excludeFilterFile>${project.basedir}/findbugs-exclude.xml</excludeFilterFile>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>1.9.4</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <phase>verify</phase>

--- a/src/main/java/com/spotify/docker/client/messages/AuthRegistryConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/AuthRegistryConfig.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client.messages;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.google.common.base.Objects;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+/**
+  * A formatted string passed in X-Registry-Config request header.
+  * {"configs":{"myrepository":{
+  *   "username":"myusername",
+  *   "password":"mypassword",
+  *   "auth":"",
+  *   "email":"myemail",
+  *   "serveraddress":"myserverAddress"}}}
+*/
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class AuthRegistryConfig {
+
+  @JsonIgnore
+  private final Map<String, String> properties = new HashMap<String, String>();
+
+  @JsonProperty("configs") private final Map<String, Map<String, String>> configs = 
+                             new HashMap<String, Map<String, String>>();
+  @JsonIgnore private final String repository;
+  @JsonIgnore private final String username;
+  @JsonIgnore private final String password;
+  @JsonIgnore private final String auth;
+  @JsonIgnore private final String email;
+  @JsonIgnore private final String serverAddress;
+
+  public static final AuthRegistryConfig EMPTY = new AuthRegistryConfig("", "", "", "", "", "");
+
+  /**
+   * Wrapper to support X-Registry-Config header with auth.
+   * @param repository    Repository name (uniquely identifies the config)
+   * @param username      User name
+   * @param password      Password for authentication
+   * @param auth          Not used but must be supplied
+   * @param email         EMAIL address of authenticated user
+   * @param serverAddress The address of the repository
+  */
+  public AuthRegistryConfig(String repository, 
+                            String username, 
+                            String password, 
+                            String auth, 
+                            String email, 
+                            String serverAddress) {
+    this.repository = repository;
+    this.username = username;
+    this.password = password;
+    this.auth = auth;
+    this.email = email;
+    this.serverAddress = serverAddress;
+    properties.put("username", username);
+    properties.put("password", password);
+    properties.put("auth", auth);
+    properties.put("email", email);
+    properties.put("serveraddress", serverAddress);
+    configs.put(repository, properties);
+  }
+
+  /**
+   * Wrapper to support X-Registry-Config header without auth.
+   * @param repository    Repository name (uniquely identifies the config)
+   * @param username      User name
+   * @param password      Password for authentication
+   * @param email         EMAIL address of authenticated user
+   * @param serverAddress The address of the repository
+  */
+  public AuthRegistryConfig(String repository, 
+                            String username, 
+                            String password, 
+                            String email, 
+                            String serverAddress) {
+    this(repository, username, password, "", email, serverAddress);
+  }
+  
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final AuthRegistryConfig config = (AuthRegistryConfig) o;
+    if (repository != null ? !repository.equals(config.repository) : config.repository != null) {
+      return false;
+    }
+    if (username != null ? !username.equals(config.username) : config.username != null) {
+      return false;
+    }
+    if (password != null ? !password.equals(config.password) : config.password != null) {
+      return false;
+    }
+    if (auth != null ? !auth.equals(config.auth) : config.auth != null) {
+      return false;
+    }
+    if (email != null ? !email.equals(config.email) : config.email != null) {
+      return false;
+    }
+    if (serverAddress != null ?
+        !serverAddress.equals(config.serverAddress) : config.serverAddress != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = repository != null ? repository.hashCode() : 0;
+    result = 31 * result + (username != null ? username.hashCode() : 0);
+    result = 31 * result + (password != null ? password.hashCode() : 0);
+    result = 31 * result + (auth != null ? auth.hashCode() : 0);
+    result = 31 * result + (email != null ? email.hashCode() : 0);
+    result = 31 * result + (serverAddress != null ? serverAddress.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("repository", repository)
+        .add("username", username)
+        .add("password", password)
+        .add("auth", auth)
+        .add("email", email)
+        .add("serverAddress", serverAddress)
+        .toString();
+  }
+}

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -413,6 +413,26 @@ public class DefaultDockerClientTest {
   }
 
   @Test
+  public void testBuildImageIdWithAuth() throws Exception {
+    final String dockerDirectory = Resources.getResource("dockerDirectory").getPath();
+    final AtomicReference<String> imageIdFromMessage = new AtomicReference<>();
+
+    final DefaultDockerClient sut2 = sut.builder().uri(dockerEndpoint).authConfig(authConfig).build();
+    final String returnedImageId = sut2.build(
+        Paths.get(dockerDirectory), "test", new ProgressHandler() {
+          @Override
+          public void progress(ProgressMessage message) throws DockerException {
+            final String imageId = message.buildImageId();
+            if (imageId != null) {
+              imageIdFromMessage.set(imageId);
+            }
+          }
+        });
+
+    assertThat(returnedImageId, is(imageIdFromMessage.get()));
+  }
+
+  @Test
   public void testFailedBuildDoesNotLeakConn() throws Exception {
     final String dockerDirectory =
         Resources.getResource("dockerDirectoryNonExistentImage").getPath();
@@ -1273,8 +1293,8 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testExecInspect() throws DockerException, InterruptedException, IOException {
-    assumeTrue("Docker API should be at least v1.15 to support Exec, got "
-               + sut.version().apiVersion(), versionCompare(sut.version().apiVersion(), "1.15") >= 0);
+    assumeTrue("Docker API should be at least v1.16 to support Exec Inspect, got "
+               + sut.version().apiVersion(), versionCompare(sut.version().apiVersion(), "1.16") >= 0);
     assumeThat("Only native (libcontainer) driver supports Exec",
                sut.info().executionDriver(), startsWith("native"));
 


### PR DESCRIPTION
Introduce a wrapper class to pass auth values and return formatted X-Registry-Config string.
The user/password/email and repository are base64 encoded and passed on the request header.

Notes - in order to get a local build, a couple of issues were found: 
a). Found that the ant version 1.8.2 is transitively pulled which causes findbugs to fail with a class not found exception - explicitly added 1.9.4 in the pom to correct this
b). Although exec has been added to the API in 1.15, exec inspect didn't get added until 1.16 so this causes failures in docker 1.3.2 (API V1.15)