### PR TITLE
Support for using docker login credentials from ~/.dockercfg and ~/.docker/config.json

### DIFF
--- a/src/main/java/com/spotify/docker/client/AuthConfigParser.java
+++ b/src/main/java/com/spotify/docker/client/AuthConfigParser.java
@@ -52,10 +52,10 @@ public class AuthConfigParser {
         File dockerCfg = new File(home, ".dockercfg");
 
         if (dockerConfig.isFile()) {
-            log.debug("Using configfile: " + dockerConfig);
+            log.debug("Using configfile: {}", dockerConfig);
             parseAuthBuilders(dockerConfig);
         } else if (dockerCfg.isFile()) {
-            log.debug("Using configfile: " + dockerCfg);
+            log.debug("Using configfile: {} ", dockerCfg);
             parseAuthBuilders(dockerCfg);
         } else {
             log.error("Could not find a docker config. Please run 'docker login' to create one");
@@ -85,7 +85,7 @@ public class AuthConfigParser {
         if (authBuilders.containsKey(serverAddress)) {
             return authBuilders.get(serverAddress);
         } else {
-            log.error("Could not find auth config for ${serverAddress}, returning empty builder");
+            log.error("Could not find auth config for {}, returning empty builder", serverAddress);
             return AuthConfig.builder().serverAddress(serverAddress);
         }
     }
@@ -110,11 +110,11 @@ public class AuthConfigParser {
                     authBuilder.username(authParams[0].trim());
                     authBuilder.password(authParams[1].trim());
                 } else {
-                    log.error("Failed to parse auth string for ${server} in ${configFile}");
+                    log.error("Failed to parse auth string for {}", server);
                     continue;
                 }
             } else {
-                log.error("Could not find auth value for ${server} in ${configFile}");
+                log.error("Could not find auth value for {}", server);
                 continue;
             }
 
@@ -134,7 +134,7 @@ public class AuthConfigParser {
         try {
             config = mapper.readTree(configFile);
         } catch (IOException e) {
-            log.error("Could not read configfile: ${configFile}");
+            log.error("Could not read configfile: {}", configFile);
             log.error(e.getMessage());
         }
         if (config.has("auths")) {

--- a/src/main/java/com/spotify/docker/client/AuthConfigParser.java
+++ b/src/main/java/com/spotify/docker/client/AuthConfigParser.java
@@ -33,7 +33,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 /**
- * This helper class is used to build a {@Link AuthConf.Builder} from the docker config json
+ * This helper class is used to build a {@link AuthConfig.Builder} from the docker config json
  * created by running `docker login`
  */
 public class AuthConfigParser {
@@ -63,7 +63,7 @@ public class AuthConfigParser {
     }
 
     /**
-     * @return a {@Link AuthConf.Builder} based on docker config json
+     * @return a {@link AuthConfig.Builder} based on docker config json
      */
     public AuthConfig.Builder getBuilder() {
         if (authBuilders.isEmpty()) {
@@ -78,7 +78,7 @@ public class AuthConfigParser {
 
     /**
      * @param serverAddress
-     * @return a {@Link AuthConf.Builder} based on docker config json for the
+     * @return a {@link AuthConfig.Builder} based on docker config json for the
      * given serverAdress
      */
     public AuthConfig.Builder getBuilderFor(String serverAddress) {

--- a/src/main/java/com/spotify/docker/client/AuthConfigParser.java
+++ b/src/main/java/com/spotify/docker/client/AuthConfigParser.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.spotify.docker.client.messages.AuthConfig;
+import org.glassfish.jersey.internal.util.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * This helper class is used to build a {@Link AuthConf.Builder} from the docker config json
+ * created by running `docker login`
+ */
+public class AuthConfigParser {
+    private Map<String, AuthConfig.Builder> authBuilders;
+
+    private static final Logger log = LoggerFactory.getLogger(AuthConfigParser.class);
+
+    public AuthConfigParser(String configFile) {
+        File dockerConfig = new File(configFile);
+        parseAuthBuilders(dockerConfig);
+    }
+
+    public AuthConfigParser() {
+        String home = System.getProperty("user.home");
+        File dockerConfig = new File(new File(home, ".docker"), "config.json");
+        File dockerCfg = new File(home, ".dockercfg");
+
+        if (dockerConfig.isFile()) {
+            log.debug("Using configfile: " + dockerConfig);
+            parseAuthBuilders(dockerConfig);
+        } else if (dockerCfg.isFile()) {
+            log.debug("Using configfile: " + dockerCfg);
+            parseAuthBuilders(dockerCfg);
+        } else {
+            log.error("Could not find a docker config. Please run 'docker login' to create one");
+        }
+    }
+
+    /**
+     * @return a {@Link AuthConf.Builder} based on docker config json
+     */
+    public AuthConfig.Builder getBuilder() {
+        if (authBuilders.isEmpty()) {
+            log.error("Could not find any valid auth configurations, returning default builder");
+            return AuthConfig.builder();
+        } else {
+            String serverAddress = new ArrayList<>(authBuilders.keySet()).get(0);
+            return authBuilders.get(serverAddress);
+        }
+
+    }
+
+    /**
+     * @param serverAddress
+     * @return a {@Link AuthConf.Builder} based on docker config json for the
+     * given serverAdress
+     */
+    public AuthConfig.Builder getBuilderFor(String serverAddress) {
+        if (authBuilders.containsKey(serverAddress)) {
+            return authBuilders.get(serverAddress);
+        } else {
+            log.error("Could not find auth config for ${serverAddress}, returning empty builder");
+            return AuthConfig.builder().serverAddress(serverAddress);
+        }
+    }
+
+    private void parseAuthBuilders(File configFile) {
+        authBuilders = new HashMap<>();
+        JsonNode authJson = extractAuthJson(configFile);
+
+        Iterator<String> servers = authJson.fieldNames();
+        while (servers.hasNext()) {
+            String server = servers.next();
+            AuthConfig.Builder authBuilder = AuthConfig.builder();
+            authBuilder.serverAddress(server);
+
+            JsonNode serverAuth = authJson.get(server);
+
+            if (serverAuth.has("auth")) {
+                String authString = serverAuth.get("auth").asText();
+                String[] authParams = Base64.decodeAsString(authString).split(":");
+
+                if (authParams.length == 2) {
+                    authBuilder.username(authParams[0].trim());
+                    authBuilder.password(authParams[1].trim());
+                } else {
+                    log.error("Failed to parse auth string for ${server} in ${configFile}");
+                    continue;
+                }
+            } else {
+                log.error("Could not find auth value for ${server} in ${configFile}");
+                continue;
+            }
+
+            if (serverAuth.has("email")) {
+                authBuilder.email(serverAuth.get("email").asText());
+            }
+
+            authBuilders.put(server, authBuilder);
+        }
+
+    }
+
+    private JsonNode extractAuthJson(File configFile)  {
+        ObjectMapper mapper = new ObjectMapper();
+
+        JsonNode config = new TextNode("");
+        try {
+            config = mapper.readTree(configFile);
+        } catch (IOException e) {
+            log.error("Could not read configfile: ${configFile}");
+            log.error(e.getMessage());
+        }
+        if (config.has("auths")) {
+            return config.get("auths");
+        }
+        return config;
+    }
+}
+

--- a/src/main/java/com/spotify/docker/client/messages/AuthConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/AuthConfig.java
@@ -110,11 +110,11 @@ public class AuthConfig {
     return new Builder(this);
   }
 
-  public Builder fromDockerConfig(String serverAddress) {
+  public static Builder fromDockerConfig(String serverAddress) {
     return new AuthConfigParser().getBuilderFor(serverAddress);
   }
 
-  public Builder fromDockerConfig() {
+  public static Builder fromDockerConfig() {
     return new AuthConfigParser().getBuilder();
   }
 

--- a/src/main/java/com/spotify/docker/client/messages/AuthConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/AuthConfig.java
@@ -21,6 +21,7 @@ import com.google.common.base.MoreObjects;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.spotify.docker.client.AuthConfigParser;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
@@ -109,6 +110,14 @@ public class AuthConfig {
     return new Builder(this);
   }
 
+  public Builder fromDockerConfig(String serverAddress) {
+    return new AuthConfigParser().getBuilderFor(serverAddress);
+  }
+
+  public Builder fromDockerConfig() {
+    return new AuthConfigParser().getBuilder();
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -166,6 +175,7 @@ public class AuthConfig {
     public String serverAddress() {
       return serverAddress;
     }
+
 
     public AuthConfig build() {
       return new AuthConfig(this);

--- a/src/test/java/com/spotify/docker/client/AuthConfigParserTest.java
+++ b/src/test/java/com/spotify/docker/client/AuthConfigParserTest.java
@@ -10,41 +10,52 @@ import static org.junit.Assert.*;
 
 public class AuthConfigParserTest {
 
-    AuthConfig fullConfig;
+    AuthConfig dockerIo;
+    AuthConfig myDock;
     AuthConfig defaultConfig;
 
     @Before
     public void setup() {
-        fullConfig = AuthConfig.builder()
+        dockerIo = AuthConfig.builder()
                 .serverAddress("https://index.docker.io/v1/")
                 .username("dockerman")
                 .password("sw4gy0lo")
                 .email("dockerman@hub.com")
+                .build();
+        myDock = AuthConfig.builder()
+                .serverAddress("https://narnia.mydock.io/v1/")
+                .username("megaman")
+                .password("riffraff")
+                .email("megaman@mydock.com")
                 .build();
         defaultConfig = AuthConfig.builder().build();
     }
 
     @Test
     public void testFromFullConfig() {
-        AuthConfig authConfig = new AuthConfigParser(Resources.getResource("dockerConfig/fullConfig.json").getPath()).getBuilder().build();
-        assertEquals(authConfig, fullConfig);
+        AuthConfig authConfig = new AuthConfigParser(getTestFile("dockerConfig/fullConfig.json"))
+                .getBuilder().build();
+        assertEquals(authConfig, dockerIo);
     }
 
     @Test
     public void testFromFullDockerCFG() {
-        AuthConfig authConfig = new AuthConfigParser(Resources.getResource("dockerConfig/fulldockercfg").getPath()).getBuilder().build();
-        assertEquals(authConfig, fullConfig);
+        AuthConfig authConfig = new AuthConfigParser(getTestFile("dockerConfig/fulldockercfg"))
+                .getBuilder().build();
+        assertEquals(authConfig, dockerIo);
     }
 
     @Test
     public void testFromIncompleteConfig() {
-        AuthConfig authConfig = new AuthConfigParser(Resources.getResource("dockerConfig/incompleteConfig.json").getPath()).getBuilder().build();
+        AuthConfig authConfig = new AuthConfigParser(getTestFile("dockerConfig/incompleteConfig.json"))
+                .getBuilder().build();
         assertEquals(defaultConfig, authConfig);
     }
 
     @Test
     public void testWrongConfig() {
-        AuthConfig authConfig = new AuthConfigParser(Resources.getResource("dockerConfig/wrongConfig.json").getPath()).getBuilder().build();
+        AuthConfig authConfig = new AuthConfigParser(getTestFile("dockerConfig/wrongConfig.json"))
+                .getBuilder().build();
         assertEquals(defaultConfig, authConfig);
 
     }
@@ -54,5 +65,19 @@ public class AuthConfigParserTest {
         String randomFileName = RandomStringUtils.randomAlphanumeric(16) + ".json";
         AuthConfig authConfig = new AuthConfigParser(randomFileName).getBuilder().build();
         assertEquals(defaultConfig, authConfig);
+    }
+
+    @Test
+    public void testGettingMultiConfig(){
+        AuthConfig myDockParsed = new AuthConfigParser(getTestFile("dockerConfig/multiConfig.json"))
+                .getBuilderFor("https://narnia.mydock.io/v1/").build();
+        assertEquals(myDock, myDockParsed);
+        AuthConfig dockerIoParsed = new AuthConfigParser(getTestFile("dockerConfig/multiConfig.json"))
+                .getBuilderFor("https://index.docker.io/v1/").build();
+        assertEquals(dockerIo, dockerIoParsed);
+    }
+
+    private String getTestFile(String path) {
+        return Resources.getResource(path).getPath();
     }
 }

--- a/src/test/java/com/spotify/docker/client/AuthConfigParserTest.java
+++ b/src/test/java/com/spotify/docker/client/AuthConfigParserTest.java
@@ -1,0 +1,58 @@
+package com.spotify.docker.client;
+
+import com.google.common.io.Resources;
+import com.spotify.docker.client.messages.AuthConfig;
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class AuthConfigParserTest {
+
+    AuthConfig fullConfig;
+    AuthConfig defaultConfig;
+
+    @Before
+    public void setup() {
+        fullConfig = AuthConfig.builder()
+                .serverAddress("https://index.docker.io/v1/")
+                .username("dockerman")
+                .password("sw4gy0lo")
+                .email("dockerman@hub.com")
+                .build();
+        defaultConfig = AuthConfig.builder().build();
+    }
+
+    @Test
+    public void testFromFullConfig() {
+        AuthConfig authConfig = new AuthConfigParser(Resources.getResource("dockerConfig/fullConfig.json").getPath()).getBuilder().build();
+        assertEquals(authConfig, fullConfig);
+    }
+
+    @Test
+    public void testFromFullDockerCFG() {
+        AuthConfig authConfig = new AuthConfigParser(Resources.getResource("dockerConfig/fulldockercfg").getPath()).getBuilder().build();
+        assertEquals(authConfig, fullConfig);
+    }
+
+    @Test
+    public void testFromIncompleteConfig() {
+        AuthConfig authConfig = new AuthConfigParser(Resources.getResource("dockerConfig/incompleteConfig.json").getPath()).getBuilder().build();
+        assertEquals(defaultConfig, authConfig);
+    }
+
+    @Test
+    public void testWrongConfig() {
+        AuthConfig authConfig = new AuthConfigParser(Resources.getResource("dockerConfig/wrongConfig.json").getPath()).getBuilder().build();
+        assertEquals(defaultConfig, authConfig);
+
+    }
+
+    @Test
+    public void testFromMissingConfig() {
+        String randomFileName = RandomStringUtils.randomAlphanumeric(16) + ".json";
+        AuthConfig authConfig = new AuthConfigParser(randomFileName).getBuilder().build();
+        assertEquals(defaultConfig, authConfig);
+    }
+}

--- a/src/test/resources/dockerConfig/fullConfig.json
+++ b/src/test/resources/dockerConfig/fullConfig.json
@@ -1,0 +1,8 @@
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "ZG9ja2VybWFuOnN3NGd5MGxvCg==",
+      "email": "dockerman@hub.com"
+    }
+  }
+}

--- a/src/test/resources/dockerConfig/fulldockercfg
+++ b/src/test/resources/dockerConfig/fulldockercfg
@@ -1,0 +1,6 @@
+{
+    "https://index.docker.io/v1/": {
+      "auth": "ZG9ja2VybWFuOnN3NGd5MGxvCg==",
+      "email": "dockerman@hub.com"
+    }
+}

--- a/src/test/resources/dockerConfig/incompleteConfig.json
+++ b/src/test/resources/dockerConfig/incompleteConfig.json
@@ -1,0 +1,7 @@
+{
+  "auths": {
+    "https://different.docker.io/v1/": {
+      "email": "dockerman@hub.com"
+    }
+  }
+}

--- a/src/test/resources/dockerConfig/multiConfig.json
+++ b/src/test/resources/dockerConfig/multiConfig.json
@@ -5,7 +5,7 @@
       "email": "dockerman@hub.com"
     },
     "https://narnia.mydock.io/v1/": {
-      "auth": "bWVnYW1hbjpyaWZmcmFmZgo",
+      "auth": "bWVnYW1hbjpyaWZmcmFmZgo=",
       "email": "megaman@mydock.com"
     }
   }

--- a/src/test/resources/dockerConfig/multiConfig.json
+++ b/src/test/resources/dockerConfig/multiConfig.json
@@ -1,0 +1,12 @@
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "ZG9ja2VybWFuOnN3NGd5MGxvCg==",
+      "email": "dockerman@hub.com"
+    },
+    "https://narnia.mydock.io/v1/": {
+      "auth": "bWVnYW1hbjpyaWZmcmFmZgo",
+      "email": "megaman@mydock.com"
+    }
+  }
+}

--- a/src/test/resources/dockerConfig/wrongConfig.json
+++ b/src/test/resources/dockerConfig/wrongConfig.json
@@ -1,0 +1,8 @@
+{
+  "wrong": {
+    "https://xkcd.com/221/": {
+      "number": "4",
+      "random": true
+    }
+  }
+}


### PR DESCRIPTION
I had a PR in #219 but, it had gone stale so I created this in stead.
I'm not a huge fan of parsing json this way, since server name is used as a key, and there are two almost identical format, this seemed like an acceptable tradeoff.