### PR TITLE
Change return type of DockerClient.archiveContainer() to plain InputStream

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -72,7 +72,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.net.HostAndPort;
 
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -760,7 +759,8 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     }
   }
 
-  public TarArchiveInputStream archiveContainer(String containerId, String path)
+  @Override
+  public InputStream archiveContainer(String containerId, String path)
       throws DockerException, InterruptedException {
     final String apiVersion = version().apiVersion();
     final int versionComparison = compareVersion(apiVersion, "1.20");
@@ -775,8 +775,8 @@ public class DefaultDockerClient implements DockerClient, Closeable {
         .queryParam("path", path);
 
     try {
-      return new TarArchiveInputStream(request(GET, InputStream.class, resource,
-          resource.request(APPLICATION_OCTET_STREAM_TYPE)));
+      return request(GET, InputStream.class, resource,
+          resource.request(APPLICATION_OCTET_STREAM_TYPE));
     } catch (DockerRequestException e) {
       switch (e.status()) {
         case 404:

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -44,8 +44,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-
 import static com.google.common.base.Strings.isNullOrEmpty;
 
 /**
@@ -925,7 +923,7 @@ public interface DockerClient extends Closeable {
    * @throws DockerException      if a server error occurred (500)
    * @throws InterruptedException If the thread is interrupted
    */
-  TarArchiveInputStream archiveContainer(String containerId, String path)
+  InputStream archiveContainer(String containerId, String path)
       throws DockerException, InterruptedException;
 
   /**

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -960,7 +960,7 @@ public class DefaultDockerClientTest {
 
     final ImmutableSet.Builder<String> files = ImmutableSet.builder();
     try (final TarArchiveInputStream tarStream =
-        sut.archiveContainer(id, "/bin")) {
+        new TarArchiveInputStream(sut.archiveContainer(id, "/bin"))) {
       TarArchiveEntry entry;
       while ((entry = tarStream.getNextTarEntry()) != null) {
         files.add(entry.getName());
@@ -1182,10 +1182,10 @@ public class DefaultDockerClientTest {
 
       // Copy the same files from container
       final ImmutableSet.Builder<String> filesDownloaded = ImmutableSet.builder();
-      try (TarArchiveInputStream tarStream =
+      try (TarArchiveInputStream tarStream = new TarArchiveInputStream(
                dockerApiVersionLessThan("1.24") ?
-               new TarArchiveInputStream(sut.copyContainer(id, "/tmp")) :
-               sut.archiveContainer(id, "/tmp")) {
+               sut.copyContainer(id, "/tmp") :
+               sut.archiveContainer(id, "/tmp"))) {
         TarArchiveEntry entry;
         while ((entry = tarStream.getNextTarEntry()) != null) {
           filesDownloaded.add(entry.getName());


### PR DESCRIPTION
While I appreciate the feature addition from 23f3c29ae7205d2b4f483a1a4df7db6025774f2f, I question the new method signature. Handing out a `TarArchiveInputStream` makes assumptions about the caller's use case and limits the general usability of the new API. Wrapping a plain input stream into a `TarArchiveInputStream` is easy to do in calling code, the opposite however of getting to the plain stream (e.g. to simply write it out to disk) from `TarArchiveInputStream` is not.