### PR TITLE
Handle empty patterns in .dockerignore

### DIFF
--- a/src/main/java/com/spotify/docker/client/CompressedDirectory.java
+++ b/src/main/java/com/spotify/docker/client/CompressedDirectory.java
@@ -138,6 +138,10 @@ class CompressedDirectory implements Closeable {
 
     if (Files.isReadable(dockerIgnorePath) && Files.isRegularFile(dockerIgnorePath)) {
       for (final String line : Files.readAllLines(dockerIgnorePath, StandardCharsets.UTF_8)) {
+        if (line.isEmpty()) {
+          log.debug("Will skip '{}' - cause it's empty", line);
+          continue;
+        }
         matchersBuilder.add(goPathMatcher(dockerIgnorePath.getFileSystem(), line));
       }
     }

--- a/src/main/java/com/spotify/docker/client/CompressedDirectory.java
+++ b/src/main/java/com/spotify/docker/client/CompressedDirectory.java
@@ -138,11 +138,12 @@ class CompressedDirectory implements Closeable {
 
     if (Files.isReadable(dockerIgnorePath) && Files.isRegularFile(dockerIgnorePath)) {
       for (final String line : Files.readAllLines(dockerIgnorePath, StandardCharsets.UTF_8)) {
-        if (line.isEmpty()) {
-          log.debug("Will skip '{}' - cause it's empty", line);
+        final String pattern = line.trim();
+        if (pattern.isEmpty()) {
+          log.debug("Will skip '{}' - cause it's empty after trimming", line);
           continue;
         }
-        matchersBuilder.add(goPathMatcher(dockerIgnorePath.getFileSystem(), line));
+        matchersBuilder.add(goPathMatcher(dockerIgnorePath.getFileSystem(), pattern));
       }
     }
 

--- a/src/test/resources/dockerDirectoryWithIgnore/.dockerignore
+++ b/src/test/resources/dockerDirectoryWithIgnore/.dockerignore
@@ -1,5 +1,7 @@
 to-be-ignored
-subdir
+  subdir
 
-*.ignore
+*.ignore  
+  
+		
 subdir2/*.ignore

--- a/src/test/resources/dockerDirectoryWithIgnore/.dockerignore
+++ b/src/test/resources/dockerDirectoryWithIgnore/.dockerignore
@@ -1,4 +1,5 @@
 to-be-ignored
 subdir
+
 *.ignore
 subdir2/*.ignore


### PR DESCRIPTION
Two issues:
 * handle empty line - pattern that matches everything
 * handle white character patterns

Empty lines should be ignored, and patterns should be trimmed.