### PR TITLE
Unit tests windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.spotify</groupId>
   <artifactId>docker-client</artifactId>
-  <version>3.4.1-SNAPSHOT</version>
+  <version>3.5.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>docker-client</name>
   <description>A docker client</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.spotify</groupId>
   <artifactId>docker-client</artifactId>
-  <version>3.5.0</version>
+  <version>3.5.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>docker-client</name>
   <description>A docker client</description>
@@ -33,7 +33,7 @@
     <connection>scm:git:https://github.com/spotify/docker-client</connection>
     <developerConnection>scm:git:git@github.com:spotify/docker-client</developerConnection>
     <url>https://github.com/spotify/docker-client</url>
-    <tag>v3.5.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.spotify</groupId>
   <artifactId>docker-client</artifactId>
-  <version>3.5.0-SNAPSHOT</version>
+  <version>3.5.0</version>
   <packaging>jar</packaging>
   <name>docker-client</name>
   <description>A docker client</description>
@@ -33,7 +33,7 @@
     <connection>scm:git:https://github.com/spotify/docker-client</connection>
     <developerConnection>scm:git:git@github.com:spotify/docker-client</developerConnection>
     <url>https://github.com/spotify/docker-client</url>
-    <tag>HEAD</tag>
+    <tag>v3.5.0</tag>
   </scm>
 
   <distributionManagement>

--- a/src/main/java/com/spotify/docker/client/CompressedDirectory.java
+++ b/src/main/java/com/spotify/docker/client/CompressedDirectory.java
@@ -19,7 +19,6 @@ package com.spotify.docker.client;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
-
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
@@ -138,7 +137,7 @@ class CompressedDirectory implements Closeable {
 
     if (Files.isReadable(dockerIgnorePath) && Files.isRegularFile(dockerIgnorePath)) {
       for (final String line : Files.readAllLines(dockerIgnorePath, StandardCharsets.UTF_8)) {
-        final String pattern = line.trim();
+        final String pattern = createPattern(line);
         if (pattern.isEmpty()) {
           log.debug("Will skip '{}' - cause it's empty after trimming", line);
           continue;
@@ -148,6 +147,17 @@ class CompressedDirectory implements Closeable {
     }
 
     return matchersBuilder.build();
+  }
+
+  private static String createPattern(String line) {
+
+    String pattern = line.trim();
+
+    if (OSUtils.isLinux()) {
+      return pattern;
+    }
+
+    return pattern.replace("/", "\\\\");
   }
 
   @VisibleForTesting

--- a/src/main/java/com/spotify/docker/client/OSUtils.java
+++ b/src/main/java/com/spotify/docker/client/OSUtils.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client;
+
+import java.io.File;
+
+public class OSUtils {
+    public static boolean isLinux() {
+        return File.separatorChar == '/';
+    }
+}

--- a/src/test/java/com/spotify/docker/client/DockerHostTest.java
+++ b/src/test/java/com/spotify/docker/client/DockerHostTest.java
@@ -23,10 +23,11 @@ import java.net.URI;
 
 import static com.google.common.base.Optional.fromNullable;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.spotify.docker.client.DockerHost.DEFAULT_PORT;
+import static com.spotify.docker.client.DockerHost.DEFAULT_HOST;
 import static com.spotify.docker.client.DockerHost.DEFAULT_UNIX_ENDPOINT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
 public class DockerHostTest {
 
@@ -75,7 +76,7 @@ public class DockerHostTest {
   @Test
   public void testFromEnv() throws Exception {
     final String dockerHostEnvVar =
-        fromNullable(System.getenv("DOCKER_HOST")).or(DEFAULT_UNIX_ENDPOINT);
+        fromNullable(System.getenv("DOCKER_HOST")).or(defaultEndpoint());
     final boolean isUnixSocket = dockerHostEnvVar.startsWith("unix://");
     final URI dockerHostUri = new URI(dockerHostEnvVar);
     final String dockerCertPathEnvVar = System.getenv("DOCKER_CERT_PATH");
@@ -110,4 +111,10 @@ public class DockerHostTest {
     assertThat(dockerHost.dockerCertPath(), equalTo(dockerCertPathEnvVar));
   }
 
+  private static String defaultEndpoint() {
+    if (OSUtils.isLinux()) {
+      return DEFAULT_UNIX_ENDPOINT;
+    }
+    return "http://" + DEFAULT_HOST + ":" + DEFAULT_PORT;
+  }
 }

--- a/src/test/java/com/spotify/docker/client/messages/AuthConfigTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/AuthConfigTest.java
@@ -18,13 +18,14 @@
 package com.spotify.docker.client.messages;
 
 import com.google.common.io.Resources;
-
+import com.spotify.docker.client.OSUtils;
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.FileNotFoundException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -142,6 +143,19 @@ public class AuthConfigTest {
   }
 
   private static Path getTestFilePath(final String path) {
+    if (OSUtils.isLinux()) {
+      return getLinuxPath(path);
+    } else {
+      return getWindowsPath(path);
+    }
+  }
+
+  private static Path getWindowsPath(final String path) {
+    URL resource = AuthConfigTest.class.getResource("/" + path);
+    return Paths.get(resource.getPath().substring(1));
+  }
+
+  private static Path getLinuxPath(final String path) {
     return Paths.get(Resources.getResource(path).getPath());
   }
 }


### PR DESCRIPTION
Fixing https://github.com/spotify/docker-client/issues/327

Includes:
1. CompressedDirectory ignore pattern needs to be os specific
2. DockerHostTest needs default env needs to be os specific
3. AuthConfigTest file paths needs to be os specific