### PR TITLE
added null-empty check on config builders

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -475,16 +475,18 @@ public class ContainerConfig {
     }
 
     public Builder portSpecs(final List<String> portSpecs) {
-      if (portSpecs != null && !portSpecs.isEmpty())
-    	this.portSpecs = ImmutableList.copyOf(portSpecs);
-      
+      if (portSpecs != null && !portSpecs.isEmpty()) {
+        this.portSpecs = ImmutableList.copyOf(portSpecs);
+      }
+
       return this;
     }
 
     public Builder portSpecs(final String... portSpecs) {
-      if (portSpecs != null && portSpecs.length > 0)
+      if (portSpecs != null && portSpecs.length > 0) {
         this.portSpecs = ImmutableList.copyOf(portSpecs);
-      
+      }
+
       return this;
     }
 
@@ -493,16 +495,18 @@ public class ContainerConfig {
     }
 
     public Builder exposedPorts(final Set<String> exposedPorts) {
-      if (exposedPorts != null && !exposedPorts.isEmpty())
-    	this.exposedPorts = ImmutableSet.copyOf(exposedPorts);
-      
+      if (exposedPorts != null && !exposedPorts.isEmpty()) {
+        this.exposedPorts = ImmutableSet.copyOf(exposedPorts);
+      }
+
       return this;
     }
 
     public Builder exposedPorts(final String... exposedPorts) {
-      if (exposedPorts != null && exposedPorts.length > 0)
-    	this.exposedPorts = ImmutableSet.copyOf(exposedPorts);
-      
+      if (exposedPorts != null && exposedPorts.length > 0) {
+        this.exposedPorts = ImmutableSet.copyOf(exposedPorts);
+      }
+
       return this;
     }
 
@@ -538,16 +542,18 @@ public class ContainerConfig {
     }
 
     public Builder env(final List<String> env) {
-      if (env != null && !env.isEmpty())
+      if (env != null && !env.isEmpty()) {
         this.env = ImmutableList.copyOf(env);
-      
+      }
+
       return this;
     }
 
     public Builder env(final String... env) {
-      if (env != null && env.length > 0)
-    	this.env = ImmutableList.copyOf(env);
-      
+      if (env != null && env.length > 0) {
+        this.env = ImmutableList.copyOf(env);
+      }
+
       return this;
     }
 
@@ -556,16 +562,18 @@ public class ContainerConfig {
     }
 
     public Builder cmd(final List<String> cmd) {
-      if (cmd != null && !cmd.isEmpty())
-    	this.cmd = ImmutableList.copyOf(cmd);
-      
+      if (cmd != null && !cmd.isEmpty()) {
+        this.cmd = ImmutableList.copyOf(cmd);
+      }
+
       return this;
     }
 
     public Builder cmd(final String... cmd) {
-      if (cmd != null && cmd.length > 0)
-    	this.cmd = ImmutableList.copyOf(cmd);
-      
+      if (cmd != null && cmd.length > 0) {
+        this.cmd = ImmutableList.copyOf(cmd);
+      }
+
       return this;
     }
 
@@ -583,16 +591,18 @@ public class ContainerConfig {
     }
 
     public Builder volumes(final Set<String> volumes) {
-      if (volumes != null && !volumes.isEmpty())
-    	this.volumes = ImmutableSet.copyOf(volumes);
-      
+      if (volumes != null && !volumes.isEmpty()) {
+        this.volumes = ImmutableSet.copyOf(volumes);
+      }
+
       return this;
     }
 
     public Builder volumes(final String... volumes) {
-      if (volumes != null && volumes.length > 0)
-    	this.volumes = ImmutableSet.copyOf(volumes);
-      
+      if (volumes != null && volumes.length > 0) {
+        this.volumes = ImmutableSet.copyOf(volumes);
+      }
+
       return this;
     }
 
@@ -610,16 +620,18 @@ public class ContainerConfig {
     }
 
     public Builder entrypoint(final List<String> entrypoint) {
-      if (entrypoint != null && !entrypoint.isEmpty())
-    	this.entrypoint = ImmutableList.copyOf(entrypoint);
-      
+      if (entrypoint != null && !entrypoint.isEmpty()) {
+        this.entrypoint = ImmutableList.copyOf(entrypoint);
+      }
+
       return this;
     }
 
     public Builder entrypoint(final String... entrypoint) {
-      if (entrypoint != null && entrypoint.length > 0)
-    	this.entrypoint = ImmutableList.copyOf(entrypoint);
-      
+      if (entrypoint != null && entrypoint.length > 0) {
+        this.entrypoint = ImmutableList.copyOf(entrypoint);
+      }
+
       return this;
     }
 
