### PR TITLE
Add support for missing parameters for showing logs.

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -873,13 +873,13 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   }
 
   @Override
-  public LogStream logs(final String containerId, final LogsParameter... params)
+  public LogStream logs(final String containerId, final LogsParam... params)
       throws DockerException, InterruptedException {
     WebTarget resource = resource()
         .path("containers").path(containerId).path("logs");
 
-    for (final LogsParameter param : params) {
-      resource = resource.queryParam(param.name().toLowerCase(Locale.ROOT), String.valueOf(true));
+    for (LogsParam param : params) {
+      resource = resource.queryParam(param.name(), param.value());
     }
 
     try {

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -511,7 +511,7 @@ public interface DockerClient extends Closeable {
    * @throws DockerException if a server error occurred (500)
    * @throws InterruptedException If the thread is interrupted
    */
-  LogStream logs(String containerId, LogsParameter... params)
+  LogStream logs(String containerId, LogsParam... params)
       throws DockerException, InterruptedException;
 
 
@@ -604,13 +604,142 @@ public interface DockerClient extends Closeable {
   void close();
 
   /**
-   * Parameters for {@link #logs(String, LogsParameter...)}
+   * Parameters for {@link #logs(String, LogsParam...)}
    */
-  public static enum LogsParameter {
-    FOLLOW,
-    STDOUT,
-    STDERR,
-    TIMESTAMPS,
+  public static class LogsParam {
+
+    private final String name;
+    private final String value;
+
+    public LogsParam(final String name, final String value) {
+      this.name = name;
+      this.value = value;
+    }
+
+    /**
+     * Parameter name.
+     *
+     * @return name of parameter
+     */
+    public String name() {
+      return name;
+    }
+
+    /**
+     * Parameter value.
+     *
+     * @return value of parameter
+     */
+    public String value() {
+      return value;
+    }
+
+    /**
+     * Return stream.
+     *
+     * @return LogsParam
+     */
+    public static LogsParam follow() {
+      return follow(true);
+    }
+
+    /**
+     * Return stream. Default false.
+     *
+     * @param follow Whether to return stream.
+     * @return LogsParam
+     */
+    public static LogsParam follow(final boolean follow) {
+      return create("follow", String.valueOf(follow));
+    }
+
+    /**
+     * Show stdout log.
+     *
+     * @return LogsParam
+     */
+    public static LogsParam stdout() {
+      return stdout(true);
+    }
+
+    /**
+     * Show stdout log. Default false.
+     *
+     * @param stdout Whether to show stdout log.
+     * @return LogsParam
+     */
+    public static LogsParam stdout(final boolean stdout) {
+      return create("stdout", String.valueOf(stdout));
+    }
+
+    /**
+     * Show stderr log.
+     *
+     * @return LogsParam
+     */
+    public static LogsParam stderr() {
+      return stderr(true);
+    }
+
+    /**
+     * Show stderr log. Default false.
+     *
+     * @param stderr Whether to show stderr log.
+     * @return LogsParam
+     */
+    public static LogsParam stderr(final boolean stderr) {
+      return create("stderr", String.valueOf(stderr));
+    }
+
+    /**
+     * Filter logs and only output entries since given Unix timestamp.
+     *
+     * @param timestamp Only output entries since timestamp.
+     * @return LogsParam
+     */
+    public static LogsParam since(final Integer timestamp) {
+      return create("since", String.valueOf(timestamp));
+    }
+
+    /**
+     * Print timestamp for every log line.
+     *
+     * @return LogsParam
+     */
+    public static LogsParam timestamps() {
+      return timestamps(true);
+    }
+
+    /**
+     * Print timestamp for every log line. Default false.
+     *
+     * @param timestamps Whether to print timestamp for every log line.
+     * @return LogsParam
+     */
+    public static LogsParam timestamps(final boolean timestamps) {
+      return create("timestamps", String.valueOf(timestamps));
+    }
+
+    /**
+     * Output specified number of lines at the end of logs.
+     *
+     * @param lines Number of lines to output at the end of logs.
+     * @return LogsParam
+     */
+    public static LogsParam tail(final Integer lines) {
+      return create("tail", String.valueOf(lines));
+    }
+
+    /**
+     * Create a custom parameter.
+     *
+     * @param name custom name
+     * @param value custom value
+     * @return LogsParam
+     */
+    public static LogsParam create(final String name, final String value) {
+      return new LogsParam(name, value);
+    }
   }
 
   /**

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -93,8 +93,8 @@ import static com.spotify.docker.client.DockerClient.BuildParameter.NO_RM;
 import static com.spotify.docker.client.DockerClient.BuildParameter.PULL_NEWER_IMAGE;
 import static com.spotify.docker.client.DockerClient.ListImagesParam.allImages;
 import static com.spotify.docker.client.DockerClient.ListImagesParam.danglingImages;
-import static com.spotify.docker.client.DockerClient.LogsParameter.STDERR;
-import static com.spotify.docker.client.DockerClient.LogsParameter.STDOUT;
+import static com.spotify.docker.client.DockerClient.LogsParam.stdout;
+import static com.spotify.docker.client.DockerClient.LogsParam.stderr;
 import static com.spotify.docker.client.messages.RemovedImage.Type.UNTAGGED;
 import static java.lang.Long.toHexString;
 import static java.lang.String.format;
@@ -1211,7 +1211,7 @@ public class DefaultDockerClientTest {
     assertThat(info.state().exitCode(), is(0));
 
     final String logs;
-    try (LogStream stream = sut.logs(info.id(), STDOUT, STDERR)) {
+    try (LogStream stream = sut.logs(info.id(), stdout(), stderr())) {
       logs = stream.readFully();
     }
     assertThat(logs, containsString("bar"));


### PR DESCRIPTION
Currently the parameters (1) tail *number* and (2) since *timestamp* aren't supported.

Query parameters for showing logs: https://docs.docker.com/reference/api/docker_remote_api_v1.19/#get-container-logs