### PR TITLE
add support for sharing host devices with docker containers

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/Device.java
+++ b/src/main/java/com/spotify/docker/client/messages/Device.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client.messages;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+public class Device {
+
+    @JsonProperty("PathOnHost") private String pathOnHost;
+    @JsonProperty("PathInContainer") private String pathInContainer;
+    @JsonProperty("CgroupPermissions") private String cGroupPermissions;
+
+    public Device() {
+    }
+
+    public Device(final String pathOnHost, final String pathInContainer,
+                  final String cGroupPermissions) {
+        this.pathOnHost = pathOnHost;
+        this.pathInContainer = pathInContainer;
+        this.cGroupPermissions = cGroupPermissions;
+    }
+
+    public String pathOnHost() {
+        return pathOnHost;
+    }
+
+    public String pathInContainer() {
+        return pathInContainer;
+    }
+
+    public String cGroupPermissions() {
+        return cGroupPermissions;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Device that = (Device) o;
+
+        if (pathOnHost != null ? !pathOnHost.equals(that.pathOnHost) : that.pathOnHost != null) {
+            return false;
+        }
+        if (pathInContainer != null ?
+                !pathInContainer.equals(that.pathInContainer) : that.pathInContainer != null) {
+            return false;
+        }
+        if (cGroupPermissions != null ?
+                !cGroupPermissions.equals(that.cGroupPermissions) : 
+                that.cGroupPermissions != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = pathOnHost != null ? pathOnHost.hashCode() : 0;
+        result = 31 * result + (pathInContainer != null ? pathInContainer.hashCode() : 0);
+        result = 31 * result + (cGroupPermissions != null ? cGroupPermissions.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("pathOnHost", pathOnHost)
+                .add("pathInContainer", pathInContainer)
+                .add("cGroupPermissions", cGroupPermissions)
+                .toString();
+    }
+
+}

--- a/src/main/java/com/spotify/docker/client/messages/HostConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/HostConfig.java
@@ -46,6 +46,7 @@ public class HostConfig {
   @JsonProperty("VolumesFrom") private ImmutableList<String> volumesFrom;
   @JsonProperty("NetworkMode") private String networkMode;
   @JsonProperty("SecurityOpt") private ImmutableList<String> securityOpt;
+  @JsonProperty("Devices") private ImmutableList<Device> devices;
   @JsonProperty("Memory") private Long memory;
   @JsonProperty("MemorySwap") private Long memorySwap;
   @JsonProperty("CpuShares") private Long cpuShares;
@@ -72,6 +73,7 @@ public class HostConfig {
     this.volumesFrom = builder.volumesFrom;
     this.networkMode = builder.networkMode;
     this.securityOpt = builder.securityOpt;
+    this.devices = builder.devices;
     this.memory = builder.memory;
     this.memorySwap = builder.memorySwap;
     this.cpuShares = builder.cpuShares;
@@ -132,6 +134,10 @@ public class HostConfig {
 
   public List<String> securityOpt() {
     return securityOpt;
+  }
+  
+  public List<Device> devices() {
+    return devices;
   }
 
   public Long memory() {
@@ -219,6 +225,9 @@ public class HostConfig {
     if (securityOpt != null ? !securityOpt.equals(that.securityOpt) : that.securityOpt != null) {
       return false;
     }
+    if (devices != null ? !devices.equals(that.devices) : that.devices != null) {
+      return false;
+    }
 
     if (memory != null ? !memory.equals(that.memory) : that.memory != null) {
       return false;
@@ -272,6 +281,7 @@ public class HostConfig {
     result = 31 * result + (volumesFrom != null ? volumesFrom.hashCode() : 0);
     result = 31 * result + (networkMode != null ? networkMode.hashCode() : 0);
     result = 31 * result + (securityOpt != null ? securityOpt.hashCode() : 0);
+    result = 31 * result + (devices != null ? devices.hashCode() : 0);
     result = 31 * result + (memory != null ? memory.hashCode() : 0);
     result = 31 * result + (memorySwap != null ? memorySwap.hashCode() : 0);
     result = 31 * result + (cpuShares != null ? cpuShares.hashCode() : 0);
@@ -299,6 +309,7 @@ public class HostConfig {
         .add("volumesFrom", volumesFrom)
         .add("networkMode", networkMode)
         .add("securityOpt", securityOpt)
+        .add("devices", devices)
         .add("memory", memory)
         .add("memorySwap", memorySwap)
         .add("cpuShares", cpuShares)
@@ -455,6 +466,7 @@ public class HostConfig {
     private ImmutableList<String> volumesFrom;
     private String networkMode;
     private ImmutableList<String> securityOpt;
+    private ImmutableList<Device> devices;
     public Long memory;
     public Long memorySwap;
     public Long cpuShares;
@@ -481,6 +493,7 @@ public class HostConfig {
       this.volumesFrom = hostConfig.volumesFrom;
       this.networkMode = hostConfig.networkMode;
       this.securityOpt = hostConfig.securityOpt;
+      this.devices = hostConfig.devices;
       this.memory = hostConfig.memory;
       this.memorySwap = hostConfig.memorySwap;
       this.cpuShares = hostConfig.cpuShares;
@@ -697,6 +710,25 @@ public class HostConfig {
       return securityOpt;
     }
 
+    public Builder devices(final List<Device> devices) {
+      if (devices != null && !devices.isEmpty()) {
+        this.devices = ImmutableList.copyOf(devices);
+      }
+      return this;
+    }
+
+    public Builder devices(final Device... devices) {
+      if (devices != null && devices.length > 0) {
+        this.devices = ImmutableList.copyOf(devices);
+      }
+
+      return this;
+    }
+
+    public List<Device> devices() {
+      return devices;
+    }
+    
     public Builder memory(final Long memory) {
       this.memory = memory;
       return this;
@@ -774,5 +806,3 @@ public class HostConfig {
     }
   }
 }
-
-


### PR DESCRIPTION
This commit exposes support for hosts sharing devices with their containers.

e.g. adding support for --device
`docker run -d -P --device=/dev/video1 --device=/dev/snd -p 4444:4444 -p 5900:5900 --name chrome-stable acme.com/chrome-stable hw:0,1,1`

Our particular use case is wanting the host to set up some dummy audio and video loopback devices that pretend to be web cams/audio.  The audio and video is set up and piped to /dev/video and alsa using a gstreamer pipeline.  When the containers (running selenium) start chrome or firefox they can make use of a webcam with 'canned video'.

We found that setting up the device in the host and sharing it was more stable than setting it up in the container, and we want to continue using the spotify docker client.  Thanks!