### PR TITLE
Allow specifying LogConfig when creating a container

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/HostConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/HostConfig.java
@@ -53,6 +53,7 @@ public class HostConfig {
   @JsonProperty("CpuQuota") private Long cpuQuota;
   @JsonProperty("CgroupParent") private String cgroupParent;
   @JsonProperty("RestartPolicy") private RestartPolicy restartPolicy;
+  @JsonProperty("LogConfig") private LogConfig logConfig;
 
   private HostConfig() {
   }
@@ -78,6 +79,7 @@ public class HostConfig {
     this.cpuQuota = builder.cpuQuota;
     this.cgroupParent = builder.cgroupParent;
     this.restartPolicy = builder.restartPolicy;
+    this.logConfig = builder.logConfig;
   }
 
   public List<String> binds() {
@@ -158,6 +160,10 @@ public class HostConfig {
 
   public RestartPolicy restartPolicy() {
     return restartPolicy;
+  }
+
+  public LogConfig logConfig() {
+    return logConfig;
   }
 
   @Override
@@ -244,6 +250,10 @@ public class HostConfig {
       return false;
     }
 
+    if (logConfig != null ? !logConfig.equals(that.logConfig) : that.logConfig != null) {
+      return false;
+    }
+      
     return true;
   }
 
@@ -269,6 +279,7 @@ public class HostConfig {
     result = 31 * result + (cpuQuota != null ? cpuQuota.hashCode() : 0);
     result = 31 * result + (cgroupParent != null ? cgroupParent.hashCode() : 0);
     result = 31 * result + (restartPolicy != null ? restartPolicy.hashCode() : 0);
+    result = 31 * result + (logConfig != null ? logConfig.hashCode() : 0);
     return result;
   }
 
@@ -295,6 +306,7 @@ public class HostConfig {
         .add("cpuQuota", cpuQuota)
         .add("cgroupParent", cgroupParent)
         .add("restartPolicy", restartPolicy)
+        .add("logConfig", logConfig)
         .toString();
   }
 
@@ -450,6 +462,7 @@ public class HostConfig {
     public Long cpuQuota;
     public String cgroupParent;
     public RestartPolicy restartPolicy;
+    public LogConfig logConfig;
 
     private Builder() {
     }
@@ -475,6 +488,7 @@ public class HostConfig {
       this.cpuQuota = hostConfig.cpuQuota;
       this.cgroupParent = hostConfig.cgroupParent;
       this.restartPolicy = hostConfig.restartPolicy;
+      this.logConfig = hostConfig.logConfig;
     }
 
     public Builder binds(final List<String> binds) {
@@ -742,8 +756,17 @@ public class HostConfig {
       return this;
     }
 
+    public Builder logConfig(final LogConfig logConfig) {
+        this.logConfig = logConfig;
+        return this;
+    }
+
     public RestartPolicy restartPolicy() {
       return restartPolicy;
+    }
+
+    public LogConfig logConfig() {
+        return logConfig;
     }
 
     public HostConfig build() {

--- a/src/main/java/com/spotify/docker/client/messages/LogConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/LogConfig.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client.messages;
+
+import java.util.Collections;
+import java.util.List; 
+import java.util.Map; 
+
+import com.google.common.base.MoreObjects;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class LogConfig {
+
+  @JsonProperty("Type") private String logType;
+  @JsonProperty("Config") private Map<String, String> logOptions;
+
+  public String logType() {
+    return logType;
+  }
+
+  public void logType(final String logType) {
+    this.logType = logType;
+  }
+
+  public Map<String, String> logOptions() {
+    return (logOptions == null) ? null : Collections.unmodifiableMap(logOptions);
+  }
+
+  public void logOptions(final Map<String, String> logOptions) {
+    this.logOptions = logOptions;
+  }
+
+  public static LogConfig create(final String logType, final Map<String, String> logOptions) {
+    final LogConfig logConfig = new LogConfig();
+    logConfig.logType(logType);
+    logConfig.logOptions(logOptions);
+    return logConfig;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final LogConfig that = (LogConfig) o;
+
+    if (logType != null ? !logType.equals(that.logType) : that.logType != null) {
+      return false;
+    }
+    if (logOptions != null ? !logOptions.equals(that.logOptions) : that.logOptions != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = logType != null ? logType.hashCode() : 0;
+    result = 31 * result + (logOptions != null ? logOptions.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("Type", logType)
+        .add("Config", logOptions)
+        .toString();
+  }
+}

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -1551,14 +1551,14 @@ public class DefaultDockerClientTest {
         
       sut.pull(BUSYBOX_LATEST);
       final String name = randomName();
-        
+      
       final Map<String, String> logOptions = new HashMap<>();
-      logOptions.put("awslogs-region", "eu-west-1");
-      logOptions.put("awslogs-group", "ContainerLogs");
-      logOptions.put("awslogs-stream", name);
+      logOptions.put("max-size", "10k");
+      logOptions.put("max-file", "2");
+      logOptions.put("labels", name);
         
       final LogConfig logConfig = new LogConfig();
-      logConfig.logType("awslogs");
+      logConfig.logType("json-file");
       logConfig.logOptions(logOptions);
         
       final HostConfig expected = HostConfig.builder()

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -1545,9 +1545,9 @@ public class DefaultDockerClientTest {
   @Test
   public void testLogDriver() throws Exception {
         
-      assumeTrue("Docker API should be at least v1.18 to support Container Creation with " +
+      assumeTrue("Docker API should be at least v1.21 to support Container Creation with " +
                  "HostConfig LogConfig, got " + sut.version().apiVersion(),
-                 compareVersion(sut.version().apiVersion(), "1.18") >= 0);
+                 compareVersion(sut.version().apiVersion(), "1.21") >= 0);
         
       sut.pull(BUSYBOX_LATEST);
       final String name = randomName();
@@ -1556,7 +1556,7 @@ public class DefaultDockerClientTest {
       logOptions.put("max-size", "10k");
       logOptions.put("max-file", "2");
       logOptions.put("labels", name);
-        
+      
       final LogConfig logConfig = new LogConfig();
       logConfig.logType("json-file");
       logConfig.logOptions(logOptions);


### PR DESCRIPTION
See:
https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#create-a-container
https://docs.docker.com/engine/reference/logging/overview/