### PR TITLE
Added assessor for checkDuplicate in NetworkConfig

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/NetworkConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkConfig.java
@@ -62,6 +62,10 @@ public class NetworkConfig {
     return options;
   }
 
+  public boolean checkDuplicate() {
+    return checkDuplicate;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {


### PR DESCRIPTION
The checkDuplicate field was the only field that didn't have an assessor method.