### PR TITLE
Support usage of archive to copy files from a container

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -810,6 +810,25 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   }
 
   @Override
+  public InputStream copyFromContainer(String containerId, String path)
+      throws DockerException, InterruptedException {
+    final WebTarget resource = resource()
+        .path("containers").path(containerId).path("archive").queryParam("path", path);
+
+    try {
+      return request(GET, InputStream.class, resource,
+          resource.request(APPLICATION_OCTET_STREAM_TYPE));
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
+        case 404:
+          throw new ContainerNotFoundException(containerId, e);
+        default:
+          throw e;
+      }
+    }
+  }
+
+  @Override
   public ContainerInfo inspectContainer(final String containerId)
       throws DockerException, InterruptedException {
     try {

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -924,6 +924,26 @@ public interface DockerClient extends Closeable {
       throws DockerException, InterruptedException, IOException;
 
   /**
+   * Copies some files from a container. (API version 1.20+)
+   *
+   * @param containerId The id of the container to sent files.
+   * @param path        The path inside of the container to put files.
+   * @return A stream in tar format that contains the copied files.  If a directory was copied, the
+   * directory will be at the root of the tar archive (so {@code copy(..., "/usr/share")} will
+   * result in a directory called {@code share} in the tar archive).  The directory name is
+   * completely resolved, so copying {@code "/usr/share/././."} will still create a directory called
+   * {@code "share"} in the tar archive.  If a single file was copied, that file will be the sole
+   * entry in the tar archive.  Copying {@code "."} or equivalently {@code "/"} will result in the
+   * tar archive containing a single folder named after the container ID.
+   * @throws com.spotify.docker.client.exceptions.ContainerNotFoundException
+   *                              if container is not found (404)
+   * @throws DockerException      If a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  InputStream copyFromContainer(String containerId, String path)
+      throws DockerException, InterruptedException;
+
+  /**
    * Get docker container logs.
    *
    * @param containerId The id of the container to get logs for.

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -935,6 +935,32 @@ public class DefaultDockerClientTest {
   }
 
   @Test
+  public void testCopyFromContainer() throws Exception {
+    requireDockerApiVersionAtLeast("1.20", "copyFromContainer");
+
+    // Pull image
+    sut.pull(BUSYBOX_LATEST);
+
+    // Create container
+    final ContainerConfig config = ContainerConfig.builder().image(BUSYBOX_LATEST).build();
+    final String name = randomName();
+    final ContainerCreation creation = sut.createContainer(config, name);
+    final String containerId = creation.id();
+
+    final ImmutableSet.Builder<String> files = ImmutableSet.builder();
+    try (final TarArchiveInputStream tarStream =
+             new TarArchiveInputStream(sut.copyFromContainer(containerId, "/bin"))) {
+      TarArchiveEntry entry;
+      while ((entry = tarStream.getNextTarEntry()) != null) {
+        files.add(entry.getName());
+      }
+    }
+
+    // Check that some common files exist
+    assertThat(files.build(), both(hasItem("bin/")).and(hasItem("bin/wc")));
+  }
+
+  @Test
   public void testCommitContainer() throws Exception {
     // Pull image
     sut.pull(BUSYBOX_LATEST);


### PR DESCRIPTION
`DefaultDockerClient.copyContainer(...)` does not work with Docker Remote API version 1.24. This add `DefaultDockerClient.copyFromContainer(...)` to take advantage of `archive` functionality that has been in Docker Remote API since 1.20 and is currently used by `DefaultDockerClient.copyToContainer(...)`.