### PR TITLE
Disentangle /images/create and /images/load

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -909,29 +909,46 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   }
 
   @Override
+  @Deprecated
   public void load(final String image, final InputStream imagePayload)
       throws DockerException, InterruptedException {
-    load(image, imagePayload, authConfig, new LoggingPullHandler("image stream"));
+    create(image, imagePayload);
   }
 
   @Override
+  @Deprecated
   public void load(final String image, final InputStream imagePayload,
                    final AuthConfig authConfig)
       throws DockerException, InterruptedException {
-    load(image, imagePayload, authConfig, new LoggingPullHandler("image stream"));
+    create(image, imagePayload);
   }
 
   @Override
+  @Deprecated
   public void load(final String image, final InputStream imagePayload,
                    final ProgressHandler handler)
       throws DockerException, InterruptedException {
-    load(image, imagePayload, authConfig, handler);
+    create(image, imagePayload, handler);
   }
 
   @Override
+  @Deprecated
   public void load(final String image, final InputStream imagePayload,
                    final AuthConfig authConfig, final ProgressHandler handler)
       throws DockerException, InterruptedException {
+    create(image, imagePayload, handler);
+  }
+
+  @Override
+  public void create(final String image, final InputStream imagePayload)
+          throws DockerException, InterruptedException {
+    create(image, imagePayload, new LoggingPullHandler("image stream"));
+  }
+
+  @Override
+  public void create(final String image, final InputStream imagePayload,
+                     final ProgressHandler handler)
+          throws DockerException, InterruptedException {
     WebTarget resource = resource().path("images").path("create");
 
     resource = resource
@@ -943,13 +960,26 @@ public class DefaultDockerClient implements DockerClient, Closeable {
                                                      MediaType.APPLICATION_OCTET_STREAM);
     try (final ProgressStream load =
              request(POST, ProgressStream.class, resource,
-                     resource
-                         .request(APPLICATION_JSON_TYPE)
-                         .header("X-Registry-Auth", authHeader(authConfig)), entity)) {
+                     resource.request(APPLICATION_JSON_TYPE), entity)) {
       load.tail(loadProgressHandler, POST, resource.getUri());
       tag(loadProgressHandler.getImageId(), image, true);
     } catch (IOException e) {
       throw new DockerException(e);
+    } finally {
+      IOUtils.closeQuietly(imagePayload);
+    }
+  }
+
+  @Override
+  public void load(final InputStream imagePayload)
+          throws DockerException, InterruptedException {
+    final WebTarget resource = resource().path("images").path("load");
+
+    final Entity<InputStream> entity = Entity.entity(imagePayload,
+            MediaType.APPLICATION_OCTET_STREAM);
+    try {
+      request(POST, ProgressStream.class, resource,
+              resource.request(APPLICATION_JSON_TYPE), entity);
     } finally {
       IOUtils.closeQuietly(imagePayload);
     }

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -210,7 +210,7 @@ public interface DockerClient extends Closeable {
 
 
   /**
-   * Loads an image (the given input stream is closed internally). This method also tags the image
+   * Creates a single image from a tarball. This method also tags the image
    * with the given image name upon loading completion.
    *
    * @param image        the name to assign to the image.
@@ -218,13 +218,17 @@ public interface DockerClient extends Closeable {
    *                     file).
    * @throws DockerException      if a server error occurred (500).
    * @throws InterruptedException if the thread is interrupted.
+   *
+   * @deprecated Use {@link #load(InputStream)} to load a set of image layers from a tarball. Use
+   * {@link #create(String, InputStream)} to create a single image from the contents of a tarball.
    */
+  @Deprecated
   void load(String image, InputStream imagePayload)
       throws DockerException, InterruptedException;
 
 
   /**
-   * Loads an image (the given input stream is closed internally). This method also tags the image
+   * Creates a single image from a tarball. This method also tags the image
    * with the given image name upon loading completion.
    *
    * @param image        the name to assign to the image.
@@ -234,13 +238,18 @@ public interface DockerClient extends Closeable {
    *                     Docker.
    * @throws DockerException      if a server error occurred (500).
    * @throws InterruptedException if the thread is interrupted.
+   *
+   * @deprecated Use {@link #load(InputStream)} to load a set of image layers from a tarball. Use
+   * {@link #create(String, InputStream, ProgressHandler)} to create a single image from the
+   * contents of a tarball.
    */
+  @Deprecated
   void load(String image, InputStream imagePayload, ProgressHandler handler)
       throws DockerException, InterruptedException;
 
 
   /**
-   * Loads an image (the given input stream is closed internally). This method also tags the image
+   * Creates a single image from a tarball. This method also tags the image
    * with the given image name upon loading completion.
    *
    * @param image        the name to assign to the image.
@@ -249,13 +258,17 @@ public interface DockerClient extends Closeable {
    * @param authConfig   The authentication config needed to pull the image.
    * @throws DockerException      if a server error occurred (500).
    * @throws InterruptedException if the thread is interrupted.
+   *
+   * @deprecated Use {@link #load(InputStream)} to load a set of image layers from a tarball. Use
+   * {@link #create(String, InputStream)} to create a single image from the contents of a tarball.
    */
+  @Deprecated
   void load(String image, InputStream imagePayload, AuthConfig authConfig)
       throws DockerException, InterruptedException;
 
 
   /**
-   * Loads an image (the given input stream is closed internally). This method also tags the image
+   * Creates a single image from a tarball. This method also tags the image
    * with the given image name upon loading completion.
    *
    * @param image        the name to assign to the image.
@@ -266,10 +279,52 @@ public interface DockerClient extends Closeable {
    *                     Docker.
    * @throws DockerException      if a server error occurred (500).
    * @throws InterruptedException if the thread is interrupted.
+   *
+   * @deprecated Use {@link #load(InputStream)} to load a set of image layers from a tarball. Use
+   * {@link #create(String, InputStream, ProgressHandler)} to create a single image from the
+   * contents of a tarball.
    */
+  @Deprecated
   void load(String image, InputStream imagePayload, AuthConfig authConfig,
             ProgressHandler handler) throws DockerException, InterruptedException;
 
+  /**
+   * Load a set of images and tags from a tarball.
+   *
+   * @param imagePayload the image's payload (i.e.: the stream corresponding to the image's .tar
+   *                     file).
+   * @throws DockerException      if a server error occurred (500).
+   * @throws InterruptedException if the thread is interrupted.
+   */
+  void load(InputStream imagePayload) throws DockerException, InterruptedException;
+
+  /**
+   * Creates a single image from a tarball. This method also tags the image
+   * with the given image name upon loading completion.
+   *
+   * @param image        the name to assign to the image.
+   * @param imagePayload the image's payload (i.e.: the stream corresponding to the image's .tar
+   *                     file).
+   * @throws DockerException      if a server error occurred (500).
+   * @throws InterruptedException if the thread is interrupted.
+   */
+  void create(String image, InputStream imagePayload)
+          throws DockerException, InterruptedException;
+
+  /**
+   * Creates a single image from a tarball. This method also tags the image
+   * with the given image name upon loading completion.
+   *
+   * @param image        the name to assign to the image.
+   * @param imagePayload the image's payload (i.e.: the stream corresponding to the image's .tar
+   *                     file).
+   * @param handler      The handler to use for processing each progress message received from
+   *                     Docker.
+   * @throws DockerException      if a server error occurred (500).
+   * @throws InterruptedException if the thread is interrupted.
+   */
+  void create(String image, InputStream imagePayload, ProgressHandler handler)
+          throws DockerException, InterruptedException;
 
   /**
    * @param image the name of the image to save.

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -401,14 +401,14 @@ public class DefaultDockerClientTest {
   }
 
   @Test
-  public void testLoad() throws Exception {
+  public void testCreate() throws Exception {
     // Ensure the local Docker instance has the busybox image so that save() will work
     sut.pull(BUSYBOX_LATEST);
     final File imageFile = save(BUSYBOX);
     final String image = BUSYBOX + "test" + System.nanoTime();
 
     try (InputStream imagePayload = new BufferedInputStream(new FileInputStream(imageFile))) {
-      sut.load(image, imagePayload, authConfig);
+      sut.create(image, imagePayload);
     }
 
     final Collection<Image> images = Collections2.filter(sut.listImages(), new Predicate<Image>() {


### PR DESCRIPTION
Fix for #154 and #464.

Previously, the various `DockerClient.load(...)` methods all wrapped the `/images/create` docker API endpoint, not the `/images/load` endpoint as the method name implies. In fact, no methods in `DockerClient` wrapped `/images/load`.

This PR:
* Deprecates all existing `DockerClient.load(...)` methods;
* Creates two `DockerClient.create(...)` methods, the implementations of which perform the functions that `DefaultDockerClient.load(...)` used to perform;
* Creates a new `DockerClient.load(ImageStream)` method, the implementation of which calls `/images/load`.