### PR TITLE
Use registryUrl in push command

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -710,8 +710,13 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       throws DockerException, InterruptedException {
     final ImageRef imageRef = new ImageRef(image);
 
-    WebTarget resource =
-        resource().path("images").path(imageRef.getImage()).path("push");
+    WebTarget resource = resource().path("images");
+    
+    if ( (authConfig != null) &&  (authConfig.serverAddress() != null)) {
+        resource = resource.path(authConfig.serverAddress());
+    }
+    
+    resource = resource.path(imageRef.getImage()).path("push");
 
     if (imageRef.getTag() != null) {
       resource = resource.queryParam("tag", imageRef.getTag());


### PR DESCRIPTION
In docker-maven-plugin pushing to private registry not work. ( I set serverId and registryUrl, but plugin try push to docker.io)

here example in official documentation about pushing to private registry
https://docs.docker.com/reference/api/docker_remote_api_v1.20/#push-an-image-on-the-registry