### PR TITLE
Added NetworkID field to AttachedNetwork

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
+++ b/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
@@ -101,8 +101,8 @@ public class AttachedNetwork {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("networkID", networkId).add("endpointID", endpointId)
-        .add("gateway", gateway).add("ipAddress", ipAddress)
+    return MoreObjects.toStringHelper(this).add("networkID", networkId)
+        .add("endpointID", endpointId).add("gateway", gateway).add("ipAddress", ipAddress)
         .add("ipPrefixLen", ipPrefixLen).add("ipv6Gateway", ipv6Gateway)
         .add("globalIPv6Address", globalIPv6Address).add("globalIPv6PrefixLen", globalIPv6PrefixLen)
         .add("macAddress", macAddress).toString();

--- a/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
+++ b/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
@@ -17,10 +17,9 @@
 
 package com.spotify.docker.client.messages;
 
-import com.google.common.base.MoreObjects;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 
 import java.util.Objects;
 
@@ -30,6 +29,7 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 public class AttachedNetwork {
 
+  @JsonProperty("NetworkID") private String networkId;
   @JsonProperty("EndpointID") private String endpointId;
   @JsonProperty("Gateway") private String gateway;
   @JsonProperty("IPAddress") private String ipAddress;
@@ -82,7 +82,8 @@ public class AttachedNetwork {
 
     final AttachedNetwork that = (AttachedNetwork) o;
 
-    return Objects.equals(this.endpointId, that.endpointId) &&
+    return Objects.equals(this.networkId, that.networkId) &&
+        Objects.equals(this.endpointId, that.endpointId) &&
         Objects.equals(this.gateway, that.gateway) &&
         Objects.equals(this.ipAddress, that.ipAddress) &&
         Objects.equals(this.ipPrefixLen, that.ipPrefixLen) &&
@@ -94,14 +95,15 @@ public class AttachedNetwork {
 
   @Override
   public int hashCode() {
-    return Objects.hash(endpointId, gateway, ipAddress, ipPrefixLen, ipv6Gateway,
-                        globalIPv6Address, globalIPv6PrefixLen, macAddress);
+    return Objects.hash(networkId, endpointId, gateway, ipAddress, ipPrefixLen, ipv6Gateway,
+        globalIPv6Address, globalIPv6PrefixLen, macAddress);
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("endpointID", endpointId).add("gateway", gateway)
-        .add("ipAddress", ipAddress).add("ipPrefixLen", ipPrefixLen).add("ipv6Gateway", ipv6Gateway)
+    return MoreObjects.toStringHelper(this).add("networkID", networkId).add("endpointID", endpointId)
+        .add("gateway", gateway).add("ipAddress", ipAddress)
+        .add("ipPrefixLen", ipPrefixLen).add("ipv6Gateway", ipv6Gateway)
         .add("globalIPv6Address", globalIPv6Address).add("globalIPv6PrefixLen", globalIPv6PrefixLen)
         .add("macAddress", macAddress).toString();
   }

--- a/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
+++ b/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
@@ -39,6 +39,10 @@ public class AttachedNetwork {
   @JsonProperty("GlobalIPv6PrefixLen") private Integer globalIPv6PrefixLen;
   @JsonProperty("MacAddress") private String macAddress;
 
+  public String networkId() {
+    return networkId;
+  }
+
   public String endpointId() {
     return endpointId;
   }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -2547,6 +2547,7 @@ public class DefaultDockerClientTest {
     final AttachedNetwork attachedNetwork =
         containerInfo.networkSettings().networks().get(networkName);
     assertThat(attachedNetwork, is(notNullValue()));
+    assertThat(attachedNetwork.networkId(), is(notNullValue()));
     assertThat(attachedNetwork.endpointId(), is(notNullValue()));
     assertThat(attachedNetwork.gateway(), is(notNullValue()));
     assertThat(attachedNetwork.ipAddress(), is(notNullValue()));

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -2547,7 +2547,9 @@ public class DefaultDockerClientTest {
     final AttachedNetwork attachedNetwork =
         containerInfo.networkSettings().networks().get(networkName);
     assertThat(attachedNetwork, is(notNullValue()));
-    assertThat(attachedNetwork.networkId(), is(notNullValue()));
+    if (dockerApiVersionAtLeast("1.22")) {
+      assertThat(attachedNetwork.networkId(), is(notNullValue()));
+    }
     assertThat(attachedNetwork.endpointId(), is(notNullValue()));
     assertThat(attachedNetwork.gateway(), is(notNullValue()));
     assertThat(attachedNetwork.ipAddress(), is(notNullValue()));


### PR DESCRIPTION
The field "NetworkID" was missing from AttachedNetwork. This field was added in [Docker API 1.22](https://docs.docker.com/engine/reference/api/docker_remote_api/#v1-22-api-changes)