### PR TITLE
fixes for testEventStreamWithSinceTime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,12 @@
       <version>1.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>2.8.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/spotify/docker/client/jackson/UnixTimestampDeserializer.java
+++ b/src/main/java/com/spotify/docker/client/jackson/UnixTimestampDeserializer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.util.Date;
+
+/**
+ * A deserializer for Dates where the source data is in seconds since the epoch rather than
+ * milliseconds as {@link Date} expects.
+ */
+public class UnixTimestampDeserializer extends JsonDeserializer<Date> {
+
+  public UnixTimestampDeserializer() {
+  }
+  @Override
+  public Date deserialize(final JsonParser p, final DeserializationContext ctxt)
+      throws IOException, JsonProcessingException {
+    final JsonToken token = p.getCurrentToken();
+    if (token == JsonToken.VALUE_STRING) {
+      final String str = p.getText().trim();
+      return toDate(Long.parseLong(str));
+    } else if (token == JsonToken.VALUE_NUMBER_INT) {
+      return toDate(p.getLongValue());
+    }
+    throw ctxt.wrongTokenException(p, JsonToken.VALUE_STRING, "Expected a string or numeric value");
+  }
+
+  private static Date toDate(long secondsSinceEpoch) {
+    return new Date(secondsSinceEpoch * 1000);
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/Event.java
+++ b/src/main/java/com/spotify/docker/client/messages/Event.java
@@ -17,8 +17,11 @@
 
 package com.spotify.docker.client.messages;
 
+import com.spotify.docker.client.jackson.UnixTimestampDeserializer;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.Date;
 
@@ -31,7 +34,10 @@ public class Event {
   @JsonProperty("status") private String status;
   @JsonProperty("id") private String id;
   @JsonProperty("from") private String from;
-  @JsonProperty("time") private Date time;
+
+  @JsonProperty("time")
+  @JsonDeserialize(using= UnixTimestampDeserializer.class)
+  private Date time;
 
   public String status() {
     return status;
@@ -49,4 +55,13 @@ public class Event {
     return time == null ? null : new Date(time.getTime());
   }
 
+  @Override
+  public String toString() {
+    return "Event{" +
+           "status='" + status + '\'' +
+           ", id='" + id + '\'' +
+           ", from='" + from + '\'' +
+           ", time=" + time +
+           '}';
+  }
 }

--- a/src/main/java/com/spotify/docker/client/messages/Event.java
+++ b/src/main/java/com/spotify/docker/client/messages/Event.java
@@ -36,7 +36,7 @@ public class Event {
   @JsonProperty("from") private String from;
 
   @JsonProperty("time")
-  @JsonDeserialize(using= UnixTimestampDeserializer.class)
+  @JsonDeserialize(using = UnixTimestampDeserializer.class)
   private Date time;
 
   public String status() {

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -55,6 +55,7 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.io.Resources;
@@ -97,6 +98,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1387,25 +1389,32 @@ public class DefaultDockerClientTest {
     final ContainerCreation container = sut.createContainer(config, randomName());
     sut.startContainer(container.id());
 
-    EventStream eventStream = sut.events(DockerClient.EventsParam.since(date.getTime() / 1000));
+    final Predicate<Event> hasStatus = new Predicate<Event>() {
+      @Override
+      public boolean apply(final Event input) {
+        return input.status() != null;
+      }
+    };
 
-    final Event pullEvent = eventStream.next();
-    assertThat(pullEvent.status(), equalTo("pull"));
-    assertThat(pullEvent.id(), equalTo(BUSYBOX_LATEST));
+    try (EventStream stream = sut.events(DockerClient.EventsParam.since(date.getTime() / 1000))) {
+      final Iterator<Event> events = Iterators.filter(stream, hasStatus);
 
-    final Event createEvent = eventStream.next();
-    assertThat(createEvent.status(), equalTo("create"));
-    assertThat(createEvent.id(), equalTo(container.id()));
-    assertThat(createEvent.from(), startsWith("busybox:"));
-    assertThat(createEvent.time(), notNullValue());
+      final Event pullEvent = events.next();
+      assertThat(pullEvent.status(), equalTo("pull"));
+      assertThat(pullEvent.id(), equalTo(BUSYBOX_LATEST));
 
-    final Event startEvent = eventStream.next();
-    assertThat(startEvent.status(), equalTo("start"));
-    assertThat(startEvent.id(), equalTo(container.id()));
-    assertThat(startEvent.from(), startsWith("busybox:"));
-    assertThat(startEvent.time(), notNullValue());
+      final Event createEvent = events.next();
+      assertThat(createEvent.status(), equalTo("create"));
+      assertThat(createEvent.id(), equalTo(container.id()));
+      assertThat(createEvent.from(), startsWith("busybox:"));
+      assertThat(createEvent.time(), notNullValue());
 
-    eventStream.close();
+      final Event startEvent = events.next();
+      assertThat(startEvent.status(), equalTo("start"));
+      assertThat(startEvent.id(), equalTo(container.id()));
+      assertThat(startEvent.from(), startsWith("busybox:"));
+      assertThat(startEvent.time(), notNullValue());
+    }
   }
 
   @Test(timeout = 5000)

--- a/src/test/java/com/spotify/docker/client/jackson/UnixTimestampDeserializerTest.java
+++ b/src/test/java/com/spotify/docker/client/jackson/UnixTimestampDeserializerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client.jackson;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class UnixTimestampDeserializerTest {
+
+  private final DateTime referenceDateTime = new DateTime(2013, 7, 17, 9, 32, 4, DateTimeZone.UTC);
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private static class TestClass {
+
+    @JsonProperty("date")
+    @JsonDeserialize(using = UnixTimestampDeserializer.class)
+    private Date date;
+
+    private Date getDate() {
+      return date;
+    }
+
+  }
+
+   private String toJson(String format) {
+    return String.format(format, referenceDateTime.getMillis() / 1000);
+  }
+
+  @Test
+  public void testFromString() throws Exception {
+    final String json = toJson("{\"date\": \"%s\"}");
+
+    final TestClass value = objectMapper.readValue(json, TestClass.class);
+    assertThat(value.getDate(), equalTo(referenceDateTime.toDate()));
+  }
+
+  @Test
+  public void testFromNumber() throws Exception {
+    final String json = toJson("{\"date\": %s}");
+
+    final TestClass value = objectMapper.readValue(json, TestClass.class);
+    assertThat(value.getDate(), equalTo(referenceDateTime.toDate()));
+  }
+
+}


### PR DESCRIPTION
For some unknown reason, some of the events returned by the docker events
API are returned with null status, which causes the test to fail because
the expected event is not in the correct place in the stream. This may be
isolated to earlier versions of Docker; seems to happen consistently to us
at Spotify with v1.6.2.

Make the test resilient to these types of events by filtering them out.