### PR TITLE
correct API version that cpuQuota was introduced in

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -1307,9 +1307,14 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testContainerWithCpuQuota() throws Exception {
-    assumeTrue("Docker API should be at least v1.18 to support Container Creation with " +
-               "HostConfig, got " + sut.version().apiVersion(),
-               compareVersion(sut.version().apiVersion(), "1.18") >= 0);
+    final String requiredVersion = "1.19";
+    final String apiVersion = sut.version().apiVersion();
+    final String msg = String.format(
+        "Docker API should be at least v%s to support Container Creation with HostConfig, got %s",
+        requiredVersion, apiVersion
+    );
+    assumeTrue(msg, compareVersion(apiVersion, requiredVersion) >= 0);
+
     assumeFalse(CIRCLECI);
 
     sut.pull(BUSYBOX_LATEST);


### PR DESCRIPTION
Comparing the Docker Remote API docs for [1.19][] versus [1.18][], the
`cpuQuota` parameter was first introduced in 1.19, not 1.18. Update the
test that asserts the version that this is available in.

Spotify's internal Jenkins is using Docker API version 1.18 where this
test fails, which lends more evidence to the idea that it was introduced
in 1.19 and not 1.18.

[1.19]: https://docs.docker.com/engine/reference/api/docker_remote_api_v1.19/
[1.18]: https://docs.docker.com/engine/reference/api/docker_remote_api_v1.18/