### PR TITLE
Also close ApacheUnixSocket resources in case of exceptions

### DIFF
--- a/src/main/java/com/spotify/docker/client/ApacheUnixSocket.java
+++ b/src/main/java/com/spotify/docker/client/ApacheUnixSocket.java
@@ -270,9 +270,16 @@ public class ApacheUnixSocket extends Socket {
          sleeping = false;
       }
     }
-    shutdownInput();
-    shutdownOutput();
-    inner.close();
+
+    try {
+      shutdownInput();
+    } finally {
+      try {
+        shutdownOutput();
+      } finally {
+        inner.close();
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
When calling ApacheUnixSocket.close three resources are closed:
1. shutdownInput();
2. shutdownOutput();
3. inner.close();

But if e.g. the first throws an exception then the other two resources are not closed. Inner.close() will not close its socket file descriptors. This can be tested by calling DockerClient.ping without an active docker daemon