### PR TITLE
only deploy snapshots to sonatype once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - SONATYPE_USERNAME=mattbrownspotify
     - secure: "CTYWMDSX4LOz2TiYBSqC+7klvafj0wvwcbpyL3TJueWmgKzJwysRqSHxw9JR2rfe8ysSxGFFiRO9HEyJ4o6zTF6kIy9tYsPxvSJ8c9wIEdTbUtGMuWlrhKchuMmdDaWt07/0N2llSB4h3fv53UGglSM+5FJu4e5DxvxUmIx/Zn4="
   matrix:
-    - DOCKER_VERSION=1.6.0
+    - DOCKER_VERSION=1.6.0 UPLOAD_SONATYPE=1
     - DOCKER_VERSION=1.7.1
     - DOCKER_VERSION=1.8.3
     - DOCKER_VERSION=1.9.1
@@ -35,7 +35,7 @@ after_success:
   # test coverage reporting
   - bash <(curl -s https://codecov.io/bash)
   # deploy snapshots to Maven central, but only from master branch
-  - "[[ $TRAVIS_BRANCH == \"master\" ]] && mvn --settings sonatype-settings.xml -DskipTests -B deploy"
+  - "[[ $TRAVIS_BRANCH == \"master\" && $UPLOAD_SONATYPE == \"1\" ]] && mvn --settings sonatype-settings.xml -DskipTests -B deploy"
 
 # dump the docker logs in case they are needed for troubleshooting failures
 after_script:


### PR DESCRIPTION
Since we use a matrix build, the `after_success` block runs for each
build combination. Since the build output is the same in each build, it
is wasteful to upload the JAR to sonatype a bunch of extra times.