### PR TITLE
Do not add filters if there are none

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -406,10 +406,12 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       }
     }
 
-    // If filters were specified, we must put them in a JSON object and pass them using the
-    // 'filters' query param like this: filters={"dangling":["true"]}. If filters is an empty map,
-    // urlEncodeFilters will return null and queryParam() will remove that query parameter.
-    resource = resource.queryParam("filters", urlEncodeFilters(filters));
+    if (!filters.isEmpty()) {
+      // If filters were specified, we must put them in a JSON object and pass them using the
+      // 'filters' query param like this: filters={"dangling":["true"]}. If filters is an empty map,
+      // urlEncodeFilters will return null and queryParam() will remove that query parameter.
+      resource = resource.queryParam("filters", urlEncodeFilters(filters));
+    }
 
     return request(GET, CONTAINER_LIST, resource, resource.request(APPLICATION_JSON_TYPE));
   }
@@ -471,10 +473,12 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       }
     }
 
-    // If filters were specified, we must put them in a JSON object and pass them using the
-    // 'filters' query param like this: filters={"dangling":["true"]}. If filters is an empty map,
-    // urlEncodeFilters will return null and queryParam() will remove that query parameter.
-    resource = resource.queryParam("filters", urlEncodeFilters(filters));
+    if (!filters.isEmpty()) {
+      // If filters were specified, we must put them in a JSON object and pass them using the
+      // 'filters' query param like this: filters={"dangling":["true"]}. If filters is an empty map,
+      // urlEncodeFilters will return null and queryParam() will remove that query parameter.
+      resource = resource.queryParam("filters", urlEncodeFilters(filters));
+    }
 
     return request(GET, IMAGE_LIST, resource, resource.request(APPLICATION_JSON_TYPE));
   }


### PR DESCRIPTION
I noticed a lot of lines in my docker logs like `"GET /containers/json?filters=%7B%7D"`. That is from the `DefaultDockerClientTest#tearDown` method checking if there are running containers to stop. Looks like every request to `listContainers` and `listImages` includes `filters` as a query param whether there are any filters to include or not.

It isn't a bug. It doesn't cause anything to fail. It's just... untidy.

So this PR tidies it up.