### PR TITLE
Support for container rename

### DIFF
--- a/src/main/java/com/spotify/docker/client/ContainerRenameConflictException.java
+++ b/src/main/java/com/spotify/docker/client/ContainerRenameConflictException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client;
+
+public class ContainerRenameConflictException extends DockerException {
+
+  private final String containerId;
+  private final String newName;
+
+  public ContainerRenameConflictException(final String containerId, final String newName,
+                                          final Throwable cause) {
+    super("Container " + containerId + " could not be renamed to " + newName, cause);
+    this.containerId = containerId;
+    this.newName = newName;
+  }
+
+  public ContainerRenameConflictException(final String containerId, final String newName) {
+    this(containerId, newName, null);
+  }
+
+  public String getContainerId() {
+    return containerId;
+  }
+
+  public String getNewName() {
+    return newName;
+  }
+}

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -562,6 +562,17 @@ public interface DockerClient extends Closeable {
       throws DockerException, InterruptedException;
 
   /**
+   * Rename a docker container.
+   *
+   * @param containerId The id of the container to rename.
+   * @param name        The new name the container will have
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  void renameContainer(String containerId, String name)
+          throws DockerException, InterruptedException;
+
+  /**
    * Start a docker container.
    *
    * @param containerId The id of the container to start.


### PR DESCRIPTION
Addresses issue #361.

This is a first pass. I have two main caveats that I would like some feedback on before considering this final.

* The [API](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.18/) says the `rename` request can throw a `409` if the name is already assigned. Should I convert that into a named exception, à la `404 → ContainerNotFoundException`?
* I ran into a docker bug (or, perhaps, non-documented feature) where the `name` field returned by `container inspect <id>` has a leading `/`. See [#18558](https://github.com/docker/docker/issues/18558).  I created a test for my changes, but as I am testing the value of the name I had to change the comparison I'm making based on the API version. I'm running client 1.9.1 (API 1.21), so I am not able to test that the tests pass on lower APIs. (Though I guess CircleCI will make see if it passes on 1.20.) Any help testing on other versions would be appreciated.