### PR TITLE
Fix annotation usage for the latest version of httpcore.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,11 @@
       <version>4.5</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.4.5</version>
+    </dependency>
+    <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
       <version>0.8</version>

--- a/src/main/java/com/spotify/docker/client/UnixConnectionSocketFactory.java
+++ b/src/main/java/com/spotify/docker/client/UnixConnectionSocketFactory.java
@@ -18,7 +18,8 @@
 package com.spotify.docker.client;
 
 import org.apache.http.HttpHost;
-import org.apache.http.annotation.Immutable;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.protocol.HttpContext;
@@ -35,7 +36,7 @@ import jnr.unixsocket.UnixSocketAddress;
 /**
  * Provides a ConnectionSocketFactory for connecting Apache HTTP clients to Unix sockets.
  */
-@Immutable
+@Contract(threading = ThreadingBehavior.IMMUTABLE_CONDITIONAL)
 public class UnixConnectionSocketFactory implements ConnectionSocketFactory {
 
   private File socketFile;


### PR DESCRIPTION
In httpcore 4.4.5, there was a legal requirement to remove these
annotations. See https://issues.apache.org/jira/browse/HTTPCLIENT-1743
for more details. This patch makes use of alternative annotations
to fix the build against httpcore 4.4.5 and newer.

Signed-off-by: Mat Booth <mat.booth@redhat.com>