### PR TITLE
don't use trim on progress streams in AnsiProgressHandler

### DIFF
--- a/src/main/java/com/spotify/docker/client/AnsiProgressHandler.java
+++ b/src/main/java/com/spotify/docker/client/AnsiProgressHandler.java
@@ -59,7 +59,7 @@ public class AnsiProgressHandler implements ProgressHandler {
     String value = message.stream();
     if (value != null) {
       // trim trailing new lines which are present in streams
-      value = value.trim();
+      value = value.replaceFirst("\n$", "");
     } else {
       value = message.status();
     }
@@ -114,4 +114,3 @@ public class AnsiProgressHandler implements ProgressHandler {
   }
 
 }
-


### PR DESCRIPTION
Trim deletes ANSI escape codes in the stream messages, so you end up
with everything after the escape code and then the message (sans color
or whatever else the escape code was trying to do).

Now the code explicitly just deletes any '\n' chars at the end of the
string as the comment claims it should be doing.