### PR TITLE
add support for Docker 1.8 image digest statuses

### DIFF
--- a/src/test/java/com/spotify/docker/client/messages/ProgressMessageTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/ProgressMessageTest.java
@@ -29,18 +29,30 @@ import static org.junit.Assert.assertNull;
 
 public class ProgressMessageTest {
 
-  @Test
-  public void testDigest() throws IOException {
-    final String digest = "sha256:ebd39c3e3962f804787f6b0520f8f1e35fbd5a01ab778ac14c8d6c37978e8445";
+  private final String digest =
+      "sha256:ebd39c3e3962f804787f6b0520f8f1e35fbd5a01ab778ac14c8d6c37978e8445";
+
+  private ProgressMessage readMessage(String status) throws IOException {
     final ObjectMapper objectMapper = new ObjectMapperProvider().getContext(ProgressMessage.class);
+    final String line = objectMapper.createObjectNode()
+        .put("status", status)
+        .toString();
+    return objectMapper.readValue(line, ProgressMessage.class);
+  }
 
-    assertEquals(
-        digest,
-        objectMapper.readValue("{\"status\":\"Digest: " + digest + "\"}", ProgressMessage.class)
-            .digest());
+  @Test
+  public void testNotADigest() throws Exception {
+    assertNull(readMessage("not-a-digest").digest());
+  }
 
-    assertNull(
-        objectMapper.readValue("{\"status\":\"not-a-digest\"}", ProgressMessage.class)
-            .digest());
+  @Test
+  public void testDigest_Docker16() throws Exception {
+    assertEquals(digest, readMessage("Digest: " + digest).digest());
+  }
+
+  @Test
+  public void testDigest_Docker18() throws Exception {
+    final String status = "some-image-tag: digest: " + digest + " size: 1234";
+    assertEquals(digest, readMessage(status).digest());
   }
 }


### PR DESCRIPTION
The status message for image pushes that contains the image digest is
different in docker v1.8 compared to v1.6, the format looks like:

```
<image/tag name>: digest: <digest> size: <size in bytes>
```

8dd48c2 added support for parsing the 1.6 style message, this adds the
1.8 format as well.

Fixes #250.