### PR TITLE
Actually append apiversion to uripath

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -1041,7 +1041,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   private WebTarget resource() {
     final WebTarget target = client.target(uri);
     if (!isNullOrEmpty(apiVersion)) {
-      target.path(apiVersion);
+      return target.path(apiVersion);
     }
     return target;
   }
@@ -1049,7 +1049,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   private WebTarget noTimeoutResource() {
     final WebTarget target = noTimeoutClient.target(uri);
     if (!isNullOrEmpty(apiVersion)) {
-      target.path(apiVersion);
+      return target.path(apiVersion);
     }
     return target;
   }


### PR DESCRIPTION
```
     * @param path the path, may contain URI template parameters.
     * @return a new target instance.
     * @throws NullPointerException if path is {@code null}.
     */
    public WebTarget path(String path);
```
WebTarget.path(String) returns a new instance, so the new instance should be returned. 