### PR TITLE
Standardize equals and hashCode methods

### DIFF
--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -571,11 +571,8 @@ public interface DockerClient extends Closeable {
 
       final BuildParam that = (BuildParam) o;
 
-      if (name != null ? !name.equals(that.name) : that.name != null) {
-        return false;
-      }
-      return !(value != null ? !value.equals(that.value) : that.value != null);
-
+      return Objects.equals(this.name, that.name) &&
+          Objects.equals(this.value, that.value);
     }
 
     @Override

--- a/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
+++ b/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
@@ -83,19 +83,19 @@ public class AttachedNetwork {
     final AttachedNetwork that = (AttachedNetwork) o;
 
     return Objects.equals(this.endpointId, that.endpointId) &&
-           Objects.equals(this.gateway, that.gateway) &&
-           Objects.equals(this.ipAddress, that.ipAddress) &&
-           Objects.equals(this.ipPrefixLen, that.ipPrefixLen) &&
-           Objects.equals(this.ipv6Gateway, that.ipv6Gateway) &&
-           Objects.equals(this.globalIPv6Address, that.globalIPv6Address) &&
-           Objects.equals(this.globalIPv6PrefixLen, that.globalIPv6PrefixLen) &&
-           Objects.equals(this.macAddress, that.macAddress);
+        Objects.equals(this.gateway, that.gateway) &&
+        Objects.equals(this.ipAddress, that.ipAddress) &&
+        Objects.equals(this.ipPrefixLen, that.ipPrefixLen) &&
+        Objects.equals(this.ipv6Gateway, that.ipv6Gateway) &&
+        Objects.equals(this.globalIPv6Address, that.globalIPv6Address) &&
+        Objects.equals(this.globalIPv6PrefixLen, that.globalIPv6PrefixLen) &&
+        Objects.equals(this.macAddress, that.macAddress);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(endpointId, gateway, ipAddress, ipPrefixLen, ipv6Gateway,
-                                  globalIPv6Address, globalIPv6PrefixLen, macAddress);
+                        globalIPv6Address, globalIPv6PrefixLen, macAddress);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/AuthConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/AuthConfig.java
@@ -91,23 +91,12 @@ public class AuthConfig {
       return false;
     }
 
-    final AuthConfig config = (AuthConfig) o;
-    if (username != null ? !username.equals(config.username) : config.username != null) {
-      return false;
-    }
-    if (password != null ? !password.equals(config.password) : config.password != null) {
-      return false;
-    }
-    if (email != null ? !email.equals(config.email) : config.email != null) {
-      return false;
-    }
-    //noinspection RedundantIfStatement
-    if (serverAddress != null ?
-        !serverAddress.equals(config.serverAddress) : config.serverAddress != null) {
-      return false;
-    }
+    final AuthConfig that = (AuthConfig) o;
 
-    return true;
+    return Objects.equals(this.username, that.username) &&
+        Objects.equals(this.password, that.password) &&
+        Objects.equals(this.email, that.email) &&
+        Objects.equals(this.serverAddress, that.serverAddress);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/AuthRegistryConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/AuthRegistryConfig.java
@@ -107,28 +107,14 @@ public class AuthRegistryConfig {
       return false;
     }
 
-    final AuthRegistryConfig config = (AuthRegistryConfig) o;
-    if (repository != null ? !repository.equals(config.repository) : config.repository != null) {
-      return false;
-    }
-    if (username != null ? !username.equals(config.username) : config.username != null) {
-      return false;
-    }
-    if (password != null ? !password.equals(config.password) : config.password != null) {
-      return false;
-    }
-    if (auth != null ? !auth.equals(config.auth) : config.auth != null) {
-      return false;
-    }
-    if (email != null ? !email.equals(config.email) : config.email != null) {
-      return false;
-    }
-    if (serverAddress != null ?
-        !serverAddress.equals(config.serverAddress) : config.serverAddress != null) {
-      return false;
-    }
+    final AuthRegistryConfig that = (AuthRegistryConfig) o;
 
