### PR TITLE
Fix date parsing to work with fractional seconds with less than nine digits

### DIFF
--- a/src/main/java/com/spotify/docker/client/DockerDateFormat.java
+++ b/src/main/java/com/spotify/docker/client/DockerDateFormat.java
@@ -41,9 +41,11 @@ public class DockerDateFormat extends StdDateFormat {
   @Override
   public Date parse(String source) throws ParseException {
     // If the date has nanosecond precision (e.g. 2014-10-17T21:22:56.949763914Z), remove the last
-    // six digits so we can create a Date object, which only support milliseconds.
-    if (source.matches(".+\\.\\d{9}Z$")) {
-      source = source.replaceAll("\\d{6}Z$", "Z");
+    // digits so we can create a Date object, which only support milliseconds.
+    // Docker doesn't always return nine digits for the fractional seconds part,
+    // so we need to be more flexible when trimming to milliseconds.
+    if (source.matches(".+\\.\\d{4,9}Z$")) {
+      source = source.replaceAll("(\\.\\d{3})\\d{1,6}Z$", "$1Z");
     }
 
     return super.parse(source);

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -1527,6 +1527,10 @@ public class DefaultDockerClientTest {
     // Verify DockerDateFormat converts nanosecond precision down to millisecond precision
     final Date nano = dateFormat.parse("2015-09-18T17:44:28.145855389Z");
     assertThat(nano, equalTo(expected));
+    // Verify DockerDateFormat converts nanosecond precision with less than nine digits
+    // down to millisecond precision
+    final Date nanoSevenDigits = dateFormat.parse("2015-09-18T17:44:28.1458553Z");
+    assertThat(nanoSevenDigits, equalTo(expected));
     // Verify the formatter works when used with the client
     sut.pull(BUSYBOX_BUILDROOT_2013_08_1);
     final ImageInfo imageInfo = sut.inspectImage(BUSYBOX_BUILDROOT_2013_08_1);


### PR DESCRIPTION
Fix date parsing to work with fractional seconds with less than nine digits

Docker API returns dates in rfc3339 format with nanoseconds precision but the fractional seconds part is not always nine digits long.

This pull requests changes `DockerDateFormat` so it trims the seconds fraction part to at most three digits.

My understanding of seconds fraction is that they are fractions - this means that any trailing zeros could be omitted(I guess that's why Docker sometimes returns less than nine digits). So `2014-10-17T21:22:56.9Z` should mean 59 seconds and 900 milliseconds but `com.fasterxml.jackson.databind.util.StdDateFormat` converts it to 59 seconds and 9 milliseconds. I think this is wrong but we can live with it.

Fixes #416