### PR TITLE
Fix bug in load

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -911,14 +911,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   @Override
   public void load(final String image, final InputStream imagePayload)
       throws DockerException, InterruptedException {
-    load(image, imagePayload, new LoggingPullHandler("image stream"));
-  }
-
-  @Override
-  public void load(final String image, final InputStream imagePayload,
-                   final AuthConfig authConfig, final ProgressHandler handler)
-      throws DockerException, InterruptedException {
-    load(image, imagePayload, handler);
+    load(image, imagePayload, authConfig, new LoggingPullHandler("image stream"));
   }
 
   @Override
@@ -932,7 +925,13 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   public void load(final String image, final InputStream imagePayload,
                    final ProgressHandler handler)
       throws DockerException, InterruptedException {
+    load(image, imagePayload, authConfig, handler);
+  }
 
+  @Override
+  public void load(final String image, final InputStream imagePayload,
+                   final AuthConfig authConfig, final ProgressHandler handler)
+      throws DockerException, InterruptedException {
     WebTarget resource = resource().path("images").path("create");
 
     resource = resource


### PR DESCRIPTION
There are a few different `DefaultDockerClient.load` methods with different signatures, which will use either a user-supplied or default `AuthConfig` and `ProgressHandler`. One of the versions of `load` (starting on line 918) was accepting an `AuthConfig`, but `return`ing another version of `load` that used the default `authConfig`. Effectively, that method ignored the user-supplied `AuthConfig`.

This PR fixes that.