### PR TITLE
testEventStream: Only read the next event if it exists

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -1413,8 +1413,8 @@ public class DefaultDockerClientTest {
     assertThat(createEvent.time(), notNullValue());
 
     Event startEvent = eventStream.next();
-    if (!dockerApiVersionLessThan("1.22")) {
-      // For some reason, version 1.22 has an extra null Event. So we read the next one.
+    if (dockerApiVersionAtLeast("1.22") && eventStream.hasNext()) {
+      // For some reason, version 1.22 has an extra null Event sometimes. So we read the next one.
       startEvent = eventStream.next();
     }
 


### PR DESCRIPTION
I saw [another test failure](https://travis-ci.org/johnflavin/docker-client/jobs/123603775) like the one I noted in #412. See that issue for details.

I am not certain this fix will prevent failures in `testEventStream`, as I still have no way to reproduce this failure. But I think it's worth a shot.