### PR TITLE
Make CircleCI collect test reports

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -83,6 +83,10 @@ case "$1" in
 
     codecov
 
+    mkdir -p $CIRCLE_TEST_REPORTS/junit/
+
+    find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+
     ;;
 
 esac


### PR DESCRIPTION
Show a summary of all test failures across all containers
Identify your slowest tests
According to
https://circleci.com/docs/test-metadata#java-junit-results-with-maven-surefire-plugin