### PR TITLE
Add 'Tty' flag for the execStart call.

### DIFF
--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -751,7 +751,8 @@ public interface DockerClient extends Closeable {
    * Supported parameters for {@link #execStart}
    */
   enum ExecStartParameter {
-    DETACH("Detach");
+    DETACH("Detach"),
+    TTY("Tty");
 
     private final String name;
 


### PR DESCRIPTION
The Docker reference implementation for the remote api passes 'Tty' to
both 'Exec Create' and 'Exec Start' when the '-t' option is supplied to
'docker exec' so the option should exist in both cases.

If you look in https://github.com/docker/docker/blob/master/api/client/exec.go#L51 , you'll see this to be the case. Without the option it's still possible to interact with some shell, but some characters that have special meaning in the shell (carriage return, tab, ctrl+c) don't seem to be interpreted correctly.