### PR TITLE
Add load/save support

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -20,9 +20,9 @@
 package com.spotify.docker.client;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.io.CharStreams;
 import com.google.common.net.HostAndPort;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -44,6 +44,7 @@ import com.spotify.docker.client.messages.ProgressMessage;
 import com.spotify.docker.client.messages.RemovedImage;
 import com.spotify.docker.client.messages.Version;
 
+import org.apache.commons.compress.utils.IOUtils;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
@@ -88,6 +89,7 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.ResponseProcessingException;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import static com.google.common.base.Optional.fromNullable;
@@ -110,6 +112,45 @@ import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
 
 public class DefaultDockerClient implements DockerClient, Closeable {
 
+  /**
+   * Hack: this {@link ProgressHandler} is meant to capture the image ID of an
+   * image being loaded. Weirdly enough, Docker returns the ID of a newly created image
+   * in the status of a progress message.
+   * <p>
+   * The image ID is required to tag the just loaded image since, also weirdly enough,
+   * the pull operation with the <code>fromSrc</code> parameter does not support the 
+   * <code>tag</code> parameter. By retrieving the ID, the image can be tagged with its 
+   * image name, given its ID.
+   */
+  private static class LoadProgressHandler implements ProgressHandler {
+    
+    private static final int EXPECTED_CHARACTER_NUM = 64;
+    
+    private final ProgressHandler delegate;
+    
+    private String imageId;
+    
+    private LoadProgressHandler(ProgressHandler delegate) {
+      this.delegate = delegate;
+    }
+    
+    private String getImageId() {
+      Preconditions.checkState(imageId != null, "Could not acquire image ID following load");
+      return imageId;
+    }
+    
+    @Override
+    public void progress(ProgressMessage message) throws DockerException {
+      delegate.progress(message);
+      if (message.status() != null && message.status().length() == EXPECTED_CHARACTER_NUM) {
+        imageId = message.status();
+      }
+    }
+    
+  }
+  
+  // ==========================================================================
+  
   public static final String DEFAULT_UNIX_ENDPOINT = "unix:///var/run/docker.sock";
   public static final String DEFAULT_HOST = "localhost";
   public static final int DEFAULT_PORT = 2375;
@@ -641,7 +682,73 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     return request(GET, IMAGES_SEARCH_RESULT_LIST, resource,
         resource.request(APPLICATION_JSON_TYPE));
   }
+  
+  @Override
+  public void load(final String image, final InputStream imagePayload)
+                   throws DockerException, InterruptedException {
+    load(image, imagePayload, new LoggingPullHandler("image stream"));
+  }
+  
+  @Override
+  public void load(final String image, final InputStream imagePayload,
+                   final AuthConfig authConfig, final ProgressHandler handler) 
+                   throws DockerException, InterruptedException {
+    load(image, imagePayload, handler);
+  }
+  
+  @Override
+  public void load(final String image, final InputStream imagePayload, 
+                   final AuthConfig authConfig) 
+                   throws DockerException, InterruptedException {
+    load(image, imagePayload, authConfig, new LoggingPullHandler("image stream"));
+  }
+  
+  @Override
+  public void load(final String image, final InputStream imagePayload, 
+                   final ProgressHandler handler) 
+                   throws DockerException, InterruptedException {
+  
+    WebTarget resource = resource().path("images").path("create");
 
+    resource = resource
+        .queryParam("fromSrc", "-")
+        .queryParam("tag", image);
+    
+    LoadProgressHandler loadProgressHandler = new LoadProgressHandler(handler);
+    Entity<InputStream> entity = Entity.entity(imagePayload, MediaType.APPLICATION_OCTET_STREAM);
+    try (ProgressStream load =
+             request(POST, ProgressStream.class, resource,
+                     resource
+                         .request(APPLICATION_JSON_TYPE)
+                         .header("X-Registry-Auth", authHeader(authConfig)), entity)) {
+      load.tail(loadProgressHandler, POST, resource.getUri());
+      tag(loadProgressHandler.getImageId(), image, true);
+    } catch (IOException e) {
+      throw new DockerException(e);
+    } finally {
+      IOUtils.closeQuietly(imagePayload);
+    }
+  }
+  
+  @Override
+  public InputStream save(final String image) 
+      throws DockerException, IOException, InterruptedException {
+    return save(image, authConfig);
+  }
+  
+  @Override
+  public InputStream save(final String image, final AuthConfig authConfig) 
+      throws DockerException, IOException, InterruptedException {
+    WebTarget resource = resource().path("images").path(image).path("get");
+    
+    return request(
+        GET, 
+        InputStream.class, 
+        resource,
+        resource.request(APPLICATION_JSON_TYPE).header("X-Registry-Auth", authHeader(authConfig))
+    );
+  }
+  
   @Override
   public void pull(final String image) throws DockerException, InterruptedException {
     pull(image, new LoggingPullHandler(image));
@@ -823,7 +930,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       return imageId;
     }
   }
