### PR TITLE
attachContainer, logs and build should use the 'noTimeoutClient'

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -221,7 +221,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
 
     // ApacheConnector doesn't respect per-request timeout settings.
     // Workaround: instead create a client with infinite read timeout,
-    // and use it for waitContainer and stopContainer.
+    // and use it for waitContainer, stopContainer, attachContainer, logs, and build
     final RequestConfig noReadTimeoutRequestConfig = RequestConfig.copy(requestConfig)
         .setSocketTimeout((int) NO_TIMEOUT)
         .build();
@@ -795,7 +795,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       throws DockerException, InterruptedException, IOException {
     checkNotNull(handler, "handler");
 
-    WebTarget resource = resource().path("build");
+    WebTarget resource = noTimeoutResource().path("build");
 
     for (final BuildParameter param : params) {
       resource = resource.queryParam(param.buildParamName, String.valueOf(param.buildParamValue));
@@ -885,7 +885,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   @Override
   public LogStream logs(final String containerId, final LogsParameter... params)
       throws DockerException, InterruptedException {
-    WebTarget resource = resource()
+    WebTarget resource = noTimeoutResource()
         .path("containers").path(containerId).path("logs");
 
     for (final LogsParameter param : params) {
@@ -909,7 +909,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   public LogStream attachContainer(final String containerId,
                                    final AttachParameter... params) throws DockerException,
       InterruptedException {
-    WebTarget resource = resource().path("containers").path(containerId)
+    WebTarget resource = noTimeoutResource().path("containers").path(containerId)
         .path("attach");
 
     for (final AttachParameter param : params) {

--- a/src/test/resources/dockerDirectorySleeping/Dockerfile
+++ b/src/test/resources/dockerDirectorySleeping/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+RUN sleep 10s
+CMD ["/bin/sh"]


### PR DESCRIPTION
Like waitContainer, and stopContainer, attachContainer may take an
arbitrary amount of time to finish, and if this exceeds the socket read
timeout (default 30s), data will have been overlooked.

I've pushed a commit at rgrunber@58e1cd9 that simply reproduces the issue by modifying the testAttachLog slightly. The issue seems to occur in both TCP/UNIX cases, but only the TCP connection throws the SocketTimeoutException.

I set the socket read timeout to 5s for convenience. It's 30s by default (and 120s in the tests) but it's just as possible to have a program with a larger gap in between data being read. The testAttachLog simply pulls/create a Fedora 22 image that prints 'Seen output after X seconds.', after waiting X seconds, where X is incremement from 1 to 7, by 1. (beyond the read timeout).

I reproduce as follows (assuming the daemon is listening on the default TCP connection) :

$ DOCKER_HOST=tcp://localhost:2375 mvn clean test -Dtest=DefaultDockerClientTest#testAttachLog

...
...

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.spotify.docker.client.DefaultDockerClientTest
- testAttachLog
Seen output after 1 seconds.

Seen output after 2 seconds.

Seen output after 3 seconds.

Seen output after 4 seconds.

Seen output after 5 seconds.

java.net.SocketTimeoutException: Read timed out

Reading has finished, waiting for program to end.


Just a few things to  note. The program still runs within the container, but no additional output is collected due to the read timeout. In the case of a UNIX socket the SocketTimeoutException is never thrown likely due to the different implementation. It seems like the stream indicates there's no more content and waitContainer just waits for the program to finish.

Changing the attachContainer call to use 'noTimeoutResource()' resolves the issue.

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.spotify.docker.client.DefaultDockerClientTest
- testAttachLog
Seen output after 1 seconds.

Seen output after 2 seconds.

Seen output after 3 seconds.

Seen output after 4 seconds.

Seen output after 5 seconds.

Seen output after 6 seconds.

Seen output after 7 seconds.

Reading has finished, waiting for program to end.


I could write a proper test case for this as part of the commit, but I'd need to look into using some well-known lightweight image that has a shell environment and some basic commands like echo, and sleep . Also, execStart, and logs may also need similar changes but I haven't fully tried those cases out.