### PR TITLE
Add support for one-time container stats

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -1006,7 +1006,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   @Override
   public ContainerStats stats(final String containerId) 
            throws DockerException, InterruptedException {
-    WebTarget resource = resource().path("containers").path(containerId).path("stats")
+    final WebTarget resource = resource().path("containers").path(containerId).path("stats")
         .queryParam("stream", "0");
 
     try {

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -32,6 +32,7 @@ import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.ContainerCreation;
 import com.spotify.docker.client.messages.ContainerExit;
 import com.spotify.docker.client.messages.ContainerInfo;
+import com.spotify.docker.client.messages.ContainerStats;
 import com.spotify.docker.client.messages.ExecState;
 import com.spotify.docker.client.messages.HostConfig;
 import com.spotify.docker.client.messages.Image;
@@ -1002,6 +1003,24 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     }
   }
 
+  @Override
+  public ContainerStats stats(final String containerId) 
+           throws DockerException, InterruptedException {
+    WebTarget resource = resource().path("containers").path(containerId).path("stats")
+        .queryParam("stream", "0");
+
+    try {
+      return request(GET, ContainerStats.class, resource, resource.request(APPLICATION_JSON_TYPE));
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
+        case 404:
+          throw new ContainerNotFoundException(containerId);
+        default:
+          throw e;
+      }
+    }
+  }
+  
   private WebTarget resource() {
     final WebTarget target = client.target(uri);
     if (!isNullOrEmpty(apiVersion)) {

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -23,6 +23,7 @@ import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.ContainerCreation;
 import com.spotify.docker.client.messages.ContainerExit;
 import com.spotify.docker.client.messages.ContainerInfo;
+import com.spotify.docker.client.messages.ContainerStats;
 import com.spotify.docker.client.messages.ExecState;
 import com.spotify.docker.client.messages.HostConfig;
 import com.spotify.docker.client.messages.Image;
@@ -576,6 +577,16 @@ public interface DockerClient extends Closeable {
    */
   ExecState execInspect(String execId) throws DockerException, InterruptedException;
 
+  /**
+   * Retrieves one-time stats (stream=0) for the container with the specified id.
+   * 
+   * @param containerId The id of the container to retrieve stats for.
+   * @return The container stats
+   * @throws DockerException if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  ContainerStats stats(String containerId) throws DockerException, InterruptedException;
+  
   /**
    * Closes any and all underlying connections to docker, and release resources.
    */

--- a/src/main/java/com/spotify/docker/client/messages/ContainerStats.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerStats.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client.messages;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class ContainerStats {
+  @JsonProperty("read") private String read;
+  @JsonProperty("network") private NetworkStats network;
+  @JsonProperty("memory_stats") private MemoryStats memoryStats;
+  @JsonProperty("cpu_stats") private CpuStats cpuStats;
+  @JsonProperty("precpu_stats") private CpuStats precpuStats;
+
+  public String read() {
+    return read;
+  }
+
+  public NetworkStats network() {
+    return network;
+  }
+
+  public MemoryStats memoryStats() {
+    return memoryStats;
+  }
+
+  public CpuStats cpuStats() {
+    return cpuStats;
+  }
+
+  public CpuStats precpuStats() {
+    return precpuStats;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + (cpuStats == null ? 0 : cpuStats.hashCode());
+    result = prime * result + (memoryStats == null ? 0 : memoryStats.hashCode());
+    result = prime * result + (network == null ? 0 : network.hashCode());
+    result = prime * result + (precpuStats == null ? 0 : precpuStats.hashCode());
+    result = prime * result + (read == null ? 0 : read.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    ContainerStats other = (ContainerStats) obj;
+    if (cpuStats == null) {
+      if (other.cpuStats != null) {
+        return false;
+      }
+    } else if (!cpuStats.equals(other.cpuStats)) {
+      return false;
+    }
+    if (memoryStats == null) {
+      if (other.memoryStats != null) {
+        return false;
+      }
+    } else if (!memoryStats.equals(other.memoryStats)) {
+      return false;
+    }
+    if (network == null) {
+      if (other.network != null) {
+        return false;
+      }
+    } else if (!network.equals(other.network)) {
+      return false;
+    }
+    if (precpuStats == null) {
+      if (other.precpuStats != null) {
+        return false;
+      }
+    } else if (!precpuStats.equals(other.precpuStats)) {
+      return false;
+    }
+    if (read == null) {
+      if (other.read != null) {
+        return false;
+      }
+    } else if (!read.equals(other.read)) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("cpuStats", cpuStats)
+        .add("memoryStats", memoryStats)
+        .add("network", network)
+        .add("precpuStats", precpuStats)
+        .add("read", read)
+        .toString();
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/CpuStats.java
+++ b/src/main/java/com/spotify/docker/client/messages/CpuStats.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client.messages;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class CpuStats {
+  @JsonProperty("cpu_usage") private CpuUsage cpuUsage;
+  @JsonProperty("system_cpu_usage") Long systemCpuUsage;
+
+  public CpuUsage cpuUsage() {
+    return cpuUsage;
+  }
+
+  public Long systemCpuUsage() {
+    return systemCpuUsage;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + (cpuUsage == null ? 0 : cpuUsage.hashCode());
+    result = prime * result + (systemCpuUsage == null ? 0 : systemCpuUsage.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    CpuStats other = (CpuStats) obj;
+    if (cpuUsage == null) {
+      if (other.cpuUsage != null) {
+        return false;
+      }
+    } else if (!cpuUsage.equals(other.cpuUsage)) {
+      return false;
+    }
+    if (systemCpuUsage == null) {
+      if (other.systemCpuUsage != null) {
+        return false;
+      }
+    } else if (!systemCpuUsage.equals(other.systemCpuUsage)) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("cpuUsage", cpuUsage)
+        .add("systemCpuUsage", systemCpuUsage)
+        .toString();
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/CpuUsage.java
+++ b/src/main/java/com/spotify/docker/client/messages/CpuUsage.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client.messages;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class CpuUsage {
+  @JsonProperty("total_usage") private Long totalUsage;
+  @JsonProperty("percpu_usage") private ImmutableList<Long> percpuUsage;
+  @JsonProperty("usage_in_kernelmode") private Long usageInKernelmode;
+  @JsonProperty("usage_in_usermode") private Long usageInUsermode;
+
+  public Long totalUsage() {
+    return totalUsage;
+  }
+
+  public ImmutableList<Long> percpuUsage() {
+    return percpuUsage;
+  }
+
+  public Long usageInKernelmode() {
+    return usageInKernelmode;
+  }
+
+  public Long usageInUsermode() {
+    return usageInUsermode;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + (percpuUsage == null ? 0 : percpuUsage.hashCode());
+    result = prime * result + (totalUsage == null ? 0 : totalUsage.hashCode());
+    result = prime * result + (usageInKernelmode == null ? 0 : usageInKernelmode.hashCode());
+    result = prime * result + (usageInUsermode == null ? 0 : usageInUsermode.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    CpuUsage other = (CpuUsage) obj;
+    if (percpuUsage == null) {
+      if (other.percpuUsage != null) {
+        return false;
+      }
+    } else if (!percpuUsage.equals(other.percpuUsage)) {
+      return false;
+    }
+    if (totalUsage == null) {
+      if (other.totalUsage != null) {
+        return false;
+      }
+    } else if (!totalUsage.equals(other.totalUsage)) {
+      return false;
+    }
+    if (usageInKernelmode == null) {
+      if (other.usageInKernelmode != null) {
+        return false;
+      }
+    } else if (!usageInKernelmode.equals(other.usageInKernelmode)) {
+      return false;
+    }
+    if (usageInUsermode == null) {
+      if (other.usageInUsermode != null) {
+        return false;
+      }
+    } else if (!usageInUsermode.equals(other.usageInUsermode)) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("percpuUsage", percpuUsage)
+        .add("totalUsage", totalUsage)
+        .add("usageInKernelmode", usageInKernelmode)
+        .add("usageInUsermode", usageInUsermode)
+        .toString();
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/MemoryStats.java
+++ b/src/main/java/com/spotify/docker/client/messages/MemoryStats.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client.messages;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class MemoryStats {
+  @JsonProperty("max_usage") private Long maxUsage;
+  @JsonProperty("usage") private Long usage;
+  @JsonProperty("failcnt") private Long failcnt;
+  @JsonProperty("limit") private Long limit;
+
+  public Long maxUsage() {
+    return maxUsage;
+  }
+
+  public Long usage() {
+    return usage;
+  }
+
+  public Long failcnt() {
+    return failcnt;
+  }
+
+  public Long limit() {
+    return limit;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + (failcnt == null ? 0 : failcnt.hashCode());
+    result = prime * result + (limit == null ? 0 : limit.hashCode());
+    result = prime * result + (maxUsage == null ? 0 : maxUsage.hashCode());
+    result = prime * result + (usage == null ? 0 : usage.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    MemoryStats other = (MemoryStats) obj;
+    if (failcnt == null) {
+      if (other.failcnt != null) {
+        return false;
+      }
+    } else if (!failcnt.equals(other.failcnt)) {
+      return false;
+    }
+    if (limit == null) {
+      if (other.limit != null) {
+        return false;
+      }
+    } else if (!limit.equals(other.limit)) {
+      return false;
+    }
+    if (maxUsage == null) {
+      if (other.maxUsage != null) {
+        return false;
+      }
+    } else if (!maxUsage.equals(other.maxUsage)) {
+      return false;
+    }
+    if (usage == null) {
+      if (other.usage != null) {
+        return false;
+      }
+    } else if (!usage.equals(other.usage)) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("failcnt", failcnt)
+        .add("limit", limit)
+        .add("maxUsage", maxUsage)
+        .add("usage", usage)
+        .toString();
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/NetworkStats.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkStats.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client.messages;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class NetworkStats {
+  @JsonProperty("rx_bytes") private Long rxBytes;
+  @JsonProperty("rx_packets") private Long rxPackets;
+  @JsonProperty("rx_dropped") private Long rxDropped;
+  @JsonProperty("rx_errors") private Long rxErrors;
+  @JsonProperty("tx_bytes") private Long txBytes;
+  @JsonProperty("tx_packets") private Long txPackets;
+  @JsonProperty("tx_dropped") private Long txDropped;
+  @JsonProperty("tx_errors") private Long txErrors;
+
+  public Long rxBytes() {
+    return rxBytes;
+  }
+
+  public Long rxPackets() {
+    return rxPackets;
+  }
+
+  public Long rxDropped() {
+    return rxDropped;
+  }
+
+  public Long rxErrors() {
+    return rxErrors;
+  }
+
+  public Long txBytes() {
+    return txBytes;
+  }
+
+  public Long txPackets() {
+    return txPackets;
+  }
+
+  public Long txDropped() {
+    return txDropped;
+  }
+
+  public Long txErrors() {
+    return txErrors;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + (rxBytes == null ? 0 : rxBytes.hashCode());
+    result = prime * result + (rxDropped == null ? 0 : rxDropped.hashCode());
+    result = prime * result + (rxErrors == null ? 0 : rxErrors.hashCode());
+    result = prime * result + (rxPackets == null ? 0 : rxPackets.hashCode());
+    result = prime * result + (txBytes == null ? 0 : txBytes.hashCode());
+    result = prime * result + (txDropped == null ? 0 : txDropped.hashCode());
+    result = prime * result + (txErrors == null ? 0 : txErrors.hashCode());
+    result = prime * result + (txPackets == null ? 0 : txPackets.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    NetworkStats other = (NetworkStats) obj;
+    if (rxBytes == null) {
+      if (other.rxBytes != null) {
+        return false;
+      }
+    } else if (!rxBytes.equals(other.rxBytes)) {
+      return false;
+    }
+    if (rxDropped == null) {
+      if (other.rxDropped != null) {
+        return false;
+      }
+    } else if (!rxDropped.equals(other.rxDropped)) {
+      return false;
+    }
+    if (rxErrors == null) {
+      if (other.rxErrors != null) {
+        return false;
+      }
+    } else if (!rxErrors.equals(other.rxErrors)) {
+      return false;
+    }
+    if (rxPackets == null) {
+      if (other.rxPackets != null) {
+        return false;
+      }
+    } else if (!rxPackets.equals(other.rxPackets)) {
+      return false;
+    }
+    if (txBytes == null) {
+      if (other.txBytes != null) {
+        return false;
+      }
+    } else if (!txBytes.equals(other.txBytes)) {
+      return false;
+    }
+    if (txDropped == null) {
+      if (other.txDropped != null) {
+        return false;
+      }
+    } else if (!txDropped.equals(other.txDropped)) {
+      return false;
+    }
+    if (txErrors == null) {
+      if (other.txErrors != null) {
+        return false;
+      }
+    } else if (!txErrors.equals(other.txErrors)) {
+      return false;
+    }
+    if (txPackets == null) {
+      if (other.txPackets != null) {
+        return false;
+      }
+    } else if (!txPackets.equals(other.txPackets)) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("rxBytes", rxBytes)
+        .add("rxDropped", rxDropped)
+        .add("rxErrors", rxErrors)
+        .add("rxPackets", rxPackets)
+        .add("txBytes", txBytes)
+        .add("txDropped", txDropped)
+        .add("txErrors", txErrors)
+        .add("txPackets", txPackets)
+        .toString();
+  }
+}


### PR DESCRIPTION
Retrieves one-time stats for a specific container using
`/containers/<container>/stats?stream=0`. Docker 1.7.2-rc3 or higher
is required for this to work.