### PR TITLE
testAttachContainer: add sleep to avoid hanging

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.SettableFuture;
+
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.spotify.docker.client.DockerClient.AttachParameter;
 import com.spotify.docker.client.messages.AuthConfig;
@@ -1379,7 +1380,9 @@ public class DefaultDockerClientTest {
     final ContainerConfig volumeConfig = ContainerConfig.builder()
         .image(BUSYBOX_LATEST)
         .volumes("/foo")
-        .cmd("ls", "-la")
+        // TODO (mbrown): remove sleep - added to make sure container is still alive when attaching
+        //.cmd("ls", "-la")
+        .cmd("sh", "-c", "ls -la; sleep 3")
         .build();
     sut.createContainer(volumeConfig, volumeContainer);
     sut.startContainer(volumeContainer);


### PR DESCRIPTION
Seems like if the container is stopped, then attaching to it will hang
forever as there will be no more output.

Future TODO: docker-client should be smarter about attaching to a
stopped container.

Resolves #273