### PR TITLE
Use JaCoCo Codecov.io for displaying coverage metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Docker Client [![Circle CI](https://circleci.com/gh/spotify/docker-client.png?style=badge)](https://circleci.com/gh/spotify/docker-client)
+# Docker Client [![Circle CI](https://circleci.com/gh/spotify/docker-client.png?style=badge)](https://circleci.com/gh/spotify/docker-client) [![codecov.io](https://codecov.io/github/spotify/docker-client/coverage.svg?branch=master)](https://codecov.io/github/spotify/docker-client?branch=master)
 
 
 This is a simple [Docker](https://github.com/dotcloud/docker) client written in Java.

--- a/circle.sh
+++ b/circle.sh
@@ -29,6 +29,8 @@ case "$1" in
 
     docker pull registry
 
+    pip install --user codecov
+
     ;;
 
   test)
@@ -74,6 +76,8 @@ case "$1" in
     docker logs registry &> $CIRCLE_ARTIFACTS/registry.log
 
     cp target/surefire-reports/*.xml $CI_REPORTS
+
+    codecov
 
     ;;
 

--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,26 @@
           <autoReleaseAfterClose>${autoReleaseAfterClose}</autoReleaseAfterClose>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.7.5.201505241946</version>
+        <executions>
+          <execution>
+            <id>jacoco-initialize</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>jacoco-site</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
This patch modifies the build and test configurations to collect test coverage metrics using JaCoCo and to display those reports using [Codecov.io](https://codecov.io).