### PR TITLE
Updated ContainerConfig for API 1.21 and added imageid to Container

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/Container.java
+++ b/src/main/java/com/spotify/docker/client/messages/Container.java
@@ -35,13 +35,14 @@ public class Container {
   @JsonProperty("Id") private String id;
   @JsonProperty("Names") private ImmutableList<String> names;
   @JsonProperty("Image") private String image;
+  @JsonProperty("ImageID") private String imageId;
   @JsonProperty("Command") private String command;
   @JsonProperty("Created") private Long created;
   @JsonProperty("Status") private String status;
   @JsonProperty("Ports") private ImmutableList<PortMapping> ports;
   @JsonProperty("Labels") private ImmutableMap<String, String> labels;
   @JsonProperty("SizeRw") private Long sizeRw;
-  @JsonProperty("SizeRootFs") private Long sizeRootFs;
+  @JsonProperty("SizeRootFs") private Long sizeRootFs;  
 
   /**
    * This method returns port information the way that <code>docker ps</code> does:
@@ -115,6 +116,10 @@ public class Container {
   public Long sizeRootFs() {
     return sizeRootFs;
   }
+  
+  public String imageId() {
+    return imageId;
+  }
 
   @Override
   public boolean equals(final Object o) {
@@ -158,6 +163,9 @@ public class Container {
     if (status != null ? !status.equals(container.status) : container.status != null) {
       return false;
     }
+    if (imageId != null ? !imageId.equals(container.imageId) : container.imageId != null) {
+      return false;
+    }
 
     return true;
   }
@@ -174,6 +182,7 @@ public class Container {
     result = 31 * result + (labels != null ? labels.hashCode() : 0);
     result = 31 * result + (sizeRw != null ? sizeRw.hashCode() : 0);
     result = 31 * result + (sizeRootFs != null ? sizeRootFs.hashCode() : 0);
+    result = 31 * result + (imageId != null ? imageId.hashCode() : 0);
     return result;
   }
 
@@ -189,6 +198,7 @@ public class Container {
         .add("labels", labels)
         .add("sizeRw", sizeRw)
         .add("sizeRootFs", sizeRootFs)
+        .add("imageId", imageId)
         .toString();
   }
 

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -57,6 +57,7 @@ public class ContainerConfig {
   @JsonProperty("Labels") private ImmutableMap<String, String> labels;
   @JsonProperty("MacAddress") private String macAddress;
   @JsonProperty("HostConfig") private HostConfig hostConfig;
+  @JsonProperty("StopSignal") private String stopSignal;
 
 
   private ContainerConfig() {
@@ -85,6 +86,7 @@ public class ContainerConfig {
     this.labels = builder.labels;
     this.macAddress = builder.macAddress;
     this.hostConfig = builder.hostConfig;
+    this.stopSignal = builder.stopSignal;
   }
 
   public String hostname() {
@@ -260,6 +262,10 @@ public class ContainerConfig {
     if (hostConfig != null ? !hostConfig.equals(config.hostConfig) : config.hostConfig != null) {
       return false;
     }
+    
+    if (stopSignal != null ? !stopSignal.equals(config.stopSignal) : config.stopSignal != null) {
+      return false;
+    }
 
     return true;
   }
@@ -288,6 +294,7 @@ public class ContainerConfig {
     result = 31 * result + (labels != null ? labels.hashCode() : 0);
     result = 31 * result + (macAddress != null ? macAddress.hashCode() : 0);
     result = 31 * result + (hostConfig != null ? hostConfig.hashCode() : 0);
+    result = 31 * result + (stopSignal != null ? stopSignal.hashCode() : 0);
     return result;
   }
 
@@ -316,6 +323,7 @@ public class ContainerConfig {
         .add("labels", labels)
         .add("macAddress", macAddress)
         .add("hostConfig", hostConfig)
+        .add("stopSignal", stopSignal)
         .toString();
   }
 
@@ -356,6 +364,7 @@ public class ContainerConfig {
     private ImmutableMap<String, String> labels;
     private String macAddress;
     private HostConfig hostConfig;
+    private String stopSignal;
 
     private Builder() {
     }
@@ -383,6 +392,7 @@ public class ContainerConfig {
       this.labels = config.labels;
       this.macAddress = config.macAddress;
       this.hostConfig = config.hostConfig;
+      this.stopSignal = config.stopSignal;
     }
 
     public Builder hostname(final String hostname) {
@@ -707,9 +717,22 @@ public class ContainerConfig {
     public HostConfig hostConfig() {
       return hostConfig;
     }
+    
+    public Builder stopSignal(final String stopSignal) {
+      this.stopSignal = stopSignal;
+      return this;
+    }
+    
+    public String stopSignal() {
+      return stopSignal;
+    }
 
     public ContainerConfig build() {
       return new ContainerConfig(this);
     }
+  }
+
+  public String getStopSignal() {
+    return stopSignal;
   }
 }

--- a/src/main/java/com/spotify/docker/client/messages/ContainerInfo.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerInfo.java
@@ -54,6 +54,12 @@ public class ContainerInfo {
   @JsonProperty("MountLabel") private String mountLabel;
   @JsonProperty("Volumes") private ImmutableMap<String, String> volumes;
   @JsonProperty("VolumesRW") private ImmutableMap<String, Boolean> volumesRW;
+  @JsonProperty("AppArmorProfile") private String appArmorProfile;
+  @JsonProperty("ExecIDs") private ImmutableList<String> execId;
+  @JsonProperty("LogPath") private String logPath;
+  @JsonProperty("RestartCount") private Long restartCount;
+  @JsonProperty("Mounts") private ImmutableList<ContainerMount> mountsList;
+  
   /**
    * This field is an extension defined by the Docker Swarm API, therefore it will only
    * be populated when communicating with a Swarm cluster.
@@ -325,5 +331,25 @@ public class ContainerInfo {
               .add("name", name)
               .toString();
     }
+  }
+
+  public String appArmorProfile() {
+    return appArmorProfile;
+  }
+
+  public List<String> execId() {
+    return execId;
+  }
+
+  public String logPath() {
+    return logPath;
+  }
+
+  public Long restartCount() {
+    return restartCount;
+  }
+
+  public List<ContainerMount> mounts() {
+    return mountsList;
   }
 }

--- a/src/main/java/com/spotify/docker/client/messages/ContainerMount.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerMount.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client.messages;
+
+import com.google.common.base.MoreObjects;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class ContainerMount {
+
+  @JsonProperty("Source") private String source;
+  @JsonProperty("Destination") private String destination;
+  @JsonProperty("Mode") private String mode;
+  @JsonProperty("RW") private Boolean rwInfo;
+
+  public String getSource() {
+    return source;
+  }
+
+  public String getDestination() {
+    return destination;
+  }
+
+  public String getMode() {
+    return mode;
+  }
+
+  public Boolean getRwInfo() {
+    return rwInfo;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final ContainerMount that = (ContainerMount) o;
+
+    if (source != null ? !source.equals(that.source) : that.source != null) {
+      return false;
+    }
+    if (destination != null ? !destination.equals(that.destination) : that.destination != null) {
+      return false;
+    }
+    if (mode != null ? !mode.equals(that.mode) : that.mode != null) {
+      return false;
+    }
+    if (rwInfo != null ? !rwInfo.equals(that.rwInfo) : that.rwInfo != null) {
+      return false;
+    }
+    
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = source != null ? source.hashCode() : 0;
+    result = 31 * result + (destination != null ? destination.hashCode() : 0);
+    result = 31 * result + (mode != null ? mode.hashCode() : 0);
+    result = 31 * result + (rwInfo != null ? rwInfo.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("source", source)
+        .add("destination", destination)
+        .add("mode", mode)
+        .add("rw", rwInfo)
+        .toString();
+  }
+}


### PR DESCRIPTION
Added fields to container inspection in order to match Docker API 1.21
Added imageid to Container, in order to match the docker API 1.21

No removals. Should work properly with previous docker versions.

https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/