### PR TITLE
Update README re: changed host configuration usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,30 +25,31 @@ docker.pull("foobar/busybox-private:latest", authConfig);
 // You can also set the AuthConfig for the DockerClient instead of passing everytime you call pull()
 DockerClient docker = DefaultDockerClient.authConfig(authConfig).build();
 
-// Create container with exposed ports
-final String[] ports = {"80", "22"};
-final ContainerConfig config = ContainerConfig.builder()
-    .image("busybox").exposedPorts(ports)
-    .cmd("sh", "-c", "while :; do sleep 1; done")
-    .build();
-
 // Bind container ports to host ports
+final String[] ports = {"80", "22"};
 final Map<String, List<PortBinding>> portBindings = new HashMap<String, List<PortBinding>>();
-for(String port : ports) {
+for (String port : ports) {
     List<PortBinding> hostPorts = new ArrayList<PortBinding>();
     hostPorts.add(PortBinding.of("0.0.0.0", port));
     portBindings.put(port, hostPorts);
 }
 final HostConfig hostConfig = HostConfig.builder().portBindings(portBindings).build();
 
-final ContainerCreation creation = docker.createContainer(config);
+// Create container with exposed ports
+final ContainerConfig containerConfig = ContainerConfig.builder()
+    .hostConfig(hostConfig)
+    .image("busybox").exposedPorts(ports)
+    .cmd("sh", "-c", "while :; do sleep 1; done")
+    .build();
+
+final ContainerCreation creation = docker.createContainer(containerConfig);
 final String id = creation.id();
 
 // Inspect container
 final ContainerInfo info = docker.inspectContainer(id);
 
 // Start container
-docker.startContainer(id, hostConfig);
+docker.startContainer(id);
 
 // Exec command inside running container with attached STDOUT and STDERR
 final String[] command = {"bash", "-c", "ls"};


### PR DESCRIPTION
`HostConfig`s are now longer passed to the `startContainer` method but wrapped by a  `ContainerConfig`. The PR reflects updating the documentation.

Additionally, the container configuration object as renamed from `config` to `containerConfig` to ease readability and be consistent with the other prefixed configuration types (`authConfig`, `hostConfig`).

Fixes #200.