### PR TITLE
Add RANDOM_AVAILABLE_PORT for convenience/clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ for (String port : ports) {
     hostPorts.add(PortBinding.of("0.0.0.0", port));
     portBindings.put(port, hostPorts);
 }
+
+// Bind container port 443 to an automatically allocated available host port.
+List<PortBinding> randomPort = new ArrayList<PortBinding>();
+randomPort.add(PortBinding.of("0.0.0.0", PortBinding.RANDOM_AVAILABLE_PORT);
+portBindings.put("443", randomPort);
+
 final HostConfig hostConfig = HostConfig.builder().portBindings(portBindings).build();
 
 // Create container with exposed ports

--- a/src/main/java/com/spotify/docker/client/messages/PortBinding.java
+++ b/src/main/java/com/spotify/docker/client/messages/PortBinding.java
@@ -28,6 +28,8 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 public class PortBinding {
 
+  public static final String RANDOM_AVAILABLE_PORT = "";
+
   @JsonProperty("HostIp") private String hostIp;
   @JsonProperty("HostPort") private String hostPort;
 


### PR DESCRIPTION
The API to bind a random available port (as opposed to an explict one) is currently like `PortBinding.of("0.0.0.0", "")`, where the empty string (or int 0) will result in Docker picking a port.

This allows API callers to get the same effect in a more readable fashion using `PortBinding.of("0.0.0.0", PortBinding.RANDOM_AVAILABLE_PORT)`.