### PR TITLE
CircleCI: Cache public Docker images

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -11,7 +11,7 @@ case "$1" in
     fi
 
     # have docker bind to both localhost and unix socket
-    docker_opts='DOCKER_OPTS="$DOCKER_OPTS -D -H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock"'
+    docker_opts='DOCKER_OPTS="$DOCKER_OPTS -D -H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock --registry-mirror=http://localhost:5000"'
     sudo sh -c "echo '$docker_opts' >> /etc/default/docker"
 
     cat /etc/default/docker
@@ -24,6 +24,16 @@ case "$1" in
     ;;
 
   test)
+    mkdir -p ~/docker-registry
+
+    docker run -d -p 5000:5000 \
+      -e STANDALONE=false \
+      -e MIRROR_SOURCE=https:/registry-1.docker.io \
+      -e MIRROR_SOURCE_INDEX=https://index.docker.io \
+      -e STORAGE_PATH=/registry \
+      -v ~/docker-registry:/registry \
+      registry
+
     # expected parallelism: 2x. needs to be set in the project settings via CircleCI's UI.
     case $CIRCLE_NODE_INDEX in
       0)

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,8 @@
 dependencies:
+  cache_directories:
+    - ~/docker-registry
+  pre:
+    - ./circle.sh pre_dependencies
   override:
     - ./circle.sh dependencies
 


### PR DESCRIPTION
Instead of always hitting the public Docker registry, run a mirror locally.

This should hopefully reduce the number of build failures we get due to
image pulls failing against the public Docker registry.