### PR TITLE
Add (documented) info fields

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/Info.java
+++ b/src/main/java/com/spotify/docker/client/messages/Info.java
@@ -18,45 +18,105 @@
 package com.spotify.docker.client.messages;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class Info {
 
+  @JsonProperty("Architecture") private String architecture;
+  @JsonProperty("ClusterStore") private String clusterStore;
+  @JsonProperty("CgroupDriver") private String cgroupDriver;
   @JsonProperty("Containers") private int containers;
-  @JsonProperty("Images") private int images;
+  @JsonProperty("ContainersRunning") private Integer containersRunning;
+  @JsonProperty("ContainersStopped") private Integer containersStopped;
+  @JsonProperty("ContainersPaused") private Integer containersPaused;
+  @JsonProperty("CpuCfsPeriod") private Boolean cpuCfsPeriod;
+  @JsonProperty("CpuCfsQuota") private Boolean cpuCfsQuota;
+  @JsonProperty("Debug") private Boolean debug;
+  @JsonProperty("DockerRootDir") private String dockerRootDir;
   @JsonProperty("Driver") private String storageDriver;
   @JsonProperty("DriverStatus") private List<List<String>> driverStatus;
-  @JsonProperty("SystemStatus") private List<List<String>> systemStatus;
   @JsonProperty("ExecutionDriver") private String executionDriver;
-  @JsonProperty("KernelVersion") private String kernelVersion;
-  @JsonProperty("NCPU") private int cpus;
-  @JsonProperty("MemTotal") private long memTotal;
-  @JsonProperty("Name") private String name;
+  @JsonProperty("ExperimentalBuild") private Boolean experimentalBuild;
+  @JsonProperty("HttpProxy") private String httpProxy;
+  @JsonProperty("HttpsProxy") private String httpsProxy;
   @JsonProperty("ID") private String id;
-  @JsonProperty("OperatingSystem") private String operatingSystem;
-  @JsonProperty("Debug") private Boolean debug;
-  @JsonProperty("NFd") private int fileDescriptors;
-  @JsonProperty("NGoroutines") private int goroutines;
-  @JsonProperty("NEventsListener") private int eventsListener;
+  @JsonProperty("IPv4Forwarding") private boolean ipv4Forwarding;
+  @JsonProperty("Images") private int images;
+  @JsonProperty("IndexServerAddress") private String indexServerAddress;
   @JsonProperty("InitPath") private String initPath;
   @JsonProperty("InitSha1") private String initSha1;
-  @JsonProperty("IndexServerAddress") private String indexServerAddress;
-  @JsonProperty("MemoryLimit") private Boolean memoryLimit;
-  @JsonProperty("SwapLimit") private Boolean swapLimit;
-  @JsonProperty("IPv4Forwarding") private boolean ipv4Forwarding;
+  @JsonProperty("KernelMemory") private Boolean kernelMemory;
+  @JsonProperty("KernelVersion") private String kernelVersion;
   @JsonProperty("Labels") private List<String> labels;
-  @JsonProperty("DockerRootDir") private String dockerRootDir;
+  @JsonProperty("MemTotal") private long memTotal;
+  @JsonProperty("MemoryLimit") private Boolean memoryLimit;
+  @JsonProperty("NCPU") private int cpus;
+  @JsonProperty("NEventsListener") private int eventsListener;
+  @JsonProperty("NFd") private int fileDescriptors;
+  @JsonProperty("NGoroutines") private int goroutines;
+  @JsonProperty("Name") private String name;
+  @JsonProperty("NoProxy") private String noProxy;
+  @JsonProperty("OomKillDisable") private Boolean oomKillDisable;
+  @JsonProperty("OperatingSystem") private String operatingSystem;
+  @JsonProperty("OSType") private String osType;
+  @JsonProperty("Plugins") private Plugins plugins;
+  @JsonProperty("RegistryConfig") private RegistryConfig registryConfig;
+  @JsonProperty("ServerVersion") private String serverVersion;
+  @JsonProperty("SwapLimit") private Boolean swapLimit;
+  @JsonProperty("SystemStatus") private List<List<String>> systemStatus;
+  @JsonProperty("SystemTime") private Date systemTime;
+
+  public String architecture() {
+    return architecture;
+  }
+
+  public String clusterStore() {
+    return clusterStore;
+  }
+
+  public String cgroupDriver() {
+    return cgroupDriver;
+  }
 
   public int containers() {
     return containers;
   }
 
-  public int images() {
-    return images;
+  public Integer containersRunning() {
+    return containersRunning;
+  }
+
+  public Integer containersStopped() {
+    return containersStopped;
+  }
+
+  public Integer containersPaused() {
+    return containersPaused;
+  }
+
+  public Boolean cpuCfsPeriod() {
+    return cpuCfsPeriod;
+  }
+
+  public Boolean cpuCfsQuota() {
+    return cpuCfsQuota;
+  }
+
+  public Boolean debug() {
+    return debug;
+  }
+
+  public String dockerRootDir() {
+    return dockerRootDir;
   }
 
   public String storageDriver() {
@@ -67,52 +127,36 @@ public class Info {
     return driverStatus;
   }
 
-  public List<List<String>> systemStatus() {
-    return systemStatus;
+  public String executionDriver() {
+    return executionDriver;
   }
 
-  public int cpus() {
-    return cpus;
+  public Boolean experimentalBuild() {
+    return experimentalBuild;
   }
 
-  public long memTotal() {
-    return memTotal;
+  public String httpProxy() {
+    return httpProxy;
   }
 
-  public String name() {
-    return name;
+  public String httpsProxy() {
+    return httpsProxy;
   }
 
   public String id() {
     return id;
   }
 
-  public String executionDriver() {
-    return executionDriver;
+  public boolean ipv4Forwarding() {
+    return ipv4Forwarding;
   }
 
-  public String kernelVersion() {
-    return kernelVersion;
+  public int images() {
+    return images;
   }
 
-  public String operatingSystem() {
-    return operatingSystem;
-  }
-
-  public boolean debug() {
-    return debug;
-  }
-
-  public int fileDescriptors() {
-    return fileDescriptors;
-  }
-
-  public int goroutines() {
-    return goroutines;
-  }
-
-  public int eventsListener() {
-    return eventsListener;
+  public String indexServerAddress() {
+    return indexServerAddress;
   }
 
   public String initPath() {
@@ -123,32 +167,88 @@ public class Info {
     return initSha1;
   }
 
-  public String indexServerAddress() {
-    return indexServerAddress;
+  public Boolean kernelMemory() {
+    return kernelMemory;
   }
 
-  public boolean memoryLimit() {
-    return memoryLimit;
-  }
-
-  public boolean swapLimit() {
-    return swapLimit;
-  }
-
-  public boolean ipv4Forwarding() {
-    return ipv4Forwarding;
+  public String kernelVersion() {
+    return kernelVersion;
   }
 
   public List<String> labels() {
     return labels;
   }
 
-  public String dockerRootDir() {
-    return dockerRootDir;
+  public long memTotal() {
+    return memTotal;
+  }
+
+  public Boolean memoryLimit() {
+    return memoryLimit;
+  }
+
+  public int cpus() {
+    return cpus;
+  }
+
+  public int eventsListener() {
+    return eventsListener;
+  }
+
+  public int fileDescriptors() {
+    return fileDescriptors;
+  }
+
+  public int goroutines() {
+    return goroutines;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public String noProxy() {
+    return noProxy;
+  }
+
+  public Boolean oomKillDisable() {
+    return oomKillDisable;
+  }
+
+  public String operatingSystem() {
+    return operatingSystem;
+  }
+
+  public String osType() {
+    return osType;
+  }
+
+  public Plugins plugins() {
+    return plugins;
+  }
+
+  public RegistryConfig registryConfig() {
+    return registryConfig;
+  }
+
+  public String serverVersion() {
+    return serverVersion;
+  }
+
+  public Boolean swapLimit() {
+    return swapLimit;
+  }
+
+  public List<List<String>> systemStatus() {
+    return systemStatus;
+  }
+
+  public Date systemTime() {
+    return systemTime == null ? null : new Date(systemTime.getTime());
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
@@ -158,62 +258,234 @@ public class Info {
 
     final Info that = (Info) o;
 
-    return Objects.equals(this.containers, that.containers) &&
-        Objects.equals(this.images, that.images) &&
-        Objects.equals(this.storageDriver, that.storageDriver) &&
-        Objects.equals(this.driverStatus, that.driverStatus) &&
-        Objects.equals(this.systemStatus, that.systemStatus) &&
-        Objects.equals(this.executionDriver, that.executionDriver) &&
-        Objects.equals(this.kernelVersion, that.kernelVersion) &&
+    return Objects.equals(this.architecture, that.architecture) &&
+        Objects.equals(this.clusterStore, that.clusterStore) &&
+        Objects.equals(this.cgroupDriver, that.cgroupDriver) &&
+        Objects.equals(this.containers, that.containers) &&
+        Objects.equals(this.containersRunning, that.containersRunning) &&
+        Objects.equals(this.containersStopped, that.containersStopped) &&
+        Objects.equals(this.containersPaused, that.containersPaused) &&
+        Objects.equals(this.cpuCfsPeriod, that.cpuCfsPeriod) &&
+        Objects.equals(this.cpuCfsQuota, that.cpuCfsQuota) &&
         Objects.equals(this.cpus, that.cpus) &&
-        Objects.equals(this.memTotal, that.memTotal) &&
-        Objects.equals(this.name, that.name) &&
-        Objects.equals(this.id, that.id) &&
-        Objects.equals(this.operatingSystem, that.operatingSystem) &&
         Objects.equals(this.debug, that.debug) &&
+        Objects.equals(this.dockerRootDir, that.dockerRootDir) &&
+        Objects.equals(this.driverStatus, that.driverStatus) &&
+        Objects.equals(this.eventsListener, that.eventsListener) &&
+        Objects.equals(this.executionDriver, that.executionDriver) &&
+        Objects.equals(this.experimentalBuild, that.experimentalBuild) &&
         Objects.equals(this.fileDescriptors, that.fileDescriptors) &&
         Objects.equals(this.goroutines, that.goroutines) &&
-        Objects.equals(this.eventsListener, that.eventsListener) &&
+        Objects.equals(this.httpProxy, that.httpProxy) &&
+        Objects.equals(this.httpsProxy, that.httpsProxy) &&
+        Objects.equals(this.id, that.id) &&
+        Objects.equals(this.images, that.images) &&
+        Objects.equals(this.indexServerAddress, that.indexServerAddress) &&
         Objects.equals(this.initPath, that.initPath) &&
         Objects.equals(this.initSha1, that.initSha1) &&
-        Objects.equals(this.indexServerAddress, that.indexServerAddress) &&
-        Objects.equals(this.memoryLimit, that.memoryLimit) &&
-        Objects.equals(this.swapLimit, that.swapLimit) &&
         Objects.equals(this.ipv4Forwarding, that.ipv4Forwarding) &&
+        Objects.equals(this.kernelVersion, that.kernelVersion) &&
         Objects.equals(this.labels, that.labels) &&
-        Objects.equals(this.dockerRootDir, that.dockerRootDir);
+        Objects.equals(this.memoryLimit, that.memoryLimit) &&
+        Objects.equals(this.memTotal, that.memTotal) &&
+        Objects.equals(this.name, that.name) &&
+        Objects.equals(this.noProxy, that.noProxy) &&
+        Objects.equals(this.oomKillDisable, that.oomKillDisable) &&
+        Objects.equals(this.operatingSystem, that.operatingSystem) &&
+        Objects.equals(this.osType, that.osType) &&
+        Objects.equals(this.plugins, that.plugins) &&
+        Objects.equals(this.registryConfig, that.registryConfig) &&
+        Objects.equals(this.serverVersion, that.serverVersion) &&
+        Objects.equals(this.storageDriver, that.storageDriver) &&
+        Objects.equals(this.swapLimit, that.swapLimit) &&
+        Objects.equals(this.systemStatus, that.systemStatus) &&
+        Objects.equals(this.systemTime, that.systemTime)
+        ;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(containers, images, storageDriver, driverStatus, systemStatus, cpus,
-                        memTotal, name, executionDriver, kernelVersion, debug, fileDescriptors,
-                        goroutines, eventsListener, initPath, initSha1, indexServerAddress,
-                        memoryLimit, swapLimit);
+    return Objects.hash(architecture, clusterStore, cgroupDriver, containers, containersRunning,
+                        containersStopped, containersPaused, cpuCfsPeriod, cpuCfsQuota, cpus, debug,
+                        dockerRootDir, driverStatus, eventsListener, executionDriver,
+                        experimentalBuild, fileDescriptors, goroutines, httpProxy, httpsProxy,
+                        id, images, indexServerAddress, initPath, initSha1, ipv4Forwarding,
+                        kernelMemory, kernelVersion, labels, memoryLimit, memTotal, name, noProxy,
+                        oomKillDisable, operatingSystem, osType, plugins, registryConfig,
+                        serverVersion, storageDriver, swapLimit, systemStatus, systemTime);
   }
+
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
+        .add("architecture", architecture)
+        .add("clusterStore", clusterStore)
+        .add("cgroupDriver", cgroupDriver)
         .add("containers", containers)
-        .add("images", images)
+        .add("containersRunning", containersRunning)
+        .add("containersStopped", containersStopped)
+        .add("containersPaused", containersPaused)
+        .add("cpuCfsPeriod", cpuCfsPeriod)
+        .add("cpuCfsQuota", cpuCfsQuota)
+        .add("debug", debug)
+        .add("dockerRootDir", dockerRootDir)
         .add("storageDriver", storageDriver)
         .add("driverStatus", driverStatus)
-        .add("systemStatus", systemStatus)
-        .add("cpus", cpus)
-        .add("memTotal", memTotal)
-        .add("name", name)
         .add("executionDriver", executionDriver)
-        .add("kernelVersion", kernelVersion)
-        .add("debug", debug)
-        .add("fileDescriptors", fileDescriptors)
-        .add("goroutines", goroutines)
-        .add("eventsListener", eventsListener)
+        .add("experimentalBuild", experimentalBuild)
+        .add("httpProxy", httpProxy)
+        .add("httpsProxy", httpsProxy)
+        .add("id", id)
+        .add("ipv4Forwarding", ipv4Forwarding)
+        .add("images", images)
+        .add("indexServerAddress", indexServerAddress)
         .add("initPath", initPath)
         .add("initSha1", initSha1)
-        .add("indexServerAddress", indexServerAddress)
+        .add("kernelMemory", kernelMemory)
+        .add("kernelVersion", kernelVersion)
+        .add("labels", labels)
+        .add("memTotal", memTotal)
         .add("memoryLimit", memoryLimit)
+        .add("cpus", cpus)
+        .add("eventsListener", eventsListener)
+        .add("fileDescriptors", fileDescriptors)
+        .add("goroutines", goroutines)
+        .add("name", name)
+        .add("noProxy", noProxy)
+        .add("oomKillDisable", oomKillDisable)
+        .add("operatingSystem", operatingSystem)
+        .add("osType", osType)
+        .add("plugins", plugins)
+        .add("registryConfig", registryConfig)
+        .add("serverVersion", serverVersion)
         .add("swapLimit", swapLimit)
+        .add("systemStatus", systemStatus)
+        .add("systemTime", systemTime)
         .toString();
+  }
+
+  public static class Plugins {
+    @JsonProperty("Volumes") private ImmutableList<String> volume;
+    @JsonProperty("Networks") private ImmutableList<String> network;
+
+    public List<String> volume() {
+      return volume;
+    }
+
+    public List<String> network() {
+      return network;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final Plugins that = (Plugins) o;
+
+      return Objects.equals(volume, that.volume) &&
+          Objects.equals(network, that.network);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(volume, network);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("volume", volume)
+          .add("network", network)
+          .toString();
+    }
+  }
+
+  public static class RegistryConfig {
+    @JsonProperty("IndexConfigs") private ImmutableMap<String, IndexConfig> indexConfigs;
+    @JsonProperty("InsecureRegistryCIDRs") private ImmutableList<String> insecureRegistryCidrs;
+
+    public Map<String, IndexConfig> indexConfigs() {
+      return indexConfigs;
+    }
+
+    public List<String> insecureRegistryCidrs() {
+      return insecureRegistryCidrs;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final RegistryConfig that = (RegistryConfig) o;
+
+      return Objects.equals(this.indexConfigs, that.indexConfigs) &&
+          Objects.equals(this.insecureRegistryCidrs, that.insecureRegistryCidrs);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(indexConfigs, insecureRegistryCidrs);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("indexConfigs", indexConfigs)
+          .add("insecureRegistryCidrs", insecureRegistryCidrs)
+          .toString();
+    }
+  }
+
+  public static class IndexConfig {
+    @JsonProperty("Name") private String name;
+    @JsonProperty("Mirrors") private String mirrors;
+    @JsonProperty("Secure") private Boolean secure;
+    @JsonProperty("Official") private Boolean official;
+
+    @JsonCreator
+    public IndexConfig() {}
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final IndexConfig that = (IndexConfig) o;
+      return Objects.equals(this.name, that.name) &&
+          Objects.equals(this.mirrors, that.mirrors) &&
+          Objects.equals(this.secure, that.secure) &&
+          Objects.equals(this.official, that.official);
+
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, mirrors, secure, official);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("name", name)
+          .add("mirrors", mirrors)
+          .add("secure", secure)
+          .add("official", official)
+          .toString();
+    }
   }
 }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -156,6 +156,7 @@ import static org.apache.commons.lang.StringUtils.containsIgnoreCase;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -166,6 +167,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -178,6 +180,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -469,12 +472,65 @@ public class DefaultDockerClientTest {
   @Test
   public void testInfo() throws Exception {
     final Info info = sut.info();
-    assertThat(info.executionDriver(), not(isEmptyOrNullString()));
-    assertThat(info.initPath(), not(isEmptyOrNullString()));
-    assertThat(info.kernelVersion(), not(isEmptyOrNullString()));
+    assertThat(info.containers(), is(anything()));
+    assertThat(info.debug(), is(anything()));
+    assertThat(info.dockerRootDir(), not(isEmptyOrNullString()));
     assertThat(info.storageDriver(), not(isEmptyOrNullString()));
+    assertThat(info.driverStatus(), is(anything()));
+    assertThat(info.executionDriver(), not(isEmptyOrNullString()));
+    assertThat(info.id(), not(isEmptyOrNullString()));
+    assertThat(info.ipv4Forwarding(), is(anything()));
+    assertThat(info.images(), greaterThan(0));
+    assertThat(info.indexServerAddress(), not(isEmptyOrNullString()));
+    assertThat(info.initPath(), not(isEmptyOrNullString()));
+    assertThat(info.initSha1(), is(anything()));
+    assertThat(info.kernelVersion(), not(isEmptyOrNullString()));
+    assertThat(info.labels(), is(anything()));
+    assertThat(info.memTotal(), greaterThan(0L));
     assertThat(info.memoryLimit(), not(nullValue()));
+    assertThat(info.cpus(), greaterThan(0));
+    assertThat(info.eventsListener(), is(anything()));
+    assertThat(info.fileDescriptors(), is(anything()));
+    assertThat(info.goroutines(), is(anything()));
+    assertThat(info.name(), not(isEmptyOrNullString()));
+    assertThat(info.operatingSystem(), not(isEmptyOrNullString()));
+    assertThat(info.registryConfig(), notNullValue());
+    assertThat(info.registryConfig().indexConfigs(), hasKey("docker.io"));
     assertThat(info.swapLimit(), not(nullValue()));
+
+    if (dockerApiVersionAtLeast("1.18")) {
+      assertThat(info.httpProxy(), is(anything()));
+      assertThat(info.httpsProxy(), is(anything()));
+      assertThat(info.noProxy(), is(anything()));
+      assertThat(info.systemTime(), not(nullValue()));
+    }
+
+    if (dockerApiVersionAtLeast("1.19")) {
+      assertThat(info.cpuCfsPeriod(), is(anything()));
+      assertThat(info.cpuCfsQuota(), is(anything()));
+      assertThat("Sorry if you're testing on an experimental build",
+          info.experimentalBuild(), is(false));
+      assertThat(info.oomKillDisable(), is(anything()));
+    }
+
+    if (dockerApiVersionAtLeast("1.21")) {
+      assertThat(info.clusterStore(), is(anything()));
+      assertEquals(info.serverVersion(), sut.version().version());
+    }
+
+    if (dockerApiVersionAtLeast("1.22")) {
+      assertThat(info.architecture(), not(isEmptyOrNullString()));
+      assertThat(info.containersRunning(), is(anything()));
+      assertThat(info.containersStopped(), is(anything()));
+      assertThat(info.containersPaused(), is(anything()));
+      assertThat(info.osType(), not(isEmptyOrNullString()));
+      assertThat(info.systemStatus(), is(anything()));
+    }
+
+    if (dockerApiVersionAtLeast("1.23")) {
+      assertThat(info.cgroupDriver(), not(isEmptyOrNullString()));
+      assertThat(info.kernelMemory(), is(anything()));
+    }
   }
 
   @Test


### PR DESCRIPTION
The `/info` API has seen a lot of changes in recent versions, which I've attempted to capture.

# Changes
* Add many new properties to `Info` class.
* Alphabetize properties in `Info`. There were getting to be too many properties to easily compare to the API docs (in which the example info object is alphabetized).
* Add `Plugin`, `RegistryConfig`, and `IndexConfig` classes to represent some `Info` fields.
* Add tests for all `Info` fields, with fields added in each successive new API version in a new `if` block.

# Caveats
* In my testing I found some undocumented fields returned by `/info`, and I chose not to include them here. I may open an upstream issue about it.
* Most of the test assertions I added don't actually test anything, they just compare to `Matchers.anything()`. I don't have a good way to predict beforehand what most of the fields will be, or even whether they will be null or blank.
