### PR TITLE
DockerHostTest should restore the default SystemDelegate once finished.

### DIFF
--- a/src/main/java/com/spotify/docker/client/DockerHost.java
+++ b/src/main/java/com/spotify/docker/client/DockerHost.java
@@ -41,7 +41,7 @@ public class DockerHost {
     String getenv(String name);
   }
 
-  private static SystemDelegate systemDelegate = new SystemDelegate() {
+  private static final SystemDelegate defaultSystemDelegate = new SystemDelegate() {
     @Override
     public String getProperty(final String key) {
       return System.getProperty(key);
@@ -51,6 +51,7 @@ public class DockerHost {
       return System.getenv(name);
     }
   };
+  private static SystemDelegate systemDelegate = defaultSystemDelegate;
 
   private static final String DEFAULT_UNIX_ENDPOINT = "unix:///var/run/docker.sock";
   private static final String DEFAULT_ADDRESS = "localhost";
@@ -145,6 +146,11 @@ public class DockerHost {
   @VisibleForTesting
   static void setSystemDelegate(final SystemDelegate delegate) {
     systemDelegate = delegate;
+  }
+
+  @VisibleForTesting
+  static void restoreSystemDelegate() {
+    systemDelegate = defaultSystemDelegate;
   }
 
   /**

--- a/src/test/java/com/spotify/docker/client/DockerHostTest.java
+++ b/src/test/java/com/spotify/docker/client/DockerHostTest.java
@@ -19,6 +19,7 @@ package com.spotify.docker.client;
 
 import com.spotify.docker.client.DockerHost.SystemDelegate;
 
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,6 +38,11 @@ public class DockerHostTest {
   @Before
   public void before() {
     systemDelegate = mock(SystemDelegate.class);
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    DockerHost.restoreSystemDelegate();
   }
 
   @Test


### PR DESCRIPTION
DockerHostTest mocks the SystemDelegate class but never restores the
original implementation (using java.lang.System) once finished. Perhaps
on most systems DockerHostTest runs after DefaultDockerClientTest so
this issue is never seen.

This is a little strange because it seems like the actual test class ordering is different, across systems. As an example, in https://travis-ci.org/spotify/docker-client/jobs/135929097 , DefaultDockerClientTest runs before DockerHostTest so this error never gets triggerd. On my machine DockerHostTest runs before DefaultDockerClientTest resulting in errors on each test because setup() can't get the DOCKER_HOST from the initially set delegate.

testLogDriver(com.spotify.docker.client.DefaultDockerClientTest)  Time elapsed: 0.007 sec  <<< ERROR!
java.lang.NullPointerException
	at com.spotify.docker.client.DockerHost.defaultDockerEndpoint(DockerHost.java:174)
	at com.spotify.docker.client.DockerHost.endpointFromEnv(DockerHost.java:183)
	at com.spotify.docker.client.DefaultDockerClient.fromEnv(DefaultDockerClient.java:1691)
	at com.spotify.docker.client.DefaultDockerClientTest.setup(DefaultDockerClientTest.java:232)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:24)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.ExpectedException$ExpectedExceptionStatement.evaluate(ExpectedException.java:239)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)