### PR TITLE
Fix testBuildName for docker 1.10

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -661,12 +661,23 @@ public class DefaultDockerClientTest {
   }
 
   @Test
-  public void testBuildName() throws Exception {
+  public void testBuildNameAPILessThan122() throws Exception {
+    requireDockerApiVersionLessThan("1.22", "image ids with no sha256: prefix");
     final String imageName = "test-build-name";
     final String dockerDirectory = Resources.getResource("dockerDirectory").getPath();
     final String imageId = sut.build(Paths.get(dockerDirectory), imageName);
     final ImageInfo info = sut.inspectImage(imageName);
     assertThat(info.id(), startsWith(imageId));
+  }
+
+  @Test
+  public void testBuildNameAPIEqualsOrGreater122() throws Exception {
+    requireDockerApiVersion("1.22", "image ids with sha256: prefix");
+    final String imageName = "test-build-name";
+    final String dockerDirectory = Resources.getResource("dockerDirectory").getPath();
+    final String imageId = sut.build(Paths.get(dockerDirectory), imageName);
+    final ImageInfo info = sut.inspectImage(imageName);
+    assertThat(info.id(), startsWith("sha256:" + imageId));
   }
 
   @Test


### PR DESCRIPTION
There have been a bunch of test failures over on #389, and this fixes one.

See this stack trace ([Line 3337 of build 305.9](https://travis-ci.org/spotify/docker-client/jobs/117967153#L3337)):

    testBuildName(com.spotify.docker.client.DefaultDockerClientTest)  Time elapsed: 0.303 sec  <<< FAILURE!
    java.lang.AssertionError: 
    Expected: a string starting with "bf1f8aff684a"
         but: was "sha256:bf1f8aff684a8497e4f856d15ff0a5bbf0a531db25d5152abb1f9bae4b505a5e"
	    at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
            ...
This is because API 1.22 reports image ids with a "`sha256:`" prefix on `docker inspect`. Nothing in the library is wrong. The test just needs to be updated to assert the correct ID.