### PR TITLE
travis: whitelist master branch for "build pushes"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,7 @@ after_success:
 # dump the docker logs in case they are needed for troubleshooting failures
 after_script:
   - sudo cat /var/log/upstart/docker.log
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
Travis has two options for what it can build "build pull requests" and
"build pushes".

If you enable both, then this causes two builds to be
kicked off for each PR (one build for the branch, and one for the merge
commit).

If you disable "build pushes", then the master branch is never built
after the PR is merged (or if any commits are made directly to master).

As a workaround, and inspired by [this Stack Overflow question][SO],
add 'master' as a branch whitelist so that "build pushes" can be enabled
without getting the double build on pull requests.

[SO]: http://stackoverflow.com/questions/31882306/how-to-configure-travis-ci-to-build-pull-requests-merges-to-master-w-o-redunda