@@ -637,16 +649,18 @@ public class ContainerConfig {
     }
 
     public Builder onBuild(final List<String> onBuild) {
-      if (onBuild != null && !onBuild.isEmpty())
-    	this.onBuild = ImmutableList.copyOf(onBuild);
-      
+      if (onBuild != null && !onBuild.isEmpty()) {
+        this.onBuild = ImmutableList.copyOf(onBuild);
+      }
+
       return this;
     }
 
     public Builder onBuild(final String... onBuild) {
-      if (onBuild != null && onBuild.length > 0)
-    	this.onBuild = ImmutableList.copyOf(onBuild);
-      
+      if (onBuild != null && onBuild.length > 0) {
+        this.onBuild = ImmutableList.copyOf(onBuild);
+      }
+
       return this;
     }
 
@@ -655,9 +669,10 @@ public class ContainerConfig {
     }
 
     public Builder labels(final Map<String, String> labels) {
-      if (labels != null && !labels.isEmpty())
-    	this.labels = ImmutableMap.copyOf(labels);
-      
+      if (labels != null && !labels.isEmpty()) {
+        this.labels = ImmutableMap.copyOf(labels);
+      }
+
       return this;
     }
 

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -475,12 +475,16 @@ public class ContainerConfig {
     }
 
     public Builder portSpecs(final List<String> portSpecs) {
-      this.portSpecs = ImmutableList.copyOf(portSpecs);
+      if (portSpecs != null && !portSpecs.isEmpty())
+    	this.portSpecs = ImmutableList.copyOf(portSpecs);
+      
       return this;
     }
 
     public Builder portSpecs(final String... portSpecs) {
-      this.portSpecs = ImmutableList.copyOf(portSpecs);
+      if (portSpecs != null && portSpecs.length > 0)
+        this.portSpecs = ImmutableList.copyOf(portSpecs);
+      
       return this;
     }
 
@@ -489,12 +493,16 @@ public class ContainerConfig {
     }
 
     public Builder exposedPorts(final Set<String> exposedPorts) {
-      this.exposedPorts = ImmutableSet.copyOf(exposedPorts);
+      if (exposedPorts != null && !exposedPorts.isEmpty())
+    	this.exposedPorts = ImmutableSet.copyOf(exposedPorts);
+      
       return this;
     }
 
     public Builder exposedPorts(final String... exposedPorts) {
-      this.exposedPorts = ImmutableSet.copyOf(exposedPorts);
+      if (exposedPorts != null && exposedPorts.length > 0)
+    	this.exposedPorts = ImmutableSet.copyOf(exposedPorts);
+      
       return this;
     }
 
@@ -530,12 +538,16 @@ public class ContainerConfig {
     }
 
     public Builder env(final List<String> env) {
-      this.env = ImmutableList.copyOf(env);
+      if (env != null && !env.isEmpty())
+        this.env = ImmutableList.copyOf(env);
+      
       return this;
     }
 
     public Builder env(final String... env) {
-      this.env = ImmutableList.copyOf(env);
+      if (env != null && env.length > 0)
+    	this.env = ImmutableList.copyOf(env);
+      
       return this;
     }
 
@@ -544,12 +556,16 @@ public class ContainerConfig {
     }
 
     public Builder cmd(final List<String> cmd) {
-      this.cmd = ImmutableList.copyOf(cmd);
+      if (cmd != null && !cmd.isEmpty())
+    	this.cmd = ImmutableList.copyOf(cmd);
+      
       return this;
     }
 
     public Builder cmd(final String... cmd) {
-      this.cmd = ImmutableList.copyOf(cmd);
+      if (cmd != null && cmd.length > 0)
+    	this.cmd = ImmutableList.copyOf(cmd);
+      
       return this;
     }
 
@@ -567,12 +583,16 @@ public class ContainerConfig {
     }
 
     public Builder volumes(final Set<String> volumes) {
-      this.volumes = ImmutableSet.copyOf(volumes);
+      if (volumes != null && !volumes.isEmpty())
+    	this.volumes = ImmutableSet.copyOf(volumes);
+      
       return this;
     }
 
     public Builder volumes(final String... volumes) {
-      this.volumes = ImmutableSet.copyOf(volumes);
+      if (volumes != null && volumes.length > 0)
+    	this.volumes = ImmutableSet.copyOf(volumes);
+      
       return this;
     }
 
