### PR TITLE
Fixed resource path when API version is specified

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -1050,7 +1050,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   private WebTarget resource() {
     final WebTarget target = client.target(uri);
     if (!isNullOrEmpty(apiVersion)) {
-      target.path(apiVersion);
+      return target.path(apiVersion);
     }
     return target;
   }
@@ -1058,7 +1058,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   private WebTarget noTimeoutResource() {
     final WebTarget target = noTimeoutClient.target(uri);
     if (!isNullOrEmpty(apiVersion)) {
-      target.path(apiVersion);
+      return target.path(apiVersion);
     }
     return target;
   }


### PR DESCRIPTION
The `javax.ws.rs.client.WebTarget.path(String)` method creates a new `WebTarget` instance. The new instance has to be returned from the `resource()` and `noTimeoutResource()` methods of `DefaultDockerClient` class.