### PR TITLE
Fix Info->IndexConfig->Mirros Jackson deserialization

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/Info.java
+++ b/src/main/java/com/spotify/docker/client/messages/Info.java
@@ -449,7 +449,7 @@ public class Info {
 
   public static class IndexConfig {
     @JsonProperty("Name") private String name;
-    @JsonProperty("Mirrors") private String mirrors;
+    @JsonProperty("Mirrors") private List<String> mirrors;
     @JsonProperty("Secure") private Boolean secure;
     @JsonProperty("Official") private Boolean official;
 


### PR DESCRIPTION
Mirrors is a list of strings not a string.
I'm not sure how it passed on Travis-CI, but it broke our internal
Jenkins build.