-
+  
   @Override
   public ImageInfo inspectImage(final String image) throws DockerException, InterruptedException {
     try {
@@ -1060,7 +1167,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       throw propagate(method, resource, e);
     }
   }
-
+  
   private <T> T request(final String method, final Class<T> clazz,
                         final WebTarget resource, final Invocation.Builder request,
                         final Entity<?> entity)

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -181,6 +181,89 @@ public interface DockerClient extends Closeable {
    */
   List<ImageSearchResult> searchImages(String term) throws DockerException, InterruptedException;
 
+  
+  /**
+   * Loads an image (the given input stream is closed internally). This method also tags the 
+   * image with the given image name upon loading completion.
+   *  
+   * @param image the name to assign to the image.
+   * @param imagePayload the image's payload 
+   *        (i.e.: the stream corresponding to the image's .tar file).
+   * @throws DockerException if a server error occurred (500).
+   * @throws InterruptedException if the thread is interrupted.
+   */
+  void load(String image, InputStream imagePayload) 
+      throws DockerException, InterruptedException;
+  
+  
+  /**
+   * Loads an image (the given input stream is closed internally). This method also tags the 
+   * image with the given image name upon loading completion.
+   * 
+   * @param image the name to assign to the image.
+   * @param imagePayload the image's payload 
+   *        (i.e.: the stream corresponding to the image's .tar file).
+   * @param handler The handler to use for processing each progress message received from Docker.
+   * @throws DockerException if a server error occurred (500).
+   * @throws InterruptedException if the thread is interrupted.
+   */
+  void load(String image, InputStream imagePayload, ProgressHandler handler) 
+      throws DockerException, InterruptedException;
+  
+  
+  /**
+   * Loads an image (the given input stream is closed internally). This method also tags the 
+   * image with the given image name upon loading completion.
+   *  
+   * @param image the name to assign to the image.
+   * @param imagePayload the image's payload 
+   *        (i.e.: the stream corresponding to the image's .tar file).
+   * @param authConfig The authentication config needed to pull the image.
+   * @throws DockerException if a server error occurred (500).
+   * @throws InterruptedException if the thread is interrupted.
+   */
+  void load(String image, InputStream imagePayload, AuthConfig authConfig) 
+      throws DockerException, InterruptedException;
+  
+  
+  /**
+   * Loads an image (the given input stream is closed internally). This method also tags the 
+   * image with the given image name upon loading completion.
+   *  
+   * @param image the name to assign to the image.
+   * @param imagePayload the image's payload 
+   *        (i.e.: the stream corresponding to the image's .tar file).
+   * @param authConfig The authentication config needed to pull the image.
+   * @param handler The handler to use for processing each progress message received from Docker.
+   * @throws DockerException if a server error occurred (500).
+   * @throws InterruptedException if the thread is interrupted.
+   */
+  void load(String image, InputStream imagePayload, AuthConfig authConfig, 
+            ProgressHandler handler) throws DockerException, InterruptedException;
+
+  
+  /**
+   * @param image the name of the image to save.
+   * @return the image's .tar stream.
+   * @throws DockerException if a server error occurred (500).
+   * @throws IOException if the server started returning, but an I/O error occurred 
+   *                     in the context of processing it on the client-side.
+   * @throws InterruptedException if the thread is interrupted.
+   */
+  InputStream save(String image) throws DockerException, IOException, InterruptedException;
+
+  /**
+   * @param image the name of the image to save.
+   * @param authConfig The authentication config needed to pull the image.
+   * @return the image's .tar stream.
+   * @throws DockerException if a server error occurred (500).
+   * @throws IOException if the server started returning, but an I/O error occurred 
+   *                     in the context of processing it on the client-side.
+   * @throws InterruptedException if the thread is interrupted.
+   */
+  InputStream save(String image, AuthConfig authConfig) 
+      throws DockerException, IOException, InterruptedException;
+  
   /**
    * Pull a docker container image.
    *


### PR DESCRIPTION
* DockerClient.load allows loading the tarball of an image as a stream. An
image name must be passed in, and the load implementation internally
tags the just loaded image with the provided name. The load
implementation is passed on Docker API's pull, which takes a fromSrc
parameter, indicating it to treat the request's body as the .tar payload
of the image.

* DockerClient.save allows pulling the .tar stream of an image (and saving
it locally or whatever).