### PR TITLE
Fix testConnectTimeout on Linux

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -809,7 +809,7 @@ public class DefaultDockerClientTest {
     assertThat(getClientConnectionPoolStats(sut).getLeased(), equalTo(0));
   }
 
-  @Test(expected = DockerTimeoutException.class)
+  @Test(expected = DockerException.class)
   public void testConnectTimeout() throws Exception {
     // Attempt to connect to reserved IP -> should timeout
     try (final DefaultDockerClient connectTimeoutClient = DefaultDockerClient.builder()


### PR DESCRIPTION
For some reason on Linux, testConnectTimeout() throws DockerException
while on Mac it throws DockerTimeoutException. Changing the test to
expect DockerException passes for both platforms.