### PR TITLE
setup travis-ci for multiple docker versions

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 set -e
 
-show_help() {
-  echo "Usage: $0 <command>"
-  echo "Commands: install_docker, dump_docker_config"
-}
-
 if [[ -z $1 ]]; then
-  show_help
+  "I need a command!"
   exit 1
 fi
 
@@ -30,6 +25,9 @@ case "$1" in
     apt-cache policy docker-engine
     sudo apt-get -q -y install docker-engine=$DOCKER_VERSION* "linux-image-extra-$(uname -r)"
 
+    # set DOCKER_OPTS to make sure docker listens on the ports we intend
+    echo 'DOCKER_OPTS="-D=true -H=unix:///var/run/docker.sock -H=tcp://127.0.0.1:2375"' | sudo tee -a /etc/default/docker
+
     if [[ "$DOCKER_VERSION" =~ ^1\.6\..* ]]; then
       # docker-engine 1.6.x packages don't seem to have the upstart job config,
       # so write it ourselves
@@ -42,27 +40,34 @@ limit nproc 524288 1048576
 respawn
 kill timeout 20
 script
-	DOCKER=/usr/bin/$UPSTART_JOB
-	DOCKER_OPTS="-D=true -H=unix:///var/run/docker.sock -H=tcp://127.0.0.1:2375"
-	exec "$DOCKER" -d $DOCKER_OPTS
+  DOCKER=/usr/bin/$UPSTART_JOB
+  DOCKER_OPTS=
+  if [ -f /etc/default/$UPSTART_JOB ]; then
+    . /etc/default/$UPSTART_JOB
+  fi
+  exec "$DOCKER" -d $DOCKER_OPTS
 end script
 # Don'"'"'t emit "started" event until docker.sock is ready.
 # See https://github.com/docker/docker/issues/6647
 post-start script
-	DOCKER_OPTS="-D=true -H=unix:///var/run/docker.sock -H=tcp://127.0.0.1:2375"
-	while ! [ -e /var/run/docker.sock ]; do
-		initctl status $UPSTART_JOB | grep -qE "(stop|respawn)/" && exit 1
-		echo "Waiting for /var/run/docker.sock"
-		sleep 0.1
-	done
-	echo "/var/run/docker.sock is up"
+  DOCKER_OPTS=
+  if [ -f /etc/default/$UPSTART_JOB ]; then
+    . /etc/default/$UPSTART_JOB
+  fi
+  while ! [ -e /var/run/docker.sock ]; do
+    initctl status $UPSTART_JOB | grep -qE "(stop|respawn)/" && exit 1
+    echo "Waiting for /var/run/docker.sock"
+    sleep 0.1
+  done
+  echo "/var/run/docker.sock is up"
 end script
       ' | sudo tee /etc/init/docker.conf
       sudo cat /etc/init/docker.conf
+      # need to start the service since we just wrote the upstart config
       sudo start docker
     else
-      # set DOCKER_OPTS to make sure docker listens on the ports we intend
-	    echo 'DOCKER_OPTS="-D=true -H=unix:///var/run/docker.sock -H=tcp://127.0.0.1:2375"' | sudo tee -a /etc/default/docker
+      # restart the service for the /etc/default/docker change we made after
+      # installing the package
       sudo restart docker
     fi
 

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -e
+
+show_help() {
+  echo "Usage: $0 <command>"
+  echo "Commands: install_docker"
+}
+
+if [[ -z $1 ]]; then
+  show_help
+  exit 1
+fi
+
+case "$1" in
+  install_docker)
+
+    if [[ -z $DOCKER_VERSION ]]; then
+      echo "DOCKER_VERSION needs to be set as an environment variable"
+      exit 1
+    fi
+
+    # TODO detect which docker version is already installed and skip
+    # uninstall/reinstall if it matches $DOCKER_VERSION
+
+    # stop docker service if running
+    sudo stop docker || :
+
+    sudo apt-get -qq update
+    sudo apt-get -q -y purge docker-engine
+    apt-cache policy docker-engine
+    sudo apt-get -q -y install docker-engine=$DOCKER_VERSION* "linux-image-extra-$(uname -r)"
+
+    if [[ "$DOCKER_VERSION" =~ ^1\.6\..* ]]; then
+      # docker-engine 1.6.x packages don't seem to have the upstart job config,
+      # so write it ourselves
+      echo '
+description "Docker daemon"
+start on (local-filesystems and net-device-up IFACE!=lo)
+stop on runlevel [!2345]
+limit nofile 524288 1048576
+limit nproc 524288 1048576
+respawn
+kill timeout 20
+script
+	DOCKER=/usr/bin/$UPSTART_JOB
+	DOCKER_OPTS="-D=true -H=unix:///var/run/docker.sock -H=tcp://127.0.0.1:2375"
+	exec "$DOCKER" -d $DOCKER_OPTS
+end script
+# Don'"'"'t emit "started" event until docker.sock is ready.
+# See https://github.com/docker/docker/issues/6647
+post-start script
+	DOCKER_OPTS="-D=true -H=unix:///var/run/docker.sock -H=tcp://127.0.0.1:2375"
+	while ! [ -e /var/run/docker.sock ]; do
+		initctl status $UPSTART_JOB | grep -qE "(stop|respawn)/" && exit 1
+		echo "Waiting for /var/run/docker.sock"
+		sleep 0.1
+	done
+	echo "/var/run/docker.sock is up"
+end script
+      ' | sudo tee /etc/init/docker.conf
+      sudo cat /etc/init/docker.conf
+      sudo start docker
+    else
+      # set DOCKER_OPTS to make sure docker listens on the ports we intend
+	    echo 'DOCKER_OPTS="-D=true -H=unix:///var/run/docker.sock -H=tcp://127.0.0.1:2375"' | sudo tee -a /etc/default/docker
+      sudo restart docker
+    fi
+    ;;
+
+  *)
+    echo "Unknown command $1"
+    exit 2
+esac

