### PR TITLE
Relocate ASM and JNR classes in shaded JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,10 @@
               <pattern>org.ow2.asm</pattern>
               <shadedPattern>com.spotify.docker.client.shaded.org.ow2.asm</shadedPattern>
             </relocation>
+            <relocation>
+              <pattern>com.github.jnr</pattern>
+              <shadedPattern>com.spotify.docker.client.shaded.com.github.jnr</shadedPattern>
+            </relocation>
           </relocations>
           <shadedArtifactAttached>true</shadedArtifactAttached>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -319,8 +319,8 @@
               <shadedPattern>com.spotify.docker.client.shaded.com.fasterxml.jackson</shadedPattern>
             </relocation>
             <relocation>
-              <pattern>org.ow2.asm</pattern>
-              <shadedPattern>com.spotify.docker.client.shaded.org.ow2.asm</shadedPattern>
+              <pattern>org.objectweb.asm</pattern>
+              <shadedPattern>com.spotify.docker.client.shaded.org.objectweb.asm</shadedPattern>
             </relocation>
             <relocation>
               <pattern>jnr</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -323,8 +323,8 @@
               <shadedPattern>com.spotify.docker.client.shaded.org.ow2.asm</shadedPattern>
             </relocation>
             <relocation>
-              <pattern>com.github.jnr</pattern>
-              <shadedPattern>com.spotify.docker.client.shaded.com.github.jnr</shadedPattern>
+              <pattern>jnr</pattern>
+              <shadedPattern>com.spotify.docker.client.shaded.jnr</shadedPattern>
             </relocation>
           </relocations>
           <shadedArtifactAttached>true</shadedArtifactAttached>

--- a/pom.xml
+++ b/pom.xml
@@ -318,6 +318,10 @@
               <pattern>com.fasterxml.jackson</pattern>
               <shadedPattern>com.spotify.docker.client.shaded.com.fasterxml.jackson</shadedPattern>
             </relocation>
+            <relocation>
+              <pattern>org.ow2.asm</pattern>
+              <shadedPattern>com.spotify.docker.client.shaded.org.ow2.asm</shadedPattern>
+            </relocation>
           </relocations>
           <shadedArtifactAttached>true</shadedArtifactAttached>
         </configuration>


### PR DESCRIPTION
The goal of this patch is to relocate the ASM and JNR classes that are included in the shaded JAR.

This change is motivated by a dependency conflict issue that I ran into while trying to use `docker-client` in Apache Spark's tests. There's a longer writeup at https://github.com/apache/spark/pull/9503#issuecomment-154369560 which describes our dependency conflict issues, but the TL;DR of it is that we are stuck running Jersey 1.9, which depends on ASM 3, and this causes conflicts with the ASM 5 that JNR uses.

Specifically:
- [jersey-server 1.9](http://mvnrepository.com/artifact/com.sun.jersey/jersey-server/1.9) depends on [asm.asm 3.1](http://mvnrepository.com/artifact/asm/asm/3.1), which exposes its classes under the `org.objectweb.asm` namespace.
- [docker-client 3.2.1](http://mvnrepository.com/artifact/com.spotify/docker-client/3.2.1) transitively depends on [jnr-ffi 2.0.3](http://mvnrepository.com/artifact/com.github.jnr/jnr-ffi/2.0.3), which depends on [org.ow2.asm.asm 5.0.3](http://mvnrepository.com/artifact/org.ow2.asm/asm/5.0.3). This version of ASM also contains classes under the `org.objectweb.asm` namespace, producing a binary incompatibility conflict which Maven doesn't detect.

Given that the primary motivation for having a shaded artifact seems to be avoiding conflicts with old versions of Jersey, I think that the best solution here is to relocate the ASM and JNR classes in `docker-client`'s shaded JAR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spotify/docker-client/272)
<!-- Reviewable:end -->
