### PR TITLE
added try/catch on ObjectMapperProvider

### DIFF
--- a/src/main/java/com/spotify/docker/client/ObjectMapperProvider.java
+++ b/src/main/java/com/spotify/docker/client/ObjectMapperProvider.java
@@ -42,9 +42,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 @Provider
 @Produces(MediaType.APPLICATION_JSON)
 public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
+    
+  private static final Logger log = LoggerFactory.getLogger(ObjectMapperProvider.class);
 
   private static final Function<? super Object, ?> VOID_VALUE =
       new Function<Object, Object>() {
@@ -58,15 +63,20 @@ public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   static {
-    MODULE.addSerializer(Set.class, new SetSerializer());
-    MODULE.addDeserializer(Set.class, new SetDeserializer());
-    MODULE.addSerializer(ImmutableSet.class, new ImmutableSetSerializer());
-    MODULE.addDeserializer(ImmutableSet.class, new ImmutableSetDeserializer());
-    OBJECT_MAPPER.registerModule(new GuavaModule());
-    OBJECT_MAPPER.registerModule(MODULE);
-    OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-    OBJECT_MAPPER.setDateFormat(new DockerDateFormat());
+      try {
+      MODULE.addSerializer(Set.class, new SetSerializer());
+      MODULE.addDeserializer(Set.class, new SetDeserializer());
+      MODULE.addSerializer(ImmutableSet.class, new ImmutableSetSerializer());
+      MODULE.addDeserializer(ImmutableSet.class, new ImmutableSetDeserializer());
+      OBJECT_MAPPER.registerModule(new GuavaModule());
+      OBJECT_MAPPER.registerModule(MODULE);
+      OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+      OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+      OBJECT_MAPPER.setDateFormat(new DockerDateFormat());
+      } catch (Throwable t) {
+          log.error("Failure during static initialization", t);
+          throw t;
+        }
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/ObjectMapperProvider.java
+++ b/src/main/java/com/spotify/docker/client/ObjectMapperProvider.java
@@ -1,16 +1,20 @@
 /*
  * Copyright (c) 2014 Spotify AB.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 
 package com.spotify.docker.client;
 
@@ -46,79 +50,81 @@ import org.slf4j.LoggerFactory;
 @Produces(MediaType.APPLICATION_JSON)
 public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
 
-    private static final Logger log = LoggerFactory.getLogger(ObjectMapperProvider.class);
+  private static final Logger log = LoggerFactory.getLogger(ObjectMapperProvider.class);
 
-    private static final Function<? super Object, ?> VOID_VALUE = new Function<Object, Object>() {
-        @Override
-        public Object apply(final Object input) {
-            return null;
-        }
-    };
-
-    private static final SimpleModule MODULE = new SimpleModule();
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-    static {
-        try {
-            MODULE.addSerializer(Set.class, new SetSerializer());
-            MODULE.addDeserializer(Set.class, new SetDeserializer());
-            MODULE.addSerializer(ImmutableSet.class, new ImmutableSetSerializer());
-            MODULE.addDeserializer(ImmutableSet.class, new ImmutableSetDeserializer());
-            OBJECT_MAPPER.registerModule(new GuavaModule());
-            OBJECT_MAPPER.registerModule(MODULE);
-            OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-            OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-            OBJECT_MAPPER.setDateFormat(new DockerDateFormat());
-        } catch (Throwable t) {
-            log.error("Failure during static initialization", t);
-            throw t;
-        }
+  private static final Function<? super Object, ?> VOID_VALUE = new Function<Object, Object>() {
+    @Override
+    public Object apply(final Object input) {
+      return null;
     }
+  };
+
+  private static final SimpleModule MODULE = new SimpleModule();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  static {
+    try {
+      MODULE.addSerializer(Set.class, new SetSerializer());
+      MODULE.addDeserializer(Set.class, new SetDeserializer());
+      MODULE.addSerializer(ImmutableSet.class, new ImmutableSetSerializer());
+      MODULE.addDeserializer(ImmutableSet.class, new ImmutableSetDeserializer());
+      OBJECT_MAPPER.registerModule(new GuavaModule());
+      OBJECT_MAPPER.registerModule(MODULE);
+      OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+      OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+      OBJECT_MAPPER.setDateFormat(new DockerDateFormat());
+    } catch (Throwable t) {
+      log.error("Failure during static initialization", t);
+      throw t;
+    }
+  }
+
+  @Override
+  public ObjectMapper getContext(Class<?> type) {
+    return OBJECT_MAPPER;
+  }
+
+  static ObjectMapper objectMapper() {
+    return OBJECT_MAPPER;
+  }
+
+  private static class SetSerializer extends JsonSerializer<Set> {
 
     @Override
-    public ObjectMapper getContext(Class<?> type) {
-        return OBJECT_MAPPER;
+    public void serialize(final Set value, final JsonGenerator jgen,
+        final SerializerProvider provider) throws IOException {
+      final Map map = (value == null) ? null : Maps.asMap(value, VOID_VALUE);
+      OBJECT_MAPPER.writeValue(jgen, map);
     }
+  }
 
-    static ObjectMapper objectMapper() {
-        return OBJECT_MAPPER;
+  private static class SetDeserializer extends JsonDeserializer<Set> {
+
+    @Override
+    public Set<?> deserialize(final JsonParser jp, final DeserializationContext ctxt)
+        throws IOException {
+      final Map map = OBJECT_MAPPER.readValue(jp, Map.class);
+      return (map == null) ? null : map.keySet();
     }
+  }
 
-    private static class SetSerializer extends JsonSerializer<Set> {
+  private static class ImmutableSetSerializer extends JsonSerializer<ImmutableSet> {
 
-        @Override
-        public void serialize(final Set value, final JsonGenerator jgen, final SerializerProvider provider)
-                throws IOException {
-            final Map map = (value == null) ? null : Maps.asMap(value, VOID_VALUE);
-            OBJECT_MAPPER.writeValue(jgen, map);
-        }
+    @Override
+    public void serialize(final ImmutableSet value, final JsonGenerator jgen,
+        final SerializerProvider provider) throws IOException {
+      final Map map = (value == null) ? null : Maps.asMap(value, VOID_VALUE);
+      OBJECT_MAPPER.writeValue(jgen, map);
     }
+  }
 
-    private static class SetDeserializer extends JsonDeserializer<Set> {
+  private static class ImmutableSetDeserializer extends JsonDeserializer<ImmutableSet> {
 
-        @Override
-        public Set<?> deserialize(final JsonParser jp, final DeserializationContext ctxt) throws IOException {
-            final Map map = OBJECT_MAPPER.readValue(jp, Map.class);
-            return (map == null) ? null : map.keySet();
-        }
+    @Override
+    public ImmutableSet<?> deserialize(final JsonParser jp, final DeserializationContext ctxt)
+        throws IOException {
+      final Map map = OBJECT_MAPPER.readValue(jp, Map.class);
+      return (map == null) ? null : ImmutableSet.copyOf(map.keySet());
     }
-
-    private static class ImmutableSetSerializer extends JsonSerializer<ImmutableSet> {
-
-        @Override
-        public void serialize(final ImmutableSet value, final JsonGenerator jgen, final SerializerProvider provider)
-                throws IOException {
-            final Map map = (value == null) ? null : Maps.asMap(value, VOID_VALUE);
-            OBJECT_MAPPER.writeValue(jgen, map);
-        }
-    }
-
-    private static class ImmutableSetDeserializer extends JsonDeserializer<ImmutableSet> {
-
-        @Override
-        public ImmutableSet<?> deserialize(final JsonParser jp, final DeserializationContext ctxt) throws IOException {
-            final Map map = OBJECT_MAPPER.readValue(jp, Map.class);
-            return (map == null) ? null : ImmutableSet.copyOf(map.keySet());
-        }
-    }
+  }
 }

--- a/src/main/java/com/spotify/docker/client/ObjectMapperProvider.java
+++ b/src/main/java/com/spotify/docker/client/ObjectMapperProvider.java
@@ -1,18 +1,15 @@
 /*
  * Copyright (c) 2014 Spotify AB.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.spotify.docker.client;
@@ -48,85 +45,80 @@ import org.slf4j.LoggerFactory;
 @Provider
 @Produces(MediaType.APPLICATION_JSON)
 public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
-    
-  private static final Logger log = LoggerFactory.getLogger(ObjectMapperProvider.class);
 
-  private static final Function<? super Object, ?> VOID_VALUE =
-      new Function<Object, Object>() {
+    private static final Logger log = LoggerFactory.getLogger(ObjectMapperProvider.class);
+
+    private static final Function<? super Object, ?> VOID_VALUE = new Function<Object, Object>() {
         @Override
         public Object apply(final Object input) {
-          return null;
+            return null;
         }
-      };
+    };
 
-  private static final SimpleModule MODULE = new SimpleModule();
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final SimpleModule MODULE = new SimpleModule();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-  static {
-      try {
-      MODULE.addSerializer(Set.class, new SetSerializer());
-      MODULE.addDeserializer(Set.class, new SetDeserializer());
-      MODULE.addSerializer(ImmutableSet.class, new ImmutableSetSerializer());
-      MODULE.addDeserializer(ImmutableSet.class, new ImmutableSetDeserializer());
-      OBJECT_MAPPER.registerModule(new GuavaModule());
-      OBJECT_MAPPER.registerModule(MODULE);
-      OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-      OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-      OBJECT_MAPPER.setDateFormat(new DockerDateFormat());
-      } catch (Throwable t) {
-          log.error("Failure during static initialization", t);
-          throw t;
+    static {
+        try {
+            MODULE.addSerializer(Set.class, new SetSerializer());
+            MODULE.addDeserializer(Set.class, new SetDeserializer());
+            MODULE.addSerializer(ImmutableSet.class, new ImmutableSetSerializer());
+            MODULE.addDeserializer(ImmutableSet.class, new ImmutableSetDeserializer());
+            OBJECT_MAPPER.registerModule(new GuavaModule());
+            OBJECT_MAPPER.registerModule(MODULE);
+            OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+            OBJECT_MAPPER.setDateFormat(new DockerDateFormat());
+        } catch (Throwable t) {
+            log.error("Failure during static initialization", t);
+            throw t;
         }
-  }
-
-  @Override
-  public ObjectMapper getContext(Class<?> type) {
-    return OBJECT_MAPPER;
-  }
-
-  static ObjectMapper objectMapper() {
-    return OBJECT_MAPPER;
-  }
-
-  private static class SetSerializer extends JsonSerializer<Set> {
+    }
 
     @Override
-    public void serialize(final Set value, final JsonGenerator jgen,
-                          final SerializerProvider provider)
-        throws IOException {
-      final Map map = (value == null) ? null : Maps.asMap(value, VOID_VALUE);
-      OBJECT_MAPPER.writeValue(jgen, map);
+    public ObjectMapper getContext(Class<?> type) {
+        return OBJECT_MAPPER;
     }
-  }
 
-  private static class SetDeserializer extends JsonDeserializer<Set> {
-
-    @Override
-    public Set<?> deserialize(final JsonParser jp, final DeserializationContext ctxt)
-        throws IOException {
-      final Map map = OBJECT_MAPPER.readValue(jp, Map.class);
-      return (map == null) ? null : map.keySet();
+    static ObjectMapper objectMapper() {
+        return OBJECT_MAPPER;
     }
-  }
 
-  private static class ImmutableSetSerializer extends JsonSerializer<ImmutableSet> {
+    private static class SetSerializer extends JsonSerializer<Set> {
 
-    @Override
-    public void serialize(final ImmutableSet value, final JsonGenerator jgen,
-                          final SerializerProvider provider)
-        throws IOException {
-      final Map map = (value == null) ? null : Maps.asMap(value, VOID_VALUE);
-      OBJECT_MAPPER.writeValue(jgen, map);
+        @Override
+        public void serialize(final Set value, final JsonGenerator jgen, final SerializerProvider provider)
+                throws IOException {
+            final Map map = (value == null) ? null : Maps.asMap(value, VOID_VALUE);
+            OBJECT_MAPPER.writeValue(jgen, map);
+        }
     }
-  }
 
-  private static class ImmutableSetDeserializer extends JsonDeserializer<ImmutableSet> {
+    private static class SetDeserializer extends JsonDeserializer<Set> {
 
-    @Override
-    public ImmutableSet<?> deserialize(final JsonParser jp, final DeserializationContext ctxt)
-        throws IOException {
-      final Map map = OBJECT_MAPPER.readValue(jp, Map.class);
-      return (map == null) ? null : ImmutableSet.copyOf(map.keySet());
+        @Override
+        public Set<?> deserialize(final JsonParser jp, final DeserializationContext ctxt) throws IOException {
+            final Map map = OBJECT_MAPPER.readValue(jp, Map.class);
+            return (map == null) ? null : map.keySet();
+        }
     }
-  }
+
+    private static class ImmutableSetSerializer extends JsonSerializer<ImmutableSet> {
+
+        @Override
+        public void serialize(final ImmutableSet value, final JsonGenerator jgen, final SerializerProvider provider)
+                throws IOException {
+            final Map map = (value == null) ? null : Maps.asMap(value, VOID_VALUE);
+            OBJECT_MAPPER.writeValue(jgen, map);
+        }
+    }
+
+    private static class ImmutableSetDeserializer extends JsonDeserializer<ImmutableSet> {
+
+        @Override
+        public ImmutableSet<?> deserialize(final JsonParser jp, final DeserializationContext ctxt) throws IOException {
+            final Map map = OBJECT_MAPPER.readValue(jp, Map.class);
+            return (map == null) ? null : ImmutableSet.copyOf(map.keySet());
+        }
+    }
 }


### PR DESCRIPTION
Should a dependency conflict happens, no information can be extracted from ObjectMapperProvider.java due to the static block. Suggest adding a try/catch and log block to be able to find out what is causing exceptions.

Following the information on:
http://stackoverflow.com/questions/7325579/java-lang-noclassdeffounderror-could-not-initialize-class-xxx.