@@ -590,12 +610,16 @@ public class ContainerConfig {
     }
 
     public Builder entrypoint(final List<String> entrypoint) {
-      this.entrypoint = ImmutableList.copyOf(entrypoint);
+      if (entrypoint != null && !entrypoint.isEmpty())
+    	this.entrypoint = ImmutableList.copyOf(entrypoint);
+      
       return this;
     }
 
     public Builder entrypoint(final String... entrypoint) {
-      this.entrypoint = ImmutableList.copyOf(entrypoint);
+      if (entrypoint != null && entrypoint.length > 0)
+    	this.entrypoint = ImmutableList.copyOf(entrypoint);
+      
       return this;
     }
 
@@ -613,12 +637,16 @@ public class ContainerConfig {
     }
 
     public Builder onBuild(final List<String> onBuild) {
-      this.onBuild = ImmutableList.copyOf(onBuild);
+      if (onBuild != null && !onBuild.isEmpty())
+    	this.onBuild = ImmutableList.copyOf(onBuild);
+      
       return this;
     }
 
     public Builder onBuild(final String... onBuild) {
-      this.onBuild = ImmutableList.copyOf(onBuild);
+      if (onBuild != null && onBuild.length > 0)
+    	this.onBuild = ImmutableList.copyOf(onBuild);
+      
       return this;
     }
 
@@ -627,7 +655,9 @@ public class ContainerConfig {
     }
 
     public Builder labels(final Map<String, String> labels) {
-      this.labels = ImmutableMap.copyOf(labels);
+      if (labels != null && !labels.isEmpty())
+    	this.labels = ImmutableMap.copyOf(labels);
+      
       return this;
     }
 

--- a/src/main/java/com/spotify/docker/client/messages/HostConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/HostConfig.java
@@ -371,16 +371,18 @@ public class HostConfig {
     }
 
     public Builder binds(final List<String> binds) {
-      if (binds != null && !binds.isEmpty())
-    	this.binds = ImmutableList.copyOf(binds);
-      
+      if (binds != null && !binds.isEmpty()) {
+        this.binds = ImmutableList.copyOf(binds);
+      }
+
       return this;
     }
 
     public Builder binds(final String... binds) {
-      if (binds != null && binds.length > 0)
-    	this.binds = ImmutableList.copyOf(binds);
-      
+      if (binds != null && binds.length > 0) {
+        this.binds = ImmutableList.copyOf(binds);
+      }
+
       return this;
     }
 
@@ -398,15 +400,17 @@ public class HostConfig {
     }
 
     public Builder lxcConf(final List<LxcConfParameter> lxcConf) {
-      if (lxcConf != null && !lxcConf.isEmpty())
-    	this.lxcConf = ImmutableList.copyOf(lxcConf);
+      if (lxcConf != null && !lxcConf.isEmpty()) {
+        this.lxcConf = ImmutableList.copyOf(lxcConf);
+      }
       return this;
     }
 
     public Builder lxcConf(final LxcConfParameter... lxcConf) {
-      if (lxcConf != null && lxcConf.length > 0)
-    	this.lxcConf = ImmutableList.copyOf(lxcConf);
-      
+      if (lxcConf != null && lxcConf.length > 0) {
+        this.lxcConf = ImmutableList.copyOf(lxcConf);
+      }
+
       return this;
     }
 
@@ -424,8 +428,9 @@ public class HostConfig {
     }
 
     public Builder portBindings(final Map<String, List<PortBinding>> portBindings) {
-      if (portBindings != null && !portBindings.isEmpty())
-    	this.portBindings = Maps.newHashMap(portBindings);
+      if (portBindings != null && !portBindings.isEmpty()) {
+        this.portBindings = Maps.newHashMap(portBindings);
+      }
       return this;
     }
 
@@ -434,16 +439,18 @@ public class HostConfig {
     }
 
     public Builder links(final List<String> links) {
-      if (links != null && !links.isEmpty())
-    	this.links = ImmutableList.copyOf(links);
-      
+      if (links != null && !links.isEmpty()) {
+        this.links = ImmutableList.copyOf(links);
+      }
+
       return this;
     }
 
     public Builder links(final String... links) {
-      if (links != null && links.length > 0)
-    	this.links = ImmutableList.copyOf(links);
-      
+      if (links != null && links.length > 0) {
+        this.links = ImmutableList.copyOf(links);
+      }
+
       return this;
     }
 
