### PR TITLE
Fix testRenameContainer flakiness

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -2517,7 +2517,7 @@ public class DefaultDockerClientTest {
     }
 
     // Rename a non-existent id. Should get ContainerNotFoundException.
-    final String badId = "0";
+    final String badId = "no_container_with_this_id_should_exist_otherwise_things_are_weird";
     try {
       sut.renameContainer(badId, randomName());
       fail("There should be no container with id " + badId);


### PR DESCRIPTION
Sometimes there is actually a container with an ID of 0
in CircleCI.