--- a/.travis.sh
+++ b/.travis.sh
@@ -3,7 +3,7 @@ set -e
 
 show_help() {
   echo "Usage: $0 <command>"
-  echo "Commands: install_docker"
+  echo "Commands: install_docker, dump_docker_config"
 }
 
 if [[ -z $1 ]]; then
@@ -65,6 +65,21 @@ end script
 	    echo 'DOCKER_OPTS="-D=true -H=unix:///var/run/docker.sock -H=tcp://127.0.0.1:2375"' | sudo tee -a /etc/default/docker
       sudo restart docker
     fi
+
+    ;;
+
+  dump_docker_config)
+    # output the upstart config and default config in case they are needed for
+    # troubleshooting
+    echo "Contents of /etc/init/docker.conf:"
+    sudo cat /etc/init/docker.conf
+
+    echo "Contents of /etc/default/docker"
+    sudo cat /etc/default/docker || :
+
+    echo "Contents of /var/log/upstart/docker.log"
+    sudo cat /var/log/upstart/docker.log
+
     ;;
 
   *)

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,7 @@ before_install:
 
 # TODO spin up registry, add mvn verify
 script: mvn test
+
+after_success:
+  # test coverage reporting
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ before_install:
   - docker version
   - docker info
 
-# TODO spin up registry, add mvn verify
 script: mvn test
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+sudo: required
+
+services:
+  - docker
+
+language: java
+
+jdk:
+  - oraclejdk7
+  - oraclejdk8
+
+env: 
+  - DOCKER_VERSION=1.6.0 DOCKER_HOST=tcp://127.0.0.1:2375
+  - DOCKER_VERSION=1.6.0 DOCKER_HOST=unix:///var/run/docker.sock
+  - DOCKER_VERSION=1.8.2 DOCKER_HOST=tcp://127.0.0.1:2375
+  - DOCKER_VERSION=1.8.2 DOCKER_HOST=unix:///var/run/docker.sock
+
+before_install:
+  # check what version of docker is installed beforehand
+  - dpkg -l | grep docker
+  # install the version of docker in the DOCKER_VERSION env var
+  - ./.travis.sh install_docker
+  # and double-check that the version is correct
+  - docker version
+  - docker info
+
+# TODO spin up registry, add mvn verify
+script: mvn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ language: java
 
 jdk:
   - oraclejdk7
-  - oraclejdk8
 
 env: 
   - DOCKER_VERSION=1.6.0 DOCKER_HOST=tcp://127.0.0.1:2375
@@ -20,7 +19,8 @@ before_install:
   - dpkg -l | grep docker
   # install the version of docker in the DOCKER_VERSION env var
   - ./.travis.sh install_docker
-  # and double-check that the version is correct
+  # double-check that the version/config is correct
+  - ./.travis.sh dump_docker_config
   - docker version
   - docker info
 

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -184,6 +184,7 @@ public class DefaultDockerClientTest {
   private static final String CIRROS_PRIVATE_LATEST = CIRROS_PRIVATE + ":latest";
 
   private static final boolean CIRCLECI = !isNullOrEmpty(getenv("CIRCLECI"));
+  private static final boolean TRAVIS = "true".equals(getenv("TRAVIS"));
 
   private static final String AUTH_EMAIL = "dxia+2@spotify.com";
   private static final String AUTH_USERNAME = "dxia2";
@@ -1510,6 +1511,8 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testSsl() throws Exception {
+    assumeFalse(TRAVIS);
+
     // Build a run a container that contains a Docker instance configured with our SSL cert/key
     final String imageName = "test-docker-ssl";
     final String expose = "2376/tcp";


### PR DESCRIPTION
Sets up a matrix build that combines various Docker versions with various options for `DOCKER_HOST`. This can also be used to build against multiple JDK versions as well.

Setting up a specific Docker version is done by simply `apt-get remove` and
`apt-get install` specific versions. Some care is needed with version 1.6.x
to set up an Upstart job as the docker-engine package doesn't seem to do
this until 1.7+.

This same setup works with Docker version 1.7.x, 1.9.x, and 1.10.x, but
there seem to be some real test failures with these versions. I've kept
those versions out of this matrix for now until those failures can be
fixed.

Compared with CircleCI, this allows us to test the docker-client library
across a variety of Docker runtime/API versions, and to be able to catch
possible issues with certain versions at contribution-/CI-time (rather than
when we at Spotify try to build and release a version of the library on our
Jenkins that uses Docker 1.6 days or weeks after a contribution has been
merged).

Unlike CircleCI, there doesn't seem to be an obvious limitation on how many
builds we can launch at once; we would just possibly have to deal with
longer queue times.

I haven't investigated it much yet but by testing against a regular version
of Docker instead of the special/custom version that CircleCI sets up, we
may need to ignore less tests too.

Addresses #387.