@@ -461,16 +468,18 @@ public class HostConfig {
     }
 
     public Builder dns(final List<String> dns) {
-      if (dns != null && !dns.isEmpty())
-    	this.dns = ImmutableList.copyOf(dns);
-      
+      if (dns != null && !dns.isEmpty()) {
+        this.dns = ImmutableList.copyOf(dns);
+      }
+
       return this;
     }
 
     public Builder dns(final String... dns) {
-      if (dns != null && dns.length > 0)
-    	this.dns = ImmutableList.copyOf(dns);
-      
+      if (dns != null && dns.length > 0) {
+        this.dns = ImmutableList.copyOf(dns);
+      }
+
       return this;
     }
 
@@ -479,16 +488,18 @@ public class HostConfig {
     }
 
     public Builder dnsSearch(final List<String> dnsSearch) {
-      if (dnsSearch != null && !dnsSearch.isEmpty())
-    	this.dnsSearch = ImmutableList.copyOf(dnsSearch);
-      
+      if (dnsSearch != null && !dnsSearch.isEmpty()) {
+        this.dnsSearch = ImmutableList.copyOf(dnsSearch);
+      }
+
       return this;
     }
 
     public Builder dnsSearch(final String... dnsSearch) {
-      if (dnsSearch != null && dnsSearch.length > 0)
-    	this.dnsSearch = ImmutableList.copyOf(dnsSearch);
-      
+      if (dnsSearch != null && dnsSearch.length > 0) {
+        this.dnsSearch = ImmutableList.copyOf(dnsSearch);
+      }
+
       return this;
     }
 
@@ -497,16 +508,18 @@ public class HostConfig {
     }
 
     public Builder volumesFrom(final List<String> volumesFrom) {
-      if (volumesFrom != null && !volumesFrom.isEmpty())
-    	this.volumesFrom = ImmutableList.copyOf(volumesFrom);
-      
+      if (volumesFrom != null && !volumesFrom.isEmpty()) {
+        this.volumesFrom = ImmutableList.copyOf(volumesFrom);
+      }
+
       return this;
     }
 
     public Builder volumesFrom(final String... volumesFrom) {
-      if (volumesFrom != null && volumesFrom.length > 0)
-    	this.volumesFrom = ImmutableList.copyOf(volumesFrom);
-      
+      if (volumesFrom != null && volumesFrom.length > 0) {
+        this.volumesFrom = ImmutableList.copyOf(volumesFrom);
+      }
+
       return this;
     }
 
@@ -524,16 +537,18 @@ public class HostConfig {
     }
 
     public Builder securityOpt(final List<String> securityOpt) {
-      if (securityOpt != null && !securityOpt.isEmpty())
-    	this.securityOpt = ImmutableList.copyOf(securityOpt);
-      
+      if (securityOpt != null && !securityOpt.isEmpty()) {
+        this.securityOpt = ImmutableList.copyOf(securityOpt);
+      }
+
       return this;
     }
-    
+
     public Builder securityOpt(final String... securityOpt) {
-      if (securityOpt != null && securityOpt.length > 0)
-    	this.securityOpt = ImmutableList.copyOf(securityOpt);
-      
+      if (securityOpt != null && securityOpt.length > 0) {
+        this.securityOpt = ImmutableList.copyOf(securityOpt);
+      }
+
       return this;
     }
 

--- a/src/main/java/com/spotify/docker/client/messages/HostConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/HostConfig.java
@@ -371,12 +371,16 @@ public class HostConfig {
     }
 
     public Builder binds(final List<String> binds) {
-      this.binds = ImmutableList.copyOf(binds);
+      if (binds != null && !binds.isEmpty())
+    	this.binds = ImmutableList.copyOf(binds);
+      
       return this;
     }
 
     public Builder binds(final String... binds) {
-      this.binds = ImmutableList.copyOf(binds);
+      if (binds != null && binds.length > 0)
+    	this.binds = ImmutableList.copyOf(binds);
+      
       return this;
     }
 
