### PR TITLE
Document creating a container with volumes. Update support for Mounts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,41 @@ docker.removeContainer(id);
 docker.close();
 ```
 
+### Mounting volumes in a container
+To mount a host directory into a container, create the container with a `HostConfig`.
+You can set the local path and remote path in the `binds()` method on the `HostConfig.Builder`.
+There are two ways to make a bind:
+1. Pass `binds()` a set of strings of the form `"local_path:container_path"`.
+2. Create a `Bind` object and pass it to `binds()`.
+
+If you only need to create a volume in a container, and you don't need it to mount any
+particular directory on the host, you can use the `volumes()` method on the 
+`ContainerConfig.Builder`.
+
+#### Example:
+```java
+final HostConfig hostConfig = 
+  HostConfig.builder()
+    .binds("/local/path:/remote/path")
+    .binds(Bind.from("/another/local/path")
+               .to("/another/remote/path")
+               .readOnly(true)
+               .build())
+    .build();
+final ContainerConfig volumeConfig = 
+  ContainerConfig.builder()
+    .image(BUSYBOX_LATEST)
+    .volumes("/foo")   // This volume will not mount any host directory
+    .hostConfig(hostConfig)
+    .build();
+```
+
+#### Note on Mounts
+Be aware that, starting with API version 1.20 (docker version 1.8.x), information 
+about a container's volumes is returned with the key `"Mounts"`, not `"Volumes"`.  
+As such, the `ContainerInfo.volumes()` method is deprecated. Instead, use
+`ContainerInfo.mounts()`.
+
 ### Configuration
 
 Both `DefaultDockerClient.builder()` and `DefaultDockerClient.fromEnv()` return a

--- a/src/main/java/com/spotify/docker/client/messages/ContainerInfo.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerInfo.java
@@ -58,7 +58,7 @@ public class ContainerInfo {
   @JsonProperty("ExecIDs") private ImmutableList<String> execId;
   @JsonProperty("LogPath") private String logPath;
   @JsonProperty("RestartCount") private Long restartCount;
-  @JsonProperty("Mounts") private ImmutableList<ContainerMount> mountsList;
+  @JsonProperty("Mounts") private ImmutableList<ContainerMount> mounts;
   
   /**
    * This field is an extension defined by the Docker Swarm API, therefore it will only be populated
@@ -134,10 +134,22 @@ public class ContainerInfo {
     return mountLabel;
   }
 
+  /**
+   * Volumes returned by execInspect
+   *
+   * @deprecated Replaced by {@link #mounts()} in API 1.20.
+   */
+  @Deprecated
   public Map<String, String> volumes() {
     return volumes;
   }
 
+  /**
+   * Volumes returned by execInspect
+   *
+   * @deprecated Replaced by {@link #mounts()} in API 1.20.
+   */
+  @Deprecated
   public Map<String, Boolean> volumesRW() {
     return volumesRW;
   }
@@ -235,7 +247,7 @@ public class ContainerInfo {
         that.restartCount != null) {
       return false;
     }
-    if (mountsList != null ? !mountsList.equals(that.mountsList) : that.mountsList != null) {
+    if (mounts != null ? !mounts.equals(that.mounts) : that.mounts != null) {
       return false;
     }
 
@@ -268,7 +280,7 @@ public class ContainerInfo {
     result = 31 * result + (execId != null ? execId.hashCode() : 0);
     result = 31 * result + (logPath != null ? logPath.hashCode() : 0);
     result = 31 * result + (restartCount != null ? restartCount.hashCode() : 0);
-    result = 31 * result + (mountsList != null ? mountsList.hashCode() : 0);
+    result = 31 * result + (mounts != null ? mounts.hashCode() : 0);
     return result;
   }
 
@@ -299,7 +311,7 @@ public class ContainerInfo {
         .add("execIDs", execId)
         .add("logPath", logPath)
         .add("restartCount", restartCount)
-        .add("mounts", mountsList)
+        .add("mounts", mounts)
         .toString();
   }
 
@@ -378,6 +390,6 @@ public class ContainerInfo {
   }
 
   public List<ContainerMount> mounts() {
-    return mountsList;
+    return mounts;
   }
 }

--- a/src/main/java/com/spotify/docker/client/messages/ContainerMount.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerMount.java
@@ -18,6 +18,8 @@
 package com.spotify.docker.client.messages;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -31,22 +33,22 @@ public class ContainerMount {
   @JsonProperty("Source") private String source;
   @JsonProperty("Destination") private String destination;
   @JsonProperty("Mode") private String mode;
-  @JsonProperty("RW") private Boolean rwInfo;
+  @JsonProperty("RW") private Boolean rw;
 
-  public String getSource() {
+  public String source() {
     return source;
   }
 
-  public String getDestination() {
+  public String destination() {
     return destination;
   }
 
-  public String getMode() {
+  public String mode() {
     return mode;
   }
 
-  public Boolean getRwInfo() {
-    return rwInfo;
+  public Boolean rw() {
+    return rw;
   }
 
   @Override
@@ -60,29 +62,15 @@ public class ContainerMount {
 
     final ContainerMount that = (ContainerMount) o;
 
-    if (source != null ? !source.equals(that.source) : that.source != null) {
-      return false;
-    }
-    if (destination != null ? !destination.equals(that.destination) : that.destination != null) {
-      return false;
-    }
-    if (mode != null ? !mode.equals(that.mode) : that.mode != null) {
-      return false;
-    }
-    if (rwInfo != null ? !rwInfo.equals(that.rwInfo) : that.rwInfo != null) {
-      return false;
-    }
-
-    return true;
+    return Objects.equal(this.source, that.source) &&
+        Objects.equal(this.destination, that.destination) &&
+        Objects.equal(this.mode, that.mode) &&
+        Objects.equal(this.rw, that.rw);
   }
 
   @Override
   public int hashCode() {
-    int result = source != null ? source.hashCode() : 0;
-    result = 31 * result + (destination != null ? destination.hashCode() : 0);
-    result = 31 * result + (mode != null ? mode.hashCode() : 0);
-    result = 31 * result + (rwInfo != null ? rwInfo.hashCode() : 0);
-    return result;
+    return java.util.Objects.hash(source, destination, mode, rw);
   }
 
   @Override
@@ -91,7 +79,7 @@ public class ContainerMount {
         .add("source", source)
         .add("destination", destination)
         .add("mode", mode)
-        .add("rw", rwInfo)
+        .add("rw", rw)
         .toString();
   }
 }

--- a/src/main/java/com/spotify/docker/client/messages/HostConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/HostConfig.java
@@ -19,6 +19,7 @@ package com.spotify.docker.client.messages;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -536,6 +537,9 @@ public class HostConfig {
 
     public Builder binds(final List<String> binds) {
       if (binds != null && !binds.isEmpty()) {
+        if (this.binds != null) {
+          binds.addAll(0, this.binds);
+        }
         this.binds = ImmutableList.copyOf(binds);
       }
 
@@ -544,10 +548,22 @@ public class HostConfig {
 
     public Builder binds(final String... binds) {
       if (binds != null && binds.length > 0) {
-        this.binds = ImmutableList.copyOf(binds);
+        return binds(Lists.newArrayList(binds));
       }
 
       return this;
+    }
+
+    public Builder binds(final Bind... binds) {
+      if (binds == null || binds.length == 0) {
+        return this;
+      }
+
+      final List<String> bindStrings = Lists.newArrayList();
+      for (final Bind bind : binds) {
+        bindStrings.add(bind.toString());
+      }
+      return binds(bindStrings);
     }
 
     public List<String> binds() {
@@ -863,6 +879,111 @@ public class HostConfig {
 
     public HostConfig build() {
       return new HostConfig(this);
+    }
+  }
+
+  public static class Bind {
+    private String to;
+    private String from;
+    private Boolean readOnly;
+
+    private Bind(final Builder builder) {
+      this.to = builder.to;
+      this.from = builder.from;
+      this.readOnly = builder.readOnly;
+    }
+
+    public static BuilderTo to(final String to) {
+      return new BuilderTo(to);
+    }
+
+    public static BuilderFrom from(final String from) {
+      return new BuilderFrom(from);
+    }
+
+    public String toString() {
+      if (to == null || to.equals("")) {
+        return "";
+      } else if (from == null || from.equals("")) {
+        return to;
+      } else if (readOnly == null || !readOnly) {
+        return from + ":" + to;
+      } else {
+        return from + ":" + to + ":ro";
+      }
+    }
+
+    public static class BuilderTo {
+      private String to;
+
+      public BuilderTo(final String to) {
+        this.to = to;
+      }
+
+      public Builder from(final String from) {
+        return new Builder(this, from);
+      }
+    }
+
+    public static class BuilderFrom {
+      private String from;
+
+      public BuilderFrom(final String from) {
+        this.from = from;
+      }
+
+      public Bind.Builder to(final String to) {
+        return new Builder(this, to);
+      }
+    }
+
+    public static class Builder {
+      private String to;
+      private String from;
+      private Boolean readOnly = false;
+
+      private Builder() {}
+
+      private Builder(final BuilderTo toBuilder, final String from) {
+        this.to = toBuilder.to;
+        this.from = from;
+      }
+
+      private Builder(final BuilderFrom fromBuilder, final String to) {
+        this.to = to;
+        this.from = fromBuilder.from;
+      }
+
+      public Builder to(final String to) {
+        this.to = to;
+        return this;
+      }
+
+      public String to() {
+        return to;
+      }
+
+      public Builder from(final String from) {
+        this.from = from;
+        return this;
+      }
+
+      public String from() {
+        return from;
+      }
+
+      public Builder readOnly(final Boolean readOnly) {
+        this.readOnly = readOnly;
+        return this;
+      }
+
+      public Boolean readOnly() {
+        return readOnly;
+      }
+
+      public Bind build() {
+        return new Bind(this);
+      }
     }
   }
 }


### PR DESCRIPTION
Addresses #228.

This PR:
* Adds a section to the README about how to mount a volume in a container,
* Deprecates the `ContainerInfo.volumes()` method in favor of `ContainerInfo.mounts()`. Information about container mounts has been returned in the latter since API 1.20.
* Adds a builder-style `Bind` inner class to `HostConfig`. Instead of passing a string into `HostConfig.builder().binds("/foo:/bar")`, now you can do `HostConfig.builder().binds(Bind.from("/foo").to("/bar").build())`.
* Slightly modifies & cleans up `ContainerMount`
* Tests creating containers with volumes and inspecting them, both in the old way and the new way.

I had some more substantial changes planned for this PR, but that's because I was basing my expectations on the Remote API docs. And when it comes to creating a container with mounts vs volumes, the docs are currently wrong. See [docker/docker#21335](https://github.com/docker/docker/issues/21335) and the comments on [docker/docker#15908](https://github.com/docker/docker/issues/15908).