### PR TITLE
Fixed the authentication done when using build to a private repository API version 1.20

### DIFF
--- a/src/main/java/com/spotify/docker/client/VersionCompare.java
+++ b/src/main/java/com/spotify/docker/client/VersionCompare.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ * Copyright (c) 2015 Jeppe Schou.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client;
+
+public final class VersionCompare {
+
+  private VersionCompare(){}
+
+  /**
+   * Compares two version strings.
+   * <p>
+   * https://stackoverflow.com/questions/6701948/efficient-way-to-compare-version-strings-in-java
+   * </p>
+   * Use this instead of String.compareTo() for a non-lexicographical
+   * comparison that works for version strings. e.g. "1.10".compareTo("1.6").
+   *
+   * @param str1 a string of ordinal numbers separated by decimal points.
+   * @param str2 a string of ordinal numbers separated by decimal points.
+   * @return The result is a negative integer if str1 is _numerically_ less than str2.
+   * The result is a positive integer if str1 is _numerically_ greater than str2.
+   * The result is zero if the strings are _numerically_ equal.
+   * N.B. It does not work if "1.10" is supposed to be equal to "1.10.0".
+   */
+  public static int compareVersion(String str1, String str2) {
+    String[] vals1 = str1.split("\\.");
+    String[] vals2 = str2.split("\\.");
+    int i = 0;
+    // set index to first non-equal ordinal or length of shortest version string
+    while (i < vals1.length && i < vals2.length && vals1[i].equals(vals2[i])) {
+      i++;
+    }
+    // compare first non-equal ordinal number
+    if (i < vals1.length && i < vals2.length) {
+      int diff = Integer.valueOf(vals1[i]).compareTo(Integer.valueOf(vals2[i]));
+      return Integer.signum(diff);
+    }
+    // the strings are equal or one string is a substring of the other
+    // e.g. "1.2.3" = "1.2.3" or "1.2.3" < "1.2.3.4"
+    else {
+      return Integer.signum(vals1.length - vals2.length);
+    }
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/AuthRegistryConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/AuthRegistryConfig.java
@@ -17,41 +17,34 @@
 
 package com.spotify.docker.client.messages;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.google.common.base.MoreObjects;
-
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
-import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
-
 /**
   * A formatted string passed in X-Registry-Config request header.
-  * {"configs":{"myrepository":{
+  * {"myrepository":{
   *   "username":"myusername",
   *   "password":"mypassword",
   *   "auth":"",
   *   "email":"myemail",
-  *   "serveraddress":"myserverAddress"}}}
+  *   "serveraddress":"myserverAddress"}}
 */
-@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 public class AuthRegistryConfig {
 
-  @JsonIgnore
+
   private final Map<String, String> properties = new HashMap<String, String>();
 
-  @JsonProperty("configs") private final Map<String, Map<String, String>> configs = 
+  private final Map<String, Map<String, String>> configs =
                              new HashMap<String, Map<String, String>>();
-  @JsonIgnore private final String repository;
-  @JsonIgnore private final String username;
-  @JsonIgnore private final String password;
-  @JsonIgnore private final String auth;
-  @JsonIgnore private final String email;
-  @JsonIgnore private final String serverAddress;
+  private final String repository;
+  private final String username;
+  private final String password;
+  private final String auth;
+  private final String email;
+  private final String serverAddress;
 
   public static final AuthRegistryConfig EMPTY = new AuthRegistryConfig("", "", "", "", "", "");
 
@@ -98,6 +91,11 @@ public class AuthRegistryConfig {
                             String email, 
                             String serverAddress) {
     this(repository, username, password, "", email, serverAddress);
+  }
+
+  @JsonAnyGetter
+  public Map<String, Map<String, String>> getConfigs() {
+    return configs;
   }
   
   @Override

--- a/src/test/resources/dockerDirectoryNeedsAuth/Dockerfile
+++ b/src/test/resources/dockerDirectoryNeedsAuth/Dockerfile
@@ -1,0 +1,1 @@
+FROM dxia2/scratch-private:latest


### PR DESCRIPTION
AuthRegistryConfig looked like:

{"configs":{"myrepository":{
     "username":"myusername",
     "password":"mypassword",
     "auth":"",
     "email":"myemail",
     "serveraddress":"myserverAddress"}}}

But needs to look like:
{"myrepository":{
     "username":"myusername",
     "password":"mypassword",
     "auth":"",
     "email":"myemail",
     "serveraddress":"myserverAddress"}}

Added the fix to AuthRegistryConfig.
Added a test to make sure the test works