@@ -394,12 +398,15 @@ public class HostConfig {
     }
 
     public Builder lxcConf(final List<LxcConfParameter> lxcConf) {
-      this.lxcConf = ImmutableList.copyOf(lxcConf);
+      if (lxcConf != null && !lxcConf.isEmpty())
+    	this.lxcConf = ImmutableList.copyOf(lxcConf);
       return this;
     }
 
     public Builder lxcConf(final LxcConfParameter... lxcConf) {
-      this.lxcConf = ImmutableList.copyOf(lxcConf);
+      if (lxcConf != null && lxcConf.length > 0)
+    	this.lxcConf = ImmutableList.copyOf(lxcConf);
+      
       return this;
     }
 
@@ -417,7 +424,8 @@ public class HostConfig {
     }
 
     public Builder portBindings(final Map<String, List<PortBinding>> portBindings) {
-      this.portBindings = (portBindings == null) ? null : Maps.newHashMap(portBindings);
+      if (portBindings != null && !portBindings.isEmpty())
+    	this.portBindings = Maps.newHashMap(portBindings);
       return this;
     }
 
@@ -426,12 +434,16 @@ public class HostConfig {
     }
 
     public Builder links(final List<String> links) {
-      this.links = ImmutableList.copyOf(links);
+      if (links != null && !links.isEmpty())
+    	this.links = ImmutableList.copyOf(links);
+      
       return this;
     }
 
     public Builder links(final String... links) {
-      this.links = ImmutableList.copyOf(links);
+      if (links != null && links.length > 0)
+    	this.links = ImmutableList.copyOf(links);
+      
       return this;
     }
 
@@ -449,12 +461,16 @@ public class HostConfig {
     }
 
     public Builder dns(final List<String> dns) {
-      this.dns = ImmutableList.copyOf(dns);
+      if (dns != null && !dns.isEmpty())
+    	this.dns = ImmutableList.copyOf(dns);
+      
       return this;
     }
 
     public Builder dns(final String... dns) {
-      this.dns = ImmutableList.copyOf(dns);
+      if (dns != null && dns.length > 0)
+    	this.dns = ImmutableList.copyOf(dns);
+      
       return this;
     }
 
@@ -463,12 +479,16 @@ public class HostConfig {
     }
 
     public Builder dnsSearch(final List<String> dnsSearch) {
-      this.dnsSearch = ImmutableList.copyOf(dnsSearch);
+      if (dnsSearch != null && !dnsSearch.isEmpty())
+    	this.dnsSearch = ImmutableList.copyOf(dnsSearch);
+      
       return this;
     }
 
     public Builder dnsSearch(final String... dnsSearch) {
-      this.dnsSearch = ImmutableList.copyOf(dnsSearch);
+      if (dnsSearch != null && dnsSearch.length > 0)
+    	this.dnsSearch = ImmutableList.copyOf(dnsSearch);
+      
       return this;
     }
 
@@ -477,12 +497,16 @@ public class HostConfig {
     }
 
     public Builder volumesFrom(final List<String> volumesFrom) {
-      this.volumesFrom = ImmutableList.copyOf(volumesFrom);
+      if (volumesFrom != null && !volumesFrom.isEmpty())
+    	this.volumesFrom = ImmutableList.copyOf(volumesFrom);
+      
       return this;
     }
 
     public Builder volumesFrom(final String... volumesFrom) {
-      this.volumesFrom = ImmutableList.copyOf(volumesFrom);
+      if (volumesFrom != null && volumesFrom.length > 0)
+    	this.volumesFrom = ImmutableList.copyOf(volumesFrom);
+      
       return this;
     }
 
@@ -499,8 +523,17 @@ public class HostConfig {
       return networkMode;
     }
 
+    public Builder securityOpt(final List<String> securityOpt) {
+      if (securityOpt != null && !securityOpt.isEmpty())
+    	this.securityOpt = ImmutableList.copyOf(securityOpt);
+      
+      return this;
+    }
+    
     public Builder securityOpt(final String... securityOpt) {
-      this.securityOpt = ImmutableList.copyOf(securityOpt);
+      if (securityOpt != null && securityOpt.length > 0)
+    	this.securityOpt = ImmutableList.copyOf(securityOpt);
+      
       return this;
     }
 


### PR DESCRIPTION
When using the configuration builders while loading properties from e.g. a map or a file, frequently a null or empty value is passed. While for _Strings_ or _Longs_ this is not a problem, _Maps_ and _Collections_ requires an external check thus breaking the fluency and overall being very annoying.

This PR implements those simple checks inside the builders.