### PR TITLE
Add support for missing parameter for execCreate 

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -27,6 +27,9 @@ case "$1" in
 
   test)
     set +x
+    # print version info on the CI machine
+    docker version
+    # run a registry locally
     docker run -d -p 5000:5000 \
       -e STANDALONE=false \
       -e MIRROR_SOURCE=https://registry-1.docker.io \

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -951,8 +951,9 @@ public class DefaultDockerClient implements DockerClient, Closeable {
         generator.writeBooleanField(param.getName(), true);
       }
       
-      if(user != null)
+       if (user != null) {
           generator.writeStringField("User", user);
+      }
 
       generator.writeArrayFieldStart("Cmd");
       for (String s : cmd) {

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -930,15 +930,9 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     }
   }
 
- @Override
-  public String execCreate(String containerId, String[] cmd, ExecParameter... params)
-          throws DockerException, InterruptedException {
-      return execCreate(containerId, cmd, null, params);
-  }
-  
   
   @Override
-  public String execCreate(String containerId, String[] cmd, String user, ExecParameter... params)
+  public String execCreate(String containerId, String[] cmd, final ExecParam... params)
           throws DockerException, InterruptedException {
     WebTarget resource = resource().path("containers").path(containerId).path("exec");
 
@@ -947,14 +941,12 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       final JsonGenerator generator = objectMapper().getFactory().createGenerator(writer);
       generator.writeStartObject();
 
-      for (ExecParameter param : params) {
-        generator.writeBooleanField(param.getName(), true);
-      }
+      for (ExecParam param : params) {
+          
+          if(param.value().equals("true") || param.value().equals("false")) generator.writeBooleanField(param.name(), Boolean.valueOf(param.value()));
+          else generator.writeStringField(param.name(), param.value());
+        }
       
-       if (user != null) {
-          generator.writeStringField("User", user);
-      }
-
       generator.writeArrayFieldStart("Cmd");
       for (String s : cmd) {
         generator.writeString(s);

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -930,8 +930,15 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     }
   }
 
-  @Override
+ @Override
   public String execCreate(String containerId, String[] cmd, ExecParameter... params)
+          throws DockerException, InterruptedException {
+      return execCreate(containerId, cmd, null, params);
+  }
+  
+  
+  @Override
+  public String execCreate(String containerId, String[] cmd, String user, ExecParameter... params)
           throws DockerException, InterruptedException {
     WebTarget resource = resource().path("containers").path(containerId).path("exec");
 
@@ -943,6 +950,9 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       for (ExecParameter param : params) {
         generator.writeBooleanField(param.getName(), true);
       }
+      
+      if(user != null)
+          generator.writeStringField("User", user);
 
       generator.writeArrayFieldStart("Cmd");
       for (String s : cmd) {
@@ -955,8 +965,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     } catch (IOException e) {
       throw new DockerException(e);
     }
-
-
+    
     String response;
     try {
       response = request(POST, String.class, resource,
@@ -978,6 +987,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       throw new DockerException(e);
     }
   }
+  
 
   @Override
   public LogStream execStart(String execId, ExecStartParameter... params)

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -542,10 +542,8 @@ public interface DockerClient extends Closeable {
    * @throws DockerException if a server error occurred (500)
    * @throws InterruptedException If the thread is interrupted
    */
-  String execCreate(String containerId, String[] cmd, ExecParameter... params)
-      throws DockerException, InterruptedException;
       
-  String execCreate(String containerId, String[] cmd, String user, ExecParameter... params)
+  String execCreate(String containerId, String[] cmd, ExecParam... params)
       throws DockerException, InterruptedException;
 
   /**
@@ -622,10 +620,120 @@ public interface DockerClient extends Closeable {
    */
   @Override
   void close();
+  
+  /**
+   * 
+   * @author sfk
+   *  
+   */
+//  type ExecConfig struct {
+//      User         string   // User that will run the command
+//      Privileged+   bool     // Is the container in privileged mode
+//      Tty       +   bool     // Attach standard streams to a tty.
+//      Container  +  string   // Name of the container (to execute in)
+//      AttachStdin + bool     // Attach the standard input, makes possible user interaction
+//      AttachStderr +bool     // Attach the standard output
+//      AttachStdout +bool     // Attach the standard error
+//      Detach       + bool     // Execute in detach mode
+//      Cmd        +  []string // Execution commands and args
+//  }
+  
+  
+  class ExecParam {
+      private final String name;
+      private final String value;
+      
+      public ExecParam(final String name, final String value) {
+          this.name = name;
+          this.value = value;
+      }
+      
+      public String name() {
+        return name;
+      }
+     
+      public String value() {
+        return value;
+      }
+      
+      public static ExecParam create(String name, String value)
+      {
+          return new ExecParam(name, value);
+      }
+      
+      public static ExecParam detach(final boolean detach)
+      {
+          return create("Detach", String.valueOf(detach));
+      }
+      
+      public static ExecParam detach()
+      {
+          return detach(true);
+      }
+      
+      public static ExecParam attachStdin(final boolean attachStdin)
+      {
+          return create("AttachStdin",String.valueOf(attachStdin));
+      }
+      
+      public static ExecParam attachStdin()
+      {
+          return attachStdin(true);
+      }
+      
+      public static ExecParam attachStderr(final boolean attachStderr)
+      {
+          return create("AttachStderr",String.valueOf(attachStderr));
+      }
+      
+      public static ExecParam attachStderr()
+      {
+          return attachStderr(true);
+      }
+      
+      public static ExecParam attachStdout(final boolean attachStdout)
+      {
+          return create("AttachStdout",String.valueOf(attachStdout));
+      }
+      
+      public static ExecParam attachStdout()
+      {
+          return attachStdout(true);
+      }
+      
+      public static ExecParam privileged(final boolean privileged)
+      {
+          return create("Privileged",String.valueOf(privileged));
+      }
+      
+      public static ExecParam privileged()
+      {
+          return privileged(true);
+      }
+      
+      public static ExecParam tty(final boolean tty)
+      {
+          return create("Tty",String.valueOf(tty));
+      }
+      
+      public static ExecParam tty()
+      {
+          return tty(true);
+      }
+      
+      public static ExecParam user(final String user)
+      {
+          return create("User",user);
+      }
+      
+      
+  }
+  
 
   /**
    * Parameters for {@link #logs(String, LogsParam...)}
    */
+  
   class LogsParam {
 
     private final String name;

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -544,6 +544,9 @@ public interface DockerClient extends Closeable {
    */
   String execCreate(String containerId, String[] cmd, ExecParameter... params)
       throws DockerException, InterruptedException;
+      
+  String execCreate(String containerId, String[] cmd, String user, ExecParameter... params)
+      throws DockerException, InterruptedException;
 
   /**
    * Supported parameters for {@link #execCreate}

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.SettableFuture;
 
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.spotify.docker.client.DockerClient.AttachParameter;
+import com.spotify.docker.client.DockerClient.ExecParam;
 import com.spotify.docker.client.messages.AuthConfig;
 import com.spotify.docker.client.messages.Container;
 import com.spotify.docker.client.messages.ContainerConfig;
@@ -1605,8 +1606,8 @@ public class DefaultDockerClientTest {
     sut.startContainer(containerId);
 
     String execId = sut.execCreate(containerId, new String[] {"ls", "-la"},
-            DockerClient.ExecParameter.STDOUT,
-            DockerClient.ExecParameter.STDERR);
+            ExecParam.attachStdout(),
+            ExecParam.attachStderr());
 
     log.info("execId = {}", execId);
 
@@ -1637,8 +1638,10 @@ public class DefaultDockerClientTest {
     sut.startContainer(containerId);
 
     String execId = sut.execCreate(containerId, new String[] {"sh", "-c", "exit 2"},
-                                   DockerClient.ExecParameter.STDOUT,
-                                   DockerClient.ExecParameter.STDERR);
+                                   ExecParam.attachStdout(),
+                                   ExecParam.attachStderr(),
+                                   ExecParam.tty(),
+                                   ExecParam.user("1000"));
 
     log.info("execId = {}", execId);
     try (LogStream stream = sut.execStart(execId)) {


### PR DESCRIPTION
execCreate parameter "user" is missing so default docker exec's commands files owns root. Added user query param to exeCreate.