### PR TITLE
Add support for changing authentication on push.

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -1020,7 +1020,19 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   }
 
   @Override
+  public void push(final String image, final AuthConfig authconfig)
+      throws DockerException, InterruptedException {
+    push(image, new LoggingPushHandler(image), authconfig);
+  }
+
+  @Override
   public void push(final String image, final ProgressHandler handler)
+      throws DockerException, InterruptedException {
+    push(image, handler, authConfig);
+  }
+
+  @Override
+  public void push(final String image, final ProgressHandler handler, final AuthConfig authConfig)
       throws DockerException, InterruptedException {
     final ImageRef imageRef = new ImageRef(image);
 
@@ -1035,7 +1047,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     try (ProgressStream push =
              request(POST, ProgressStream.class, resource,
                      resource.request(APPLICATION_JSON_TYPE)
-                         .header("X-Registry-Auth", authHeader()))) {
+                         .header("X-Registry-Auth", authHeader(authConfig)))) {
       push.tail(handler, POST, resource.getUri());
     } catch (IOException e) {
       throw new DockerException(e);
@@ -1615,10 +1627,6 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     } catch (IOException ignore) {
       return null;
     }
-  }
-
-  private String authHeader() throws DockerException {
-    return authHeader(authConfig);
   }
 
   private String authHeader(final AuthConfig authConfig) throws DockerException {

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -377,6 +377,12 @@ public interface DockerClient extends Closeable {
    */
   void push(String image, ProgressHandler handler) throws DockerException, InterruptedException;
 
+  void push(final String image, final AuthConfig authconfig)
+      throws DockerException, InterruptedException;
+
+  void push(final String image, final ProgressHandler handler, final AuthConfig authConfig)
+      throws DockerException, InterruptedException;
+
   /**
    * Tag a docker image.
    *

--- a/src/test/resources/dockerRegistry/auth/htpasswd
+++ b/src/test/resources/dockerRegistry/auth/htpasswd
@@ -1,2 +1,3 @@
 testuser:$2y$05$8qi1yIdKFkvGkdeSWBdBC.Mx/ra//6o0oWOEwbAnEw2/iMnaRxJhS
+testusertwo:$2y$05$svxIYziOWrs/ns61DJIJs.0miqSiWNwFKFlNRJELfYebH4T.lLTiC
 


### PR DESCRIPTION
It's not currently possible to change the authentication credentials (to push to multiple registries) per call to push(). For now users have to create a separate connection per registry and set the authentication credentials when building the connection.

With this change, users will be able to pass any AuthConfig to push, enabling pushes to various registries using the same connection.

This is bringing the same support to push() as exists for pull().