-    return true;
+    return Objects.equals(this.repository, that.repository) &&
+        Objects.equals(this.username, that.username) &&
+        Objects.equals(this.password, that.password) &&
+        Objects.equals(this.auth, that.auth) &&
+        Objects.equals(this.email, that.email) &&
+        Objects.equals(this.serverAddress, that.serverAddress);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/BlockIoStats.java
+++ b/src/main/java/com/spotify/docker/client/messages/BlockIoStats.java
@@ -86,17 +86,15 @@ public class BlockIoStats {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
+  public boolean equals(Object o) {
+    if (this == o) {
       return true;
     }
-    if (obj == null) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    final BlockIoStats that = (BlockIoStats) obj;
+
+    final BlockIoStats that = (BlockIoStats) o;
 
     return Objects.equals(this.ioServiceBytesRecursive, that.ioServiceBytesRecursive) &&
         Objects.equals(this.ioServicedRecursive, that.ioServicedRecursive) &&

--- a/src/main/java/com/spotify/docker/client/messages/Container.java
+++ b/src/main/java/com/spotify/docker/client/messages/Container.java
@@ -131,44 +131,19 @@ public class Container {
       return false;
     }
 
-    final Container container = (Container) o;
+    final Container that = (Container) o;
 
-    if (command != null ? !command.equals(container.command) : container.command != null) {
-      return false;
-    }
-    if (created != null ? !created.equals(container.created) : container.created != null) {
-      return false;
-    }
-    if (id != null ? !id.equals(container.id) : container.id != null) {
-      return false;
-    }
-    if (image != null ? !image.equals(container.image) : container.image != null) {
-      return false;
-    }
-    if (names != null ? !names.equals(container.names) : container.names != null) {
-      return false;
-    }
-    if (ports != null ? !ports.equals(container.ports) : container.ports != null) {
-      return false;
-    }
-    if (labels != null ? !labels.equals(container.labels) : container.labels != null) {
-      return false;
-    }
-    if (sizeRootFs != null ? !sizeRootFs.equals(container.sizeRootFs)
-                           : container.sizeRootFs != null) {
-      return false;
-    }
-    if (sizeRw != null ? !sizeRw.equals(container.sizeRw) : container.sizeRw != null) {
-      return false;
-    }
-    if (status != null ? !status.equals(container.status) : container.status != null) {
-      return false;
-    }
-    if (imageId != null ? !imageId.equals(container.imageId) : container.imageId != null) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(this.id, that.id) &&
+        Objects.equals(this.names, that.names) &&
+        Objects.equals(this.image, that.image) &&
+        Objects.equals(this.imageId, that.imageId) &&
+        Objects.equals(this.command, that.command) &&
+        Objects.equals(this.created, that.created) &&
+        Objects.equals(this.status, that.status) &&
+        Objects.equals(this.ports, that.ports) &&
+        Objects.equals(this.labels, that.labels) &&
+        Objects.equals(this.sizeRw, that.sizeRw) &&
+        Objects.equals(this.sizeRootFs, that.sizeRootFs);
   }
 
   @Override
@@ -227,20 +202,10 @@ public class Container {
 
       final PortMapping that = (PortMapping) o;
 
-      if (privatePort != that.privatePort) {
-        return false;
-      }
-      if (publicPort != that.publicPort) {
-        return false;
-      }
-      if (ip != null ? !ip.equals(that.ip) : that.ip != null) {
-        return false;
-      }
-      if (type != null ? !type.equals(that.type) : that.type != null) {
-        return false;
-      }
-
-      return true;
+      return Objects.equals(this.privatePort, that.privatePort) &&
+          Objects.equals(this.publicPort, that.publicPort) &&
+          Objects.equals(this.type, that.type) &&
+          Objects.equals(this.ip, that.ip);
     }
 
     @Override

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -187,88 +187,31 @@ public class ContainerConfig {
       return false;
     }
 
-    final ContainerConfig config = (ContainerConfig) o;
+    final ContainerConfig that = (ContainerConfig) o;
 
-    if (attachStderr != null ? !attachStderr.equals(config.attachStderr)
-                             : config.attachStderr != null) {
-      return false;
-    }
-    if (attachStdin != null ? !attachStdin.equals(config.attachStdin)
-                            : config.attachStdin != null) {
-      return false;
-    }
-    if (attachStdout != null ? !attachStdout.equals(config.attachStdout)
-                             : config.attachStdout != null) {
-      return false;
-    }
-    if (cmd != null ? !cmd.equals(config.cmd) : config.cmd != null) {
-      return false;
-    }
-    if (domainname != null ? !domainname.equals(config.domainname) : config.domainname != null) {
-      return false;
-    }
-    if (entrypoint != null ? !entrypoint.equals(config.entrypoint) : config.entrypoint != null) {
-      return false;
-    }
-    if (env != null ? !env.equals(config.env) : config.env != null) {
-      return false;
-    }
-    if (exposedPorts != null ? !exposedPorts.equals(config.exposedPorts)
-                             : config.exposedPorts != null) {
-      return false;
-    }
-    if (hostname != null ? !hostname.equals(config.hostname) : config.hostname != null) {
-      return false;
-    }
-    if (image != null ? !image.equals(config.image) : config.image != null) {
-      return false;
-    }
-    if (networkDisabled != null ? !networkDisabled.equals(config.networkDisabled)
-                                : config.networkDisabled != null) {
-      return false;
-    }
-    if (onBuild != null ? !onBuild.equals(config.onBuild) : config.onBuild != null) {
-      return false;
-    }
-    if (openStdin != null ? !openStdin.equals(config.openStdin) : config.openStdin != null) {
-      return false;
-    }
-    if (portSpecs != null ? !portSpecs.equals(config.portSpecs) : config.portSpecs != null) {
-      return false;
-    }
-    if (stdinOnce != null ? !stdinOnce.equals(config.stdinOnce) : config.stdinOnce != null) {
-      return false;
-    }
-    if (tty != null ? !tty.equals(config.tty) : config.tty != null) {
-      return false;
-    }
-    if (user != null ? !user.equals(config.user) : config.user != null) {
-      return false;
-    }
-    if (volumes != null ? !volumes.equals(config.volumes) : config.volumes != null) {
-      return false;
-    }
-    if (workingDir != null ? !workingDir.equals(config.workingDir) : config.workingDir != null) {
-      return false;
-    }
-
-    if (labels != null ? !labels.equals(config.labels) : config.labels != null) {
-      return false;
-    }
-
-    if (macAddress != null ? !macAddress.equals(config.macAddress) : config.macAddress != null) {
-      return false;
-    }
-
-    if (hostConfig != null ? !hostConfig.equals(config.hostConfig) : config.hostConfig != null) {
-      return false;
-    }
-
-    if (stopSignal != null ? !stopSignal.equals(config.stopSignal) : config.stopSignal != null) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(this.hostname, that.hostname) &&
+        Objects.equals(this.domainname, that.domainname) &&
+        Objects.equals(this.user, that.user) &&
+        Objects.equals(this.attachStdin, that.attachStdin) &&
+        Objects.equals(this.attachStdout, that.attachStdout) &&
+        Objects.equals(this.attachStderr, that.attachStderr) &&
+        Objects.equals(this.portSpecs, that.portSpecs) &&
+        Objects.equals(this.exposedPorts, that.exposedPorts) &&
+        Objects.equals(this.tty, that.tty) &&
+        Objects.equals(this.openStdin, that.openStdin) &&
+        Objects.equals(this.stdinOnce, that.stdinOnce) &&
+        Objects.equals(this.env, that.env) &&
+        Objects.equals(this.cmd, that.cmd) &&
+        Objects.equals(this.image, that.image) &&
+        Objects.equals(this.volumes, that.volumes) &&
+        Objects.equals(this.workingDir, that.workingDir) &&
+        Objects.equals(this.entrypoint, that.entrypoint) &&
+        Objects.equals(this.networkDisabled, that.networkDisabled) &&
+        Objects.equals(this.onBuild, that.onBuild) &&
+        Objects.equals(this.labels, that.labels) &&
+        Objects.equals(this.macAddress, that.macAddress) &&
+        Objects.equals(this.hostConfig, that.hostConfig) &&
+        Objects.equals(this.stopSignal, that.stopSignal);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/ContainerCreation.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerCreation.java
@@ -61,14 +61,8 @@ public class ContainerCreation {
 
     final ContainerCreation that = (ContainerCreation) o;
 
-    if (id != null ? !id.equals(that.id) : that.id != null) {
-      return false;
-    }
-    if (warnings != null ? !warnings.equals(that.warnings) : that.warnings != null) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(this.id, that.id) &&
+        Objects.equals(this.warnings, that.warnings);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/ContainerExit.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerExit.java
@@ -22,6 +22,8 @@ import com.google.common.base.MoreObjects;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
@@ -52,16 +54,12 @@ public class ContainerExit {
 
     final ContainerExit that = (ContainerExit) o;
 
-    if (statusCode != null ? !statusCode.equals(that.statusCode) : that.statusCode != null) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(this.statusCode, that.statusCode);
   }
 
   @Override
   public int hashCode() {
-    return statusCode != null ? statusCode.hashCode() : 0;
+    return Objects.hash(statusCode);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/ContainerInfo.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerInfo.java
@@ -173,89 +173,30 @@ public class ContainerInfo {
 
     final ContainerInfo that = (ContainerInfo) o;
 
-    if (args != null ? !args.equals(that.args) : that.args != null) {
-      return false;
-    }
-    if (config != null ? !config.equals(that.config) : that.config != null) {
-      return false;
-    }
-    if (hostConfig != null ? !hostConfig.equals(that.hostConfig) : that.hostConfig != null) {
-      return false;
-    }
-    if (created != null ? !created.equals(that.created) : that.created != null) {
-      return false;
-    }
-    if (driver != null ? !driver.equals(that.driver) : that.driver != null) {
-      return false;
-    }
-    if (execDriver != null ? !execDriver.equals(that.execDriver) : that.execDriver != null) {
-      return false;
-    }
-    if (hostnamePath != null ? !hostnamePath.equals(that.hostnamePath)
-                             : that.hostnamePath != null) {
-      return false;
-    }
-    if (hostsPath != null ? !hostsPath.equals(that.hostsPath) : that.hostsPath != null) {
-      return false;
-    }
-    if (id != null ? !id.equals(that.id) : that.id != null) {
-      return false;
-    }
-    if (image != null ? !image.equals(that.image) : that.image != null) {
-      return false;
-    }
-    if (mountLabel != null ? !mountLabel.equals(that.mountLabel) : that.mountLabel != null) {
-      return false;
-    }
-    if (name != null ? !name.equals(that.name) : that.name != null) {
-      return false;
-    }
-    if (networkSettings != null ? !networkSettings.equals(that.networkSettings)
-                                : that.networkSettings != null) {
-      return false;
-    }
-    if (path != null ? !path.equals(that.path) : that.path != null) {
-      return false;
-    }
-    if (processLabel != null ? !processLabel.equals(that.processLabel)
-                             : that.processLabel != null) {
-      return false;
-    }
-    if (resolvConfPath != null ? !resolvConfPath.equals(that.resolvConfPath)
-                               : that.resolvConfPath != null) {
-      return false;
-    }
-    if (state != null ? !state.equals(that.state) : that.state != null) {
-      return false;
-    }
-    if (volumes != null ? !volumes.equals(that.volumes) : that.volumes != null) {
-      return false;
-    }
-    if (volumesRW != null ? !volumesRW.equals(that.volumesRW) : that.volumesRW != null) {
-      return false;
-    }
-    if (node != null ? !node.equals(that.node) : that.node != null) {
-      return false;
-    }
-    if (appArmorProfile != null ? !appArmorProfile.equals(that.appArmorProfile) :
-        that.appArmorProfile != null) {
-      return false;
-    }
-    if (execId != null ? !execId.equals(that.execId) : that.execId != null) {
-      return false;
-    }
-    if (logPath != null ? !logPath.equals(that.logPath) : that.logPath != null) {
-      return false;
-    }
-    if (restartCount != null ? !restartCount.equals(that.restartCount) :
-        that.restartCount != null) {
-      return false;
-    }
-    if (mounts != null ? !mounts.equals(that.mounts) : that.mounts != null) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(this.id, that.id) &&
+        Objects.equals(this.created, that.created) &&
+        Objects.equals(this.path, that.path) &&
+        Objects.equals(this.args, that.args) &&
+        Objects.equals(this.config, that.config) &&
+        Objects.equals(this.hostConfig, that.hostConfig) &&
+        Objects.equals(this.state, that.state) &&
+        Objects.equals(this.image, that.image) &&
+        Objects.equals(this.networkSettings, that.networkSettings) &&
+        Objects.equals(this.resolvConfPath, that.resolvConfPath) &&
+        Objects.equals(this.hostnamePath, that.hostnamePath) &&
+        Objects.equals(this.hostsPath, that.hostsPath) &&
+        Objects.equals(this.name, that.name) &&
+        Objects.equals(this.driver, that.driver) &&
+        Objects.equals(this.execDriver, that.execDriver) &&
+        Objects.equals(this.processLabel, that.processLabel) &&
+        Objects.equals(this.mountLabel, that.mountLabel) &&
+        Objects.equals(this.volumes, that.volumes) &&
+        Objects.equals(this.volumesRW, that.volumesRW) &&
+        Objects.equals(this.appArmorProfile, that.appArmorProfile) &&
+        Objects.equals(this.execId, that.execId) &&
+        Objects.equals(this.logPath, that.logPath) &&
+        Objects.equals(this.restartCount, that.restartCount) &&
+        Objects.equals(this.mounts, that.mounts);
   }
 
   @Override
@@ -333,11 +274,12 @@ public class ContainerInfo {
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
-      final Node node = (Node) o;
-      return Objects.equals(id, node.id) &&
-             Objects.equals(ip, node.ip) &&
-             Objects.equals(addr, node.addr) &&
-             Objects.equals(name, node.name);
+      final Node that = (Node) o;
+
+      return Objects.equals(this.id, that.id) &&
+          Objects.equals(this.ip, that.ip) &&
+          Objects.equals(this.addr, that.addr) &&
+          Objects.equals(this.name, that.name);
     }
 
     @Override

--- a/src/main/java/com/spotify/docker/client/messages/ContainerMount.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerMount.java
@@ -19,7 +19,6 @@ package com.spotify.docker.client.messages;
 
 import com.google.common.base.MoreObjects;
 
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -64,14 +63,14 @@ public class ContainerMount {
     final ContainerMount that = (ContainerMount) o;
 
     return Objects.equals(this.source, that.source) &&
-           Objects.equals(this.destination, that.destination) &&
-           Objects.equals(this.mode, that.mode) &&
-           Objects.equals(this.rw, that.rw);
+        Objects.equals(this.destination, that.destination) &&
+        Objects.equals(this.mode, that.mode) &&
+        Objects.equals(this.rw, that.rw);
   }
 
   @Override
   public int hashCode() {
-    return java.util.Objects.hash(source, destination, mode, rw);
+    return Objects.hash(source, destination, mode, rw);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/ContainerState.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerState.java
@@ -88,35 +88,15 @@ public class ContainerState {
 
     final ContainerState that = (ContainerState) o;
 
-    if (exitCode != null ? !exitCode.equals(that.exitCode) : that.exitCode != null) {
-      return false;
-    }
-    if (finishedAt != null ? !finishedAt.equals(that.finishedAt) : that.finishedAt != null) {
-      return false;
-    }
-    if (pid != null ? !pid.equals(that.pid) : that.pid != null) {
-      return false;
-    }
-    if (running != null ? !running.equals(that.running) : that.running != null) {
-      return false;
-    }
-    if (paused != null ? !paused.equals(that.paused) : that.paused != null) {
-      return false;
-    }
-    if (restarting != null ? !restarting.equals(that.restarting) : that.restarting != null) {
-      return false;
-    }
-    if (startedAt != null ? !startedAt.equals(that.startedAt) : that.startedAt != null) {
-      return false;
-    }
-    if (error != null ? !error.equals(that.error) : that.error != null) {
-      return false;
-    }
-    if (oomKilled != null ? !oomKilled.equals(that.oomKilled) : that.oomKilled != null) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(this.running, that.running) &&
+        Objects.equals(this.paused, that.paused) &&
+        Objects.equals(this.restarting, that.restarting) &&
+        Objects.equals(this.pid, that.pid) &&
+        Objects.equals(this.exitCode, that.exitCode) &&
+        Objects.equals(this.startedAt, that.startedAt) &&
+        Objects.equals(this.finishedAt, that.finishedAt) &&
+        Objects.equals(this.error, that.error) &&
+        Objects.equals(this.oomKilled, that.oomKilled);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/ContainerStats.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerStats.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
+import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
@@ -68,81 +69,29 @@ public class ContainerStats {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + (cpuStats == null ? 0 : cpuStats.hashCode());
-    result = prime * result + (memoryStats == null ? 0 : memoryStats.hashCode());
-    result = prime * result + (network == null ? 0 : network.hashCode());
-    result = prime * result + (networks == null ? 0 : networks.hashCode());
-    result = prime * result + (blockIoStats == null ? 0 : blockIoStats.hashCode());
-    result = prime * result + (precpuStats == null ? 0 : precpuStats.hashCode());
-    result = prime * result + (read == null ? 0 : read.hashCode());
-    return result;
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final ContainerStats that = (ContainerStats) o;
+
+    return Objects.equals(this.read, that.read) &&
+        Objects.equals(this.network, that.network) &&
+        Objects.equals(this.networks, that.networks) &&
+        Objects.equals(this.memoryStats, that.memoryStats) &&
+        Objects.equals(this.blockIoStats, that.blockIoStats) &&
+        Objects.equals(this.cpuStats, that.cpuStats) &&
+        Objects.equals(this.precpuStats, that.precpuStats);
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    final ContainerStats other = (ContainerStats) obj;
-    if (cpuStats == null) {
-      if (other.cpuStats != null) {
-        return false;
-      }
-    } else if (!cpuStats.equals(other.cpuStats)) {
-      return false;
-    }
-    if (memoryStats == null) {
-      if (other.memoryStats != null) {
-        return false;
-      }
-    } else if (!memoryStats.equals(other.memoryStats)) {
-      return false;
-    }
-    if (network == null) {
-      if (other.network != null) {
-        return false;
-      }
-    } else if (!network.equals(other.network)) {
-      return false;
-    }
-    if (networks == null) {
-      if (other.networks != null) {
-        return false;
-      }
-    } else if (!networks.equals(other.networks)) {
-      return false;
-    }
-    if (blockIoStats == null) {
-      if (other.blockIoStats != null) {
-        return false;
-      }
-    } else if (!blockIoStats.equals(other.blockIoStats)) {
-      return false;
-    }
-    if (precpuStats == null) {
-      if (other.precpuStats != null) {
-        return false;
-      }
-    } else if (!precpuStats.equals(other.precpuStats)) {
-      return false;
-    }
-    if (read == null) {
-      if (other.read != null) {
-        return false;
-      }
-    } else if (!read.equals(other.read)) {
-      return false;
-    }
-    return true;
+  public int hashCode() {
+    return Objects.hash(cpuStats, memoryStats, network, networks,
+        blockIoStats, precpuStats, read);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/CpuStats.java
+++ b/src/main/java/com/spotify/docker/client/messages/CpuStats.java
@@ -22,6 +22,8 @@ import com.google.common.base.MoreObjects;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
@@ -40,41 +42,23 @@ public class CpuStats {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + (cpuUsage == null ? 0 : cpuUsage.hashCode());
-    result = prime * result + (systemCpuUsage == null ? 0 : systemCpuUsage.hashCode());
-    return result;
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final CpuStats that = (CpuStats) o;
+
+    return Objects.equals(this.cpuUsage, that.cpuUsage) &&
+        Objects.equals(this.systemCpuUsage, that.systemCpuUsage);
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    final CpuStats other = (CpuStats) obj;
-    if (cpuUsage == null) {
-      if (other.cpuUsage != null) {
-        return false;
-      }
-    } else if (!cpuUsage.equals(other.cpuUsage)) {
-      return false;
-    }
-    if (systemCpuUsage == null) {
-      if (other.systemCpuUsage != null) {
-        return false;
-      }
-    } else if (!systemCpuUsage.equals(other.systemCpuUsage)) {
-      return false;
-    }
-    return true;
+  public int hashCode() {
+    return Objects.hash(cpuUsage, systemCpuUsage);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/CpuUsage.java
+++ b/src/main/java/com/spotify/docker/client/messages/CpuUsage.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableList;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
@@ -51,57 +53,25 @@ public class CpuUsage {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + (percpuUsage == null ? 0 : percpuUsage.hashCode());
-    result = prime * result + (totalUsage == null ? 0 : totalUsage.hashCode());
-    result = prime * result + (usageInKernelmode == null ? 0 : usageInKernelmode.hashCode());
-    result = prime * result + (usageInUsermode == null ? 0 : usageInUsermode.hashCode());
-    return result;
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final CpuUsage that = (CpuUsage) o;
+
+    return Objects.equals(this.totalUsage, that.totalUsage) &&
+        Objects.equals(this.percpuUsage, that.percpuUsage) &&
+        Objects.equals(this.usageInKernelmode, that.usageInKernelmode) &&
+        Objects.equals(this.usageInUsermode, that.usageInUsermode);
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    final CpuUsage other = (CpuUsage) obj;
-    if (percpuUsage == null) {
-      if (other.percpuUsage != null) {
-        return false;
-      }
-    } else if (!percpuUsage.equals(other.percpuUsage)) {
-      return false;
-    }
-    if (totalUsage == null) {
-      if (other.totalUsage != null) {
-        return false;
-      }
-    } else if (!totalUsage.equals(other.totalUsage)) {
-      return false;
-    }
-    if (usageInKernelmode == null) {
-      if (other.usageInKernelmode != null) {
-        return false;
-      }
-    } else if (!usageInKernelmode.equals(other.usageInKernelmode)) {
-      return false;
-    }
-    if (usageInUsermode == null) {
-      if (other.usageInUsermode != null) {
-        return false;
-      }
-    } else if (!usageInUsermode.equals(other.usageInUsermode)) {
-      return false;
-    }
-    return true;
+  public int hashCode() {
+    return Objects.hash(totalUsage, percpuUsage, usageInKernelmode, usageInUsermode);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/Device.java
+++ b/src/main/java/com/spotify/docker/client/messages/Device.java
@@ -24,72 +24,59 @@ import com.google.common.base.MoreObjects;
 import java.util.Objects;
 
 public class Device {
+  @JsonProperty("PathOnHost") private String pathOnHost;
+  @JsonProperty("PathInContainer") private String pathInContainer;
+  @JsonProperty("CgroupPermissions") private String cGroupPermissions;
 
-    @JsonProperty("PathOnHost") private String pathOnHost;
-    @JsonProperty("PathInContainer") private String pathInContainer;
-    @JsonProperty("CgroupPermissions") private String cGroupPermissions;
+  public Device() {
+  }
 
-    public Device() {
-    }
+  public Device(final String pathOnHost, final String pathInContainer,
+                final String cGroupPermissions) {
+    this.pathOnHost = pathOnHost;
+    this.pathInContainer = pathInContainer;
+    this.cGroupPermissions = cGroupPermissions;
+  }
 
-    public Device(final String pathOnHost, final String pathInContainer,
-                  final String cGroupPermissions) {
-        this.pathOnHost = pathOnHost;
-        this.pathInContainer = pathInContainer;
-        this.cGroupPermissions = cGroupPermissions;
-    }
-
-    public String pathOnHost() {
+  public String pathOnHost() {
         return pathOnHost;
     }
 
-    public String pathInContainer() {
+  public String pathInContainer() {
         return pathInContainer;
     }
 
-    public String cGroupPermissions() {
+  public String cGroupPermissions() {
         return cGroupPermissions;
     }
 
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        final Device that = (Device) o;
-
-        if (pathOnHost != null ? !pathOnHost.equals(that.pathOnHost) : that.pathOnHost != null) {
-            return false;
-        }
-        if (pathInContainer != null ?
-                !pathInContainer.equals(that.pathInContainer) : that.pathInContainer != null) {
-            return false;
-        }
-        if (cGroupPermissions != null ?
-                !cGroupPermissions.equals(that.cGroupPermissions) : 
-                that.cGroupPermissions != null) {
-            return false;
-        }
-
-        return true;
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
     }
 
-    @Override
-    public int hashCode() {
+    final Device that = (Device) o;
+
+    return Objects.equals(this.pathOnHost, that.pathOnHost) &&
+        Objects.equals(this.pathInContainer, that.pathInContainer) &&
+        Objects.equals(this.cGroupPermissions, that.cGroupPermissions);
+  }
+
+  @Override
+  public int hashCode() {
         return Objects.hash(pathOnHost, pathInContainer, cGroupPermissions);
     }
 
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("pathOnHost", pathOnHost)
-                .add("pathInContainer", pathInContainer)
-                .add("cGroupPermissions", cGroupPermissions)
-                .toString();
-    }
-
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("pathOnHost", pathOnHost)
+        .add("pathInContainer", pathInContainer)
+        .add("cGroupPermissions", cGroupPermissions)
+        .toString();
+  }
 }

--- a/src/main/java/com/spotify/docker/client/messages/Event.java
+++ b/src/main/java/com/spotify/docker/client/messages/Event.java
@@ -19,11 +19,14 @@ package com.spotify.docker.client.messages;
 
 import com.spotify.docker.client.jackson.UnixTimestampDeserializer;
 
+import com.google.common.base.MoreObjects;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.Date;
+import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
@@ -56,12 +59,35 @@ public class Event {
   }
 
   @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final Event that = (Event) o;
+
+    return Objects.equals(this.status, that.status) &&
+        Objects.equals(this.id, that.id) &&
+        Objects.equals(this.from, that.from) &&
+        Objects.equals(this.time, that.time);
+
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(status, id, from, time);
+  }
+
+  @Override
   public String toString() {
-    return "Event{" +
-           "status='" + status + '\'' +
-           ", id='" + id + '\'' +
-           ", from='" + from + '\'' +
-           ", time=" + time +
-           '}';
+    return MoreObjects.toStringHelper(this)
+        .add("status", status)
+        .add("id", id)
+        .add("from", from)
+        .add("time", time)
+        .toString();
   }
 }

--- a/src/main/java/com/spotify/docker/client/messages/ExecState.java
+++ b/src/main/java/com/spotify/docker/client/messages/ExecState.java
@@ -91,32 +91,15 @@ public class ExecState {
 
     final ExecState that = (ExecState) o;
 
-    if (id != null ? !id.equals(that.id) : that.id != null) {
-      return false;
-    }
-    if (running != null ? !running.equals(that.running) : that.running != null) {
-      return false;
-    }
-    if (exitCode != null ? !exitCode.equals(that.exitCode) : that.exitCode != null) {
-      return false;
-    }
-    if (processConfig != null ? !processConfig.equals(that.processConfig)
-                              : that.processConfig != null) {
-      return false;
-    }
-    if (openStdin != null ? !openStdin.equals(that.openStdin) : that.openStdin != null) {
-      return false;
-    }
-    if (openStderr != null ? !openStderr.equals(that.openStderr) : that.openStderr != null) {
-      return false;
-    }
-    if (openStdout != null ? !openStdout.equals(that.openStdout) : that.openStdout != null) {
-      return false;
-    }
-    if (container != null ? !container.equals(that.container) : that.container != null) {
-      return false;
-    }
-    return containerID != null ? containerID.equals(that.containerID) : that.containerID == null;
+    return Objects.equals(this.id, that.id) &&
+        Objects.equals(this.running, that.running) &&
+        Objects.equals(this.exitCode, that.exitCode) &&
+        Objects.equals(this.processConfig, that.processConfig) &&
+        Objects.equals(this.openStdin, that.openStdin) &&
+        Objects.equals(this.openStderr, that.openStderr) &&
+        Objects.equals(this.openStdout, that.openStdout) &&
+        Objects.equals(this.container, that.container) &&
+        Objects.equals(this.containerID, that.containerID);
 
   }
 

--- a/src/main/java/com/spotify/docker/client/messages/HostConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/HostConfig.java
@@ -204,98 +204,31 @@ public class HostConfig {
 
     final HostConfig that = (HostConfig) o;
 
-    if (binds != null ? !binds.equals(that.binds) : that.binds != null) {
-      return false;
-    }
-    if (containerIDFile != null ? !containerIDFile.equals(that.containerIDFile)
-                                : that.containerIDFile != null) {
-      return false;
-    }
-    if (dns != null ? !dns.equals(that.dns) : that.dns != null) {
-      return false;
-    }
-    if (dnsSearch != null ? !dnsSearch.equals(that.dnsSearch) : that.dnsSearch != null) {
-      return false;
-    }
-    if (extraHosts != null ? !extraHosts.equals(that.extraHosts) : that.extraHosts != null) {
-      return false;
-    }
-    if (links != null ? !links.equals(that.links) : that.links != null) {
-      return false;
-    }
-    if (lxcConf != null ? !lxcConf.equals(that.lxcConf) : that.lxcConf != null) {
-      return false;
-    }
-    if (networkMode != null ? !networkMode.equals(that.networkMode) : that.networkMode != null) {
-      return false;
-    }
-    if (portBindings != null ? !portBindings.equals(that.portBindings)
-                             : that.portBindings != null) {
-      return false;
-    }
-    if (privileged != null ? !privileged.equals(that.privileged) : that.privileged != null) {
-      return false;
-    }
-    if (publishAllPorts != null ? !publishAllPorts.equals(that.publishAllPorts)
-                                : that.publishAllPorts != null) {
-      return false;
-    }
-    if (volumesFrom != null ? !volumesFrom.equals(that.volumesFrom) : that.volumesFrom != null) {
-      return false;
-    }
-    if (capAdd != null ? !capAdd.equals(that.capAdd) : that.capAdd != null) {
-      return false;
-    }
-    if (capDrop != null ? !capDrop.equals(that.capDrop) : that.capDrop != null) {
-      return false;
-    }
-    if (securityOpt != null ? !securityOpt.equals(that.securityOpt) : that.securityOpt != null) {
-      return false;
-    }
-    if (devices != null ? !devices.equals(that.devices) : that.devices != null) {
-      return false;
-    }
-
-    if (memory != null ? !memory.equals(that.memory) : that.memory != null) {
-      return false;
-    }
-
-    if (memorySwap != null ? !memorySwap.equals(that.memorySwap) : that.memorySwap != null) {
-      return false;
-    }
-
-    if (cpuShares != null ? !cpuShares.equals(that.cpuShares) : that.cpuShares != null) {
-      return false;
-    }
-
-    if (cpusetCpus != null ? !cpusetCpus.equals(that.cpusetCpus) : that.cpusetCpus != null) {
-      return false;
-    }
-
-    if (cpuQuota != null ? !cpuQuota.equals(that.cpuQuota) : that.cpuQuota != null) {
-      return false;
-    }
-
-    if (cgroupParent != null ? !cgroupParent.equals(that.cgroupParent)
-                             : that.cgroupParent != null) {
-      return false;
-    }
-
-    if (restartPolicy != null ? !restartPolicy.equals(that.restartPolicy)
-                              : that.restartPolicy != null) {
-      return false;
-    }
-
-    if (logConfig != null ? !logConfig.equals(that.logConfig) : that.logConfig != null) {
-      return false;
-    }
-
-    if (ipcMode != null ? !ipcMode.equals(that.ipcMode)
-            : that.ipcMode != null) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(this.binds, that.binds) &&
+        Objects.equals(this.containerIDFile, that.containerIDFile) &&
+        Objects.equals(this.lxcConf, that.lxcConf) &&
+        Objects.equals(this.privileged, that.privileged) &&
+        Objects.equals(this.portBindings, that.portBindings) &&
+        Objects.equals(this.links, that.links) &&
+        Objects.equals(this.publishAllPorts, that.publishAllPorts) &&
+        Objects.equals(this.dns, that.dns) &&
+        Objects.equals(this.dnsSearch, that.dnsSearch) &&
+        Objects.equals(this.extraHosts, that.extraHosts) &&
+        Objects.equals(this.volumesFrom, that.volumesFrom) &&
+        Objects.equals(this.capAdd, that.capAdd) &&
+        Objects.equals(this.capDrop, that.capDrop) &&
+        Objects.equals(this.networkMode, that.networkMode) &&
+        Objects.equals(this.securityOpt, that.securityOpt) &&
+        Objects.equals(this.devices, that.devices) &&
+        Objects.equals(this.memory, that.memory) &&
+        Objects.equals(this.memorySwap, that.memorySwap) &&
+        Objects.equals(this.cpuShares, that.cpuShares) &&
+        Objects.equals(this.cpusetCpus, that.cpusetCpus) &&
+        Objects.equals(this.cpuQuota, that.cpuQuota) &&
+        Objects.equals(this.cgroupParent, that.cgroupParent) &&
+        Objects.equals(this.restartPolicy, that.restartPolicy) &&
+        Objects.equals(this.logConfig, that.logConfig) &&
+        Objects.equals(this.ipcMode, that.ipcMode);
   }
 
   @Override
@@ -367,14 +300,8 @@ public class HostConfig {
 
       final LxcConfParameter that = (LxcConfParameter) o;
 
-      if (key != null ? !key.equals(that.key) : that.key != null) {
-        return false;
-      }
-      if (value != null ? !value.equals(that.value) : that.value != null) {
-        return false;
-      }
-
-      return true;
+      return Objects.equals(this.key, that.key) &&
+          Objects.equals(this.value, that.value);
     }
 
     @Override
@@ -436,11 +363,8 @@ public class HostConfig {
 
       final RestartPolicy that = (RestartPolicy) o;
 
-      if (name != null ? !name.equals(that.name) : that.name != null) {
-        return false;
-      }
-      return maxRetryCount != null ?
-             maxRetryCount.equals(that.maxRetryCount) : that.maxRetryCount == null;
+      return Objects.equals(this.name, that.name) &&
+          Objects.equals(this.maxRetryCount, that.maxRetryCount);
     }
 
     @Override

--- a/src/main/java/com/spotify/docker/client/messages/Image.java
+++ b/src/main/java/com/spotify/docker/client/messages/Image.java
@@ -82,12 +82,12 @@ public class Image {
     final Image that = (Image) o;
 
     return Objects.equals(this.created, that.created) &&
-           Objects.equals(this.id, that.id) &&
-           Objects.equals(this.parentId, that.parentId) &&
-           Objects.equals(this.repoTags, that.repoTags) &&
-           Objects.equals(this.size, that.size) &&
-           Objects.equals(this.virtualSize, that.virtualSize) &&
-           Objects.equals(this.labels, that.labels);
+        Objects.equals(this.id, that.id) &&
+        Objects.equals(this.parentId, that.parentId) &&
+        Objects.equals(this.repoTags, that.repoTags) &&
+        Objects.equals(this.size, that.size) &&
+        Objects.equals(this.virtualSize, that.virtualSize) &&
+        Objects.equals(this.labels, that.labels);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/ImageInfo.java
+++ b/src/main/java/com/spotify/docker/client/messages/ImageInfo.java
@@ -106,53 +106,21 @@ public class ImageInfo {
       return false;
     }
 
-    final ImageInfo imageInfo = (ImageInfo) o;
+    final ImageInfo that = (ImageInfo) o;
 
-    if (architecture != null ? !architecture.equals(imageInfo.architecture)
-                             : imageInfo.architecture != null) {
-      return false;
-    }
-    if (author != null ? !author.equals(imageInfo.author) : imageInfo.author != null) {
-      return false;
-    }
-    if (comment != null ? !comment.equals(imageInfo.comment) : imageInfo.comment != null) {
-      return false;
-    }
-    if (config != null ? !config.equals(imageInfo.config) : imageInfo.config != null) {
-      return false;
-    }
-    if (container != null ? !container.equals(imageInfo.container) : imageInfo.container != null) {
-      return false;
-    }
-    if (containerConfig != null ? !containerConfig.equals(imageInfo.containerConfig)
-                                : imageInfo.containerConfig != null) {
-      return false;
-    }
-    if (created != null ? !created.equals(imageInfo.created) : imageInfo.created != null) {
-      return false;
-    }
-    if (dockerVersion != null ? !dockerVersion.equals(imageInfo.dockerVersion)
-                              : imageInfo.dockerVersion != null) {
-      return false;
-    }
-    if (id != null ? !id.equals(imageInfo.id) : imageInfo.id != null) {
-      return false;
-    }
-    if (os != null ? !os.equals(imageInfo.os) : imageInfo.os != null) {
-      return false;
-    }
-    if (parent != null ? !parent.equals(imageInfo.parent) : imageInfo.parent != null) {
-      return false;
-    }
-    if (size != null ? !size.equals(imageInfo.size) : imageInfo.size != null) {
-      return false;
-    }
-    if (virtualSize != null ? !virtualSize.equals(imageInfo.virtualSize)
-                            : imageInfo.virtualSize != null) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(this.id, that.id) &&
+        Objects.equals(this.parent, that.parent) &&
+        Objects.equals(this.comment, that.comment) &&
+        Objects.equals(this.created, that.created) &&
+        Objects.equals(this.container, that.container) &&
+        Objects.equals(this.containerConfig, that.containerConfig) &&
+        Objects.equals(this.dockerVersion, that.dockerVersion) &&
+        Objects.equals(this.author, that.author) &&
+        Objects.equals(this.config, that.config) &&
+        Objects.equals(this.architecture, that.architecture) &&
+        Objects.equals(this.os, that.os) &&
+        Objects.equals(this.size, that.size) &&
+        Objects.equals(this.virtualSize, that.virtualSize);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/ImageSearchResult.java
+++ b/src/main/java/com/spotify/docker/client/messages/ImageSearchResult.java
@@ -22,6 +22,8 @@ import com.google.common.base.MoreObjects;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
@@ -73,53 +75,26 @@ public class ImageSearchResult {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + (automated ? 1231 : 1237);
-    result = prime * result + ((description == null) ? 0 : description.hashCode());
-    result = prime * result + ((name == null) ? 0 : name.hashCode());
-    result = prime * result + (official ? 1231 : 1237);
-    result = prime * result + starCount;
-    return result;
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final ImageSearchResult that = (ImageSearchResult) o;
+
+    return Objects.equals(this.description, that.description) &&
+        Objects.equals(this.official, that.official) &&
+        Objects.equals(this.automated, that.automated) &&
+        Objects.equals(this.name, that.name) &&
+        Objects.equals(this.starCount, that.starCount);
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    final ImageSearchResult other = (ImageSearchResult) obj;
-    if (automated != other.automated) {
-      return false;
-    }
-    if (description == null) {
-      if (other.description != null) {
-        return false;
-      }
-    } else if (!description.equals(other.description)) {
-      return false;
-    }
-    if (name == null) {
-      if (other.name != null) {
-        return false;
-      }
-    } else if (!name.equals(other.name)) {
-      return false;
-    }
-    if (official != other.official) {
-      return false;
-    }
-    if (starCount != other.starCount) {
-      return false;
-    }
-    return true;
+  public int hashCode() {
+    return Objects.hash(description, official, automated, name, starCount);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/Info.java
+++ b/src/main/java/com/spotify/docker/client/messages/Info.java
@@ -156,52 +156,32 @@ public class Info {
       return false;
     }
 
-    final Info info = (Info) o;
+    final Info that = (Info) o;
 
-    if (containers != info.containers) {
-      return false;
-    }
-    if (debug != null ? !debug.equals(info.debug)
-                      : info.debug != null) {
-      return false;
-    }
-    if (eventsListener != info.eventsListener) {
-      return false;
-    }
-    if (fileDescriptors != info.fileDescriptors) {
-      return false;
-    }
-    if (goroutines != info.goroutines) {
-      return false;
-    }
-    if (images != info.images) {
-      return false;
-    }
-    if (executionDriver != null ? !executionDriver.equals(info.executionDriver)
-                                : info.executionDriver != null) {
-      return false;
-    }
-    if (initPath != null ? !initPath.equals(info.initPath) : info.initPath != null) {
-      return false;
-    }
-    if (kernelVersion != null ? !kernelVersion.equals(info.kernelVersion)
-                              : info.kernelVersion != null) {
-      return false;
-    }
-    if (storageDriver != null ? !storageDriver.equals(info.storageDriver)
-                              : info.storageDriver != null) {
-      return false;
-    }
-    if (memoryLimit != null ? !memoryLimit.equals(info.memoryLimit)
-                            : info.memoryLimit != null) {
-      return false;
-    }
-    if (swapLimit != null ? !swapLimit.equals(info.swapLimit)
-                          : info.swapLimit != null) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(this.containers, that.containers) &&
+        Objects.equals(this.images, that.images) &&
+        Objects.equals(this.storageDriver, that.storageDriver) &&
+        Objects.equals(this.driverStatus, that.driverStatus) &&
+        Objects.equals(this.systemStatus, that.systemStatus) &&
+        Objects.equals(this.executionDriver, that.executionDriver) &&
+        Objects.equals(this.kernelVersion, that.kernelVersion) &&
+        Objects.equals(this.cpus, that.cpus) &&
+        Objects.equals(this.memTotal, that.memTotal) &&
+        Objects.equals(this.name, that.name) &&
+        Objects.equals(this.id, that.id) &&
+        Objects.equals(this.operatingSystem, that.operatingSystem) &&
+        Objects.equals(this.debug, that.debug) &&
+        Objects.equals(this.fileDescriptors, that.fileDescriptors) &&
+        Objects.equals(this.goroutines, that.goroutines) &&
+        Objects.equals(this.eventsListener, that.eventsListener) &&
+        Objects.equals(this.initPath, that.initPath) &&
+        Objects.equals(this.initSha1, that.initSha1) &&
+        Objects.equals(this.indexServerAddress, that.indexServerAddress) &&
+        Objects.equals(this.memoryLimit, that.memoryLimit) &&
+        Objects.equals(this.swapLimit, that.swapLimit) &&
+        Objects.equals(this.ipv4Forwarding, that.ipv4Forwarding) &&
+        Objects.equals(this.labels, that.labels) &&
+        Objects.equals(this.dockerRootDir, that.dockerRootDir);
   }
 
   @Override
@@ -214,14 +194,26 @@ public class Info {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("containers", containers).add("images", images)
-        .add("storageDriver", storageDriver).add("driverStatus", driverStatus)
-        .add("systemStatus", systemStatus).add("cpus", cpus).add("memTotal", memTotal)
-        .add("name", name).add("executionDriver", executionDriver)
-        .add("kernelVersion", kernelVersion).add("debug", debug)
-        .add("fileDescriptors", fileDescriptors).add("goroutines", goroutines)
-        .add("eventsListener", eventsListener).add("initPath", initPath).add("initSha1", initSha1)
-        .add("indexServerAddress", indexServerAddress).add("memoryLimit", memoryLimit)
-        .add("swapLimit", swapLimit).toString();
+    return MoreObjects.toStringHelper(this)
+        .add("containers", containers)
+        .add("images", images)
+        .add("storageDriver", storageDriver)
+        .add("driverStatus", driverStatus)
+        .add("systemStatus", systemStatus)
+        .add("cpus", cpus)
+        .add("memTotal", memTotal)
+        .add("name", name)
+        .add("executionDriver", executionDriver)
+        .add("kernelVersion", kernelVersion)
+        .add("debug", debug)
+        .add("fileDescriptors", fileDescriptors)
+        .add("goroutines", goroutines)
+        .add("eventsListener", eventsListener)
+        .add("initPath", initPath)
+        .add("initSha1", initSha1)
+        .add("indexServerAddress", indexServerAddress)
+        .add("memoryLimit", memoryLimit)
+        .add("swapLimit", swapLimit)
+        .toString();
   }
 }

--- a/src/main/java/com/spotify/docker/client/messages/Ipam.java
+++ b/src/main/java/com/spotify/docker/client/messages/Ipam.java
@@ -63,7 +63,8 @@ public class Ipam {
 
     final Ipam that = (Ipam) o;
 
-    return Objects.equals(this.driver, that.driver) && Objects.equals(this.config, that.config);
+    return Objects.equals(this.driver, that.driver) &&
+        Objects.equals(this.config, that.config);
   }
 
   @Override
@@ -73,14 +74,15 @@ public class Ipam {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("driver", driver).add("config", config).toString();
+    return MoreObjects.toStringHelper(this)
+        .add("driver", driver)
+        .add("config", config)
+        .toString();
   }
-
 
   public static Builder builder() {
     return new Builder();
   }
-
 
   public static class Builder {
 

--- a/src/main/java/com/spotify/docker/client/messages/IpamConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/IpamConfig.java
@@ -70,8 +70,8 @@ public class IpamConfig {
     final IpamConfig that = (IpamConfig) o;
 
     return Objects.equals(this.subnet, that.subnet) &&
-           Objects.equals(this.ipRange, that.ipRange) &&
-           Objects.equals(this.gateway, that.gateway);
+         Objects.equals(this.ipRange, that.ipRange) &&
+         Objects.equals(this.gateway, that.gateway);
   }
 
   @Override
@@ -81,8 +81,11 @@ public class IpamConfig {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("subnet", subnet).add("ipRange", ipRange)
-        .add("gateway", gateway).toString();
+    return MoreObjects.toStringHelper(this)
+        .add("subnet", subnet)
+        .add("ipRange", ipRange)
+        .add("gateway", gateway)
+        .toString();
   }
 
 }

--- a/src/main/java/com/spotify/docker/client/messages/LogConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/LogConfig.java
@@ -72,14 +72,8 @@ public class LogConfig {
 
     final LogConfig that = (LogConfig) o;
 
-    if (logType != null ? !logType.equals(that.logType) : that.logType != null) {
-      return false;
-    }
-    if (logOptions != null ? !logOptions.equals(that.logOptions) : that.logOptions != null) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(this.logType, that.logType) &&
+        Objects.equals(this.logOptions, that.logOptions);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/MemoryStats.java
+++ b/src/main/java/com/spotify/docker/client/messages/MemoryStats.java
@@ -22,6 +22,8 @@ import com.google.common.base.MoreObjects;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
@@ -50,57 +52,25 @@ public class MemoryStats {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + (failcnt == null ? 0 : failcnt.hashCode());
-    result = prime * result + (limit == null ? 0 : limit.hashCode());
-    result = prime * result + (maxUsage == null ? 0 : maxUsage.hashCode());
-    result = prime * result + (usage == null ? 0 : usage.hashCode());
-    return result;
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final MemoryStats that = (MemoryStats) o;
+
+    return Objects.equals(this.maxUsage, that.maxUsage) &&
+        Objects.equals(this.usage, that.usage) &&
+        Objects.equals(this.failcnt, that.failcnt) &&
+        Objects.equals(this.limit, that.limit);
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    final MemoryStats other = (MemoryStats) obj;
-    if (failcnt == null) {
-      if (other.failcnt != null) {
-        return false;
-      }
-    } else if (!failcnt.equals(other.failcnt)) {
-      return false;
-    }
-    if (limit == null) {
-      if (other.limit != null) {
-        return false;
-      }
-    } else if (!limit.equals(other.limit)) {
-      return false;
-    }
-    if (maxUsage == null) {
-      if (other.maxUsage != null) {
-        return false;
-      }
-    } else if (!maxUsage.equals(other.maxUsage)) {
-      return false;
-    }
-    if (usage == null) {
-      if (other.usage != null) {
-        return false;
-      }
-    } else if (!usage.equals(other.usage)) {
-      return false;
-    }
-    return true;
+  public int hashCode() {
+    return Objects.hash(maxUsage, usage, failcnt, limit);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/Network.java
+++ b/src/main/java/com/spotify/docker/client/messages/Network.java
@@ -31,31 +31,6 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 public class Network {
 
-  @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
-  public static class Container {
-
-    @JsonProperty("EndpointID") private String endpointId;
-    @JsonProperty("MacAddress") private String macAddress;
-    @JsonProperty("IPv4Address") private String ipv4address;
-    @JsonProperty("IPv6Address") private String ipv6address;
-
-    public String endpointId() {
-      return endpointId;
-    }
-
-    public String macAddress() {
-      return macAddress;
-    }
-
-    public String ipv4address() {
-      return ipv4address;
-    }
-
-    public String ipv6address() {
-      return ipv6address;
-    }
-  }
-
   @JsonProperty("Name") private String name;
   @JsonProperty("Id") private String id;
   @JsonProperty("Scope") private String scope;
@@ -104,21 +79,85 @@ public class Network {
     final Network that = (Network) o;
 
     return Objects.equals(this.name, that.name) &&
-           Objects.equals(this.id, that.id) &&
-           Objects.equals(this.scope, that.scope) &&
-           Objects.equals(this.driver, that.driver) &&
-           Objects.equals(this.options, that.options);
+        Objects.equals(this.id, that.id) &&
+        Objects.equals(this.scope, that.scope) &&
+        Objects.equals(this.driver, that.driver) &&
+        Objects.equals(this.ipam, that.ipam) &&
+        Objects.equals(this.containers, that.containers) &&
+        Objects.equals(this.options, that.options);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, id, scope, driver, options);
+    return Objects.hash(name, id, scope, driver, ipam, containers, options);
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("name", name).add("id", id).add("scope", scope)
-        .add("driver", driver).add("options", options).toString();
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .add("id", id)
+        .add("scope", scope)
+        .add("driver", driver)
+        .add("ipam", ipam)
+        .add("containers", containers)
+        .add("options", options)
+        .toString();
   }
 
+  @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+  public static class Container {
+    @JsonProperty("EndpointID") private String endpointId;
+    @JsonProperty("MacAddress") private String macAddress;
+    @JsonProperty("IPv4Address") private String ipv4address;
+    @JsonProperty("IPv6Address") private String ipv6address;
+
+    public String endpointId() {
+      return endpointId;
+    }
+
+    public String macAddress() {
+      return macAddress;
+    }
+
+    public String ipv4address() {
+      return ipv4address;
+    }
+
+    public String ipv6address() {
+      return ipv6address;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final Container that = (Container) o;
+
+      return Objects.equals(this.endpointId, that.endpointId) &&
+          Objects.equals(this.macAddress, that.macAddress) &&
+          Objects.equals(this.ipv4address, that.ipv4address) &&
+          Objects.equals(this.ipv6address, that.ipv6address);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(endpointId, macAddress, ipv4address, ipv6address);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("endpointId", endpointId)
+          .add("macAddress", macAddress)
+          .add("ipv4address", ipv4address)
+          .add("ipv6address", ipv6address)
+          .toString();
+    }
+  }
 }

--- a/src/main/java/com/spotify/docker/client/messages/NetworkConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkConfig.java
@@ -73,20 +73,11 @@ public class NetworkConfig {
 
     final NetworkConfig that = (NetworkConfig) o;
 
-    if (checkDuplicate != that.checkDuplicate) {
-      return false;
-    }
-    if (!name.equals(that.name)) {
-      return false;
-    }
-    if (driver != null ? !driver.equals(that.driver) : that.driver != null) {
-      return false;
-    }
-    if (ipam != null ? !ipam.equals(that.ipam) : that.ipam != null) {
-      return false;
-    }
-    return !(options != null ? !options.equals(that.options) : that.options != null);
-
+    return Objects.equals(this.checkDuplicate, that.checkDuplicate) &&
+        Objects.equals(this.name, that.name) &&
+        Objects.equals(this.driver, that.driver) &&
+        Objects.equals(this.ipam, that.ipam) &&
+        Objects.equals(this.options, that.options);
   }
 
   @Override
@@ -101,9 +92,13 @@ public class NetworkConfig {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("name", name).add("driver", driver)
-        .add("options", options).add("checkDuplicate", checkDuplicate)
-        .add("ipam", ipam).toString();
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .add("driver", driver)
+        .add("options", options)
+        .add("checkDuplicate", checkDuplicate)
+        .add("ipam", ipam)
+        .toString();
   }
 
   public static class Builder {

--- a/src/main/java/com/spotify/docker/client/messages/NetworkCreation.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkCreation.java
@@ -52,14 +52,8 @@ public class NetworkCreation {
 
     final NetworkCreation that = (NetworkCreation) o;
 
-    if (id != null ? !id.equals(that.id) : that.id != null) {
-      return false;
-    }
-    if (warnings != null ? !warnings.equals(that.warnings) : that.warnings != null) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(this.id, that.id) &&
+        Objects.equals(this.warnings, that.warnings);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
@@ -102,32 +102,14 @@ public class NetworkSettings {
 
     final NetworkSettings that = (NetworkSettings) o;
 
-    if (bridge != null ? !bridge.equals(that.bridge) : that.bridge != null) {
-      return false;
-    }
-    if (gateway != null ? !gateway.equals(that.gateway) : that.gateway != null) {
-      return false;
-    }
-    if (ipAddress != null ? !ipAddress.equals(that.ipAddress) : that.ipAddress != null) {
-      return false;
-    }
-    if (ipPrefixLen != null ? !ipPrefixLen.equals(that.ipPrefixLen) : that.ipPrefixLen != null) {
-      return false;
-    }
-    if (portMapping != null ? !portMapping.equals(that.portMapping) : that.portMapping != null) {
-      return false;
-    }
-    if (ports != null ? !ports.equals(that.ports) : that.ports != null) {
-      return false;
-    }
-    if (macAddress != null ? !macAddress.equals(that.macAddress) : that.macAddress != null) {
-      return false;
-    }
-    if (networks != null ? !networks.equals(that.networks) : that.networks != null) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(this.ipAddress, that.ipAddress) &&
+        Objects.equals(this.ipPrefixLen, that.ipPrefixLen) &&
+        Objects.equals(this.gateway, that.gateway) &&
+        Objects.equals(this.bridge, that.bridge) &&
+        Objects.equals(this.portMapping, that.portMapping) &&
+        Objects.equals(this.ports, that.ports) &&
+        Objects.equals(this.macAddress, that.macAddress) &&
+        Objects.equals(this.networks, that.networks);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/NetworkStats.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkStats.java
@@ -22,6 +22,8 @@ import com.google.common.base.MoreObjects;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
@@ -70,89 +72,30 @@ public class NetworkStats {
   }
 
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + (rxBytes == null ? 0 : rxBytes.hashCode());
-    result = prime * result + (rxDropped == null ? 0 : rxDropped.hashCode());
-    result = prime * result + (rxErrors == null ? 0 : rxErrors.hashCode());
-    result = prime * result + (rxPackets == null ? 0 : rxPackets.hashCode());
-    result = prime * result + (txBytes == null ? 0 : txBytes.hashCode());
-    result = prime * result + (txDropped == null ? 0 : txDropped.hashCode());
-    result = prime * result + (txErrors == null ? 0 : txErrors.hashCode());
-    result = prime * result + (txPackets == null ? 0 : txPackets.hashCode());
-    return result;
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final NetworkStats that = (NetworkStats) o;
+
+    return Objects.equals(this.rxBytes, that.rxBytes) &&
+        Objects.equals(this.rxPackets, that.rxPackets) &&
+        Objects.equals(this.rxDropped, that.rxDropped) &&
+        Objects.equals(this.rxErrors, that.rxErrors) &&
+        Objects.equals(this.txBytes, that.txBytes) &&
+        Objects.equals(this.txPackets, that.txPackets) &&
+        Objects.equals(this.txDropped, that.txDropped) &&
+        Objects.equals(this.txErrors, that.txErrors);
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    final NetworkStats other = (NetworkStats) obj;
-    if (rxBytes == null) {
-      if (other.rxBytes != null) {
-        return false;
-      }
-    } else if (!rxBytes.equals(other.rxBytes)) {
-      return false;
-    }
-    if (rxDropped == null) {
-      if (other.rxDropped != null) {
-        return false;
-      }
-    } else if (!rxDropped.equals(other.rxDropped)) {
-      return false;
-    }
-    if (rxErrors == null) {
-      if (other.rxErrors != null) {
-        return false;
-      }
-    } else if (!rxErrors.equals(other.rxErrors)) {
-      return false;
-    }
-    if (rxPackets == null) {
-      if (other.rxPackets != null) {
-        return false;
-      }
-    } else if (!rxPackets.equals(other.rxPackets)) {
-      return false;
-    }
-    if (txBytes == null) {
-      if (other.txBytes != null) {
-        return false;
-      }
-    } else if (!txBytes.equals(other.txBytes)) {
-      return false;
-    }
-    if (txDropped == null) {
-      if (other.txDropped != null) {
-        return false;
-      }
-    } else if (!txDropped.equals(other.txDropped)) {
-      return false;
-    }
-    if (txErrors == null) {
-      if (other.txErrors != null) {
-        return false;
-      }
-    } else if (!txErrors.equals(other.txErrors)) {
-      return false;
-    }
-    if (txPackets == null) {
-      if (other.txPackets != null) {
-        return false;
-      }
-    } else if (!txPackets.equals(other.txPackets)) {
-      return false;
-    }
-    return true;
+  public int hashCode() {
+    return Objects.hash(rxBytes, rxPackets, rxDropped, rxErrors,
+                        txBytes, txPackets, txDropped, txErrors);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/PortBinding.java
+++ b/src/main/java/com/spotify/docker/client/messages/PortBinding.java
@@ -75,14 +75,8 @@ public class PortBinding {
 
     final PortBinding that = (PortBinding) o;
 
-    if (hostIp != null ? !hostIp.equals(that.hostIp) : that.hostIp != null) {
-      return false;
-    }
-    if (hostPort != null ? !hostPort.equals(that.hostPort) : that.hostPort != null) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(this.hostIp, that.hostIp) &&
+        Objects.equals(this.hostPort, that.hostPort);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/ProcessConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ProcessConfig.java
@@ -67,20 +67,11 @@ public class ProcessConfig {
 
     final ProcessConfig that = (ProcessConfig) o;
 
-    if (privileged != null ? !privileged.equals(that.privileged) : that.privileged != null) {
-      return false;
-    }
-    if (user != null ? !user.equals(that.user) : that.user != null) {
-      return false;
-    }
-    if (tty != null ? !tty.equals(that.tty) : that.tty != null) {
-      return false;
-    }
-    if (entrypoint != null ? !entrypoint.equals(that.entrypoint) : that.entrypoint != null) {
-      return false;
-    }
-    return arguments != null ? arguments.equals(that.arguments) : that.arguments == null;
-
+    return Objects.equals(this.privileged, that.privileged) &&
+        Objects.equals(this.user, that.user) &&
+        Objects.equals(this.tty, that.tty) &&
+        Objects.equals(this.entrypoint, that.entrypoint) &&
+        Objects.equals(this.arguments, that.arguments);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/RemovedImage.java
+++ b/src/main/java/com/spotify/docker/client/messages/RemovedImage.java
@@ -72,14 +72,8 @@ public class RemovedImage {
 
     final RemovedImage that = (RemovedImage) o;
 
-    if (imageId != null ? !imageId.equals(that.imageId) : that.imageId != null) {
-      return false;
-    }
-    if (type != that.type) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(this.type, that.type) &&
+        Objects.equals(this.imageId, that.imageId);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/messages/Version.java
+++ b/src/main/java/com/spotify/docker/client/messages/Version.java
@@ -70,33 +70,15 @@ public class Version {
       return false;
     }
 
-    final Version version1 = (Version) o;
+    final Version that = (Version) o;
 
-    if (apiVersion != null ? !apiVersion.equals(version1.apiVersion)
-                           : version1.apiVersion != null) {
-      return false;
-    }
-    if (arch != null ? !arch.equals(version1.arch) : version1.arch != null) {
-      return false;
-    }
-    if (gitCommit != null ? !gitCommit.equals(version1.gitCommit) : version1.gitCommit != null) {
-      return false;
-    }
-    if (goVersion != null ? !goVersion.equals(version1.goVersion) : version1.goVersion != null) {
-      return false;
-    }
-    if (kernelVersion != null ? !kernelVersion.equals(version1.kernelVersion)
-                              : version1.kernelVersion != null) {
-      return false;
-    }
-    if (os != null ? !os.equals(version1.os) : version1.os != null) {
-      return false;
-    }
-    if (version != null ? !version.equals(version1.version) : version1.version != null) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(this.apiVersion, that.apiVersion) &&
+        Objects.equals(this.arch, that.arch) &&
+        Objects.equals(this.gitCommit, that.gitCommit) &&
+        Objects.equals(this.goVersion, that.goVersion) &&
+        Objects.equals(this.kernelVersion, that.kernelVersion) &&
+        Objects.equals(this.os, that.os) &&
+        Objects.equals(this.version, that.version);
   }
 
   @Override


### PR DESCRIPTION
Continues the work of #396.

* Standardize style of `equals` and `hashCode` methods
  * Replace manual hash calculation with `java.util.Objects.hash`
  * Replace manual `null` and equality checking in `equals` with `java.util.Objects.equals`.
  * Local variable names (`Object o`, `that`) in `equals`
  * Indentation and spacing
  * Method ordering: `equals`, then `hashCode`, then `toString`
* Assorted other changes
  * Replace manual String concatenation in `Event.toString()` with Guava `MoreObjects.toStringHelper()`
  * Fix indentation throughout `Device`, not just in `equals` and `hashCode`
  * Move inner class to the bottom of `Network` instead of top
  * Fix potential bug in `Network`, in which two properties had been missed in `equals` and `hashCode`