### PR TITLE
Networks information in inspectContainer

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
+++ b/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client.messages;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class AttachedNetwork {
+
+  @JsonProperty("EndpointID") private String endpointId;
+  @JsonProperty("Gateway") private String gateway;
+  @JsonProperty("IPAddress") private String ipAddress;
+  @JsonProperty("IPPrefixLen") private Integer ipPrefixLen;
+  @JsonProperty("IPv6Gateway") private String ipv6Gateway;
+  @JsonProperty("GlobalIPv6Address") private String globalIPv6Address;
+  @JsonProperty("GlobalIPv6PrefixLen") private Integer globalIPv6PrefixLen;
+  @JsonProperty("MacAddress") private String macAddress;
+
+  public String endpointId() {
+    return endpointId;
+  }
+
+  public String gateway() {
+    return gateway;
+  }
+
+  public String ipAddress() {
+    return ipAddress;
+  }
+
+  public Integer ipPrefixLen() {
+    return ipPrefixLen;
+  }
+
+  public String ipv6Gateway() {
+    return ipv6Gateway;
+  }
+
+  public String globalIPv6Address() {
+    return globalIPv6Address;
+  }
+
+  public Integer globalIPv6PrefixLen() {
+    return globalIPv6PrefixLen;
+  }
+
+  public String macAddress() {
+    return macAddress;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    AttachedNetwork that = (AttachedNetwork) o;
+
+    return Objects.equal(this.endpointId, that.endpointId) &&
+        Objects.equal(this.gateway, that.gateway) &&
+        Objects.equal(this.ipAddress, that.ipAddress) &&
+        Objects.equal(this.ipPrefixLen, that.ipPrefixLen) &&
+        Objects.equal(this.ipv6Gateway, that.ipv6Gateway) &&
+        Objects.equal(this.globalIPv6Address, that.globalIPv6Address) &&
+        Objects.equal(this.globalIPv6PrefixLen, that.globalIPv6PrefixLen) &&
+        Objects.equal(this.macAddress, that.macAddress);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(endpointId, gateway, ipAddress, ipPrefixLen, ipv6Gateway,
+        globalIPv6Address, globalIPv6PrefixLen, macAddress);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("endpointID", endpointId).add("gateway", gateway)
+        .add("ipAddress", ipAddress).add("ipPrefixLen", ipPrefixLen).add("ipv6Gateway", ipv6Gateway)
+        .add("globalIPv6Address", globalIPv6Address).add("globalIPv6PrefixLen", globalIPv6PrefixLen)
+        .add("macAddress", macAddress).toString();
+  }
+
+}

--- a/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
@@ -41,6 +41,7 @@ public class NetworkSettings {
   @JsonProperty("PortMapping") private ImmutableMap<String, Map<String, String>> portMapping;
   @JsonProperty("Ports") private Map<String, List<PortBinding>> ports;
   @JsonProperty("MacAddress") private String macAddress;
+  @JsonProperty("Networks") private ImmutableMap<String, AttachedNetwork> networks;
 
   private NetworkSettings(final Builder builder) {
     this.ipAddress = builder.ipAddress;
@@ -50,6 +51,7 @@ public class NetworkSettings {
     this.portMapping = builder.portMapping;
     this.ports = builder.ports;
     this.macAddress = builder.macAddress;
+    this.networks = builder.networks;
   }
 
   @SuppressWarnings("unused")
@@ -79,9 +81,13 @@ public class NetworkSettings {
   public Map<String, List<PortBinding>> ports() {
     return (ports == null) ? null : Collections.unmodifiableMap(ports);
   }
-  
+
   public String macAddress() {
     return macAddress;
+  }
+
+  public Map<String, AttachedNetwork> networks() {
+    return (networks == null) ? null : Collections.unmodifiableMap(networks);
   }
 
   @Override
@@ -116,6 +122,9 @@ public class NetworkSettings {
     if (macAddress != null ? !macAddress.equals(that.macAddress) : that.macAddress != null) {
       return false;
     }
+    if (networks != null ? !networks.equals(that.networks) : that.networks != null) {
+      return false;
+    }
 
     return true;
   }
@@ -129,6 +138,7 @@ public class NetworkSettings {
     result = 31 * result + (portMapping != null ? portMapping.hashCode() : 0);
     result = 31 * result + (ports != null ? ports.hashCode() : 0);
     result = 31 * result + (macAddress != null ? macAddress.hashCode() : 0);
+    result = 31 * result + (networks != null ? networks.hashCode() : 0);
     return result;
   }
 
@@ -142,6 +152,7 @@ public class NetworkSettings {
         .add("portMapping", portMapping)
         .add("ports", ports)
         .add("macAddress", macAddress)
+        .add("networks", networks)
         .toString();
   }
 
@@ -162,6 +173,7 @@ public class NetworkSettings {
     private ImmutableMap<String, Map<String, String>> portMapping;
     private Map<String, List<PortBinding>> ports;
     private String macAddress;
+    private ImmutableMap<String, AttachedNetwork> networks;
 
     private Builder() {
     }
@@ -174,6 +186,7 @@ public class NetworkSettings {
       this.portMapping = networkSettings.portMapping;
       this.ports = networkSettings.ports;
       this.macAddress = networkSettings.macAddress;
+      this.networks = networkSettings.networks;
     }
 
     public Builder ipAddress(final String ipAddress) {
@@ -212,6 +225,17 @@ public class NetworkSettings {
     
     public Builder macAddress(final String macAddress) {
       this.macAddress = macAddress;
+      return this;
+    }
+
+    public Builder networks(final Map<String, AttachedNetwork> networks) {
+      if (networks != null) {
+        final ImmutableMap.Builder<String, AttachedNetwork> builder = ImmutableMap.builder();
+        for (Map.Entry<String, AttachedNetwork> entry : networks.entrySet()) {
+          builder.put(entry.getKey(), entry.getValue());
+        }
+        this.networks = builder.build();
+      }
       return this;
     }
 

--- a/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
@@ -230,11 +230,7 @@ public class NetworkSettings {
 
     public Builder networks(final Map<String, AttachedNetwork> networks) {
       if (networks != null) {
-        final ImmutableMap.Builder<String, AttachedNetwork> builder = ImmutableMap.builder();
-        for (Map.Entry<String, AttachedNetwork> entry : networks.entrySet()) {
-          builder.put(entry.getKey(), entry.getValue());
-        }
-        this.networks = builder.build();
+        this.networks = ImmutableMap.copyOf(networks);
       }
       return this;
     }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -137,6 +137,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.instanceOf;
@@ -2119,6 +2120,9 @@ public class DefaultDockerClientTest {
     assertThat(attachedNetwork.ipAddress(), is(notNullValue()));
     assertThat(attachedNetwork.ipPrefixLen(), is(notNullValue()));
     assertThat(attachedNetwork.macAddress(), is(notNullValue()));
+    assertThat(attachedNetwork.ipv6Gateway(), is(notNullValue()));
+    assertThat(attachedNetwork.globalIPv6Address(), is(notNullValue()));
+    assertThat(attachedNetwork.globalIPv6PrefixLen(), greaterThanOrEqualTo(0));
 
     sut.disconnectFromNetwork(containerCreation.id(), networkCreation.id());
     network = sut.inspectNetwork(networkCreation.id());

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.spotify.docker.client.DockerClient.AttachParameter;
 import com.spotify.docker.client.DockerClient.BuildParam;
 import com.spotify.docker.client.DockerClient.ExecCreateParam;
+import com.spotify.docker.client.messages.AttachedNetwork;
 import com.spotify.docker.client.messages.AuthConfig;
 import com.spotify.docker.client.messages.Container;
 import com.spotify.docker.client.messages.ContainerConfig;
@@ -2107,6 +2108,17 @@ public class DefaultDockerClientTest {
     Network network = sut.inspectNetwork(networkCreation.id());
     assertThat(network.containers().size(), equalTo(1));
     assertThat(network.containers().get(containerCreation.id()), notNullValue());
+
+    final ContainerInfo containerInfo = sut.inspectContainer(containerCreation.id());
+    assertThat(containerInfo.networkSettings().networks().size(), is(2));
+    final AttachedNetwork attachedNetwork =
+        containerInfo.networkSettings().networks().get(networkName);
+    assertThat(attachedNetwork, is(notNullValue()));
+    assertThat(attachedNetwork.endpointId(), is(notNullValue()));
+    assertThat(attachedNetwork.gateway(), is(notNullValue()));
+    assertThat(attachedNetwork.ipAddress(), is(notNullValue()));
+    assertThat(attachedNetwork.ipPrefixLen(), is(notNullValue()));
+    assertThat(attachedNetwork.macAddress(), is(notNullValue()));
 
     sut.disconnectFromNetwork(containerCreation.id(), networkCreation.id());
     network = sut.inspectNetwork(networkCreation.id());


### PR DESCRIPTION
Returns information about networks associated to the container in _inspectContainer_ flow, as explained [here](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#inspect-a-container)
