### PR TITLE
Throw detailed exception on bad certificate paths

### DIFF
--- a/src/main/java/com/spotify/docker/client/DockerCertificates.java
+++ b/src/main/java/com/spotify/docker/client/DockerCertificates.java
@@ -60,6 +60,12 @@ public class DockerCertificates {
   }
 
   private DockerCertificates(final Builder builder) throws DockerCertificateException {
+    if ((builder.caCertPath == null) || (builder.clientCertPath == null) ||
+        (builder.clientKeyPath == null)) {
+      throw new DockerCertificateException(
+          "caCertPath, clientCertPath, and clientKeyPath must all be specified");
+    }
+
     try {
       final CertificateFactory cf = CertificateFactory.getInstance("X.509");
       final Certificate caCert = cf.generateCertificate(Files.newInputStream(builder.caCertPath));

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -1005,6 +1005,12 @@ public class DefaultDockerClientTest {
     assertThat(imageInfo.created(), equalTo(expected));
   }
 
+  @Test(expected = DockerCertificateException.class)
+  public void testBadDockerCertificates() throws Exception {
+    // try building a DockerCertificates without specifying a cert path
+    DockerCertificates.builder().build();
+  }
+
   @Test
   public void testSsl() throws Exception {
     // Build a run a container that contains a Docker instance configured with our SSL cert/key


### PR DESCRIPTION
Throw a detailed exception when trying to build a DockerCertificates object
if any of the required paths haven't been specified.

Fixes #193.