### PR TITLE
deprecate copyContainer and delegate to archiveContainer

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -747,7 +747,9 @@ public class DefaultDockerClient implements DockerClient, Closeable {
 
     // Version above 1.24
     if (versionComparison >= 0) {
-      throw new UnsupportedApiVersionException(apiVersion);
+      // fall back to archive added in 1.20
+      // as copy has been removed in 1.24
+      return archiveContainer(containerId, path);
     }
 
     final WebTarget resource = resource()

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -1018,11 +1018,14 @@ public interface DockerClient extends Closeable {
    * {@code "share"} in the tar archive.  If a single file was copied, that file will be the sole
    * entry in the tar archive.  Copying {@code "."} or equivalently {@code "/"} will result in the
    * tar archive containing a single folder named after the container ID.
+   * @deprecated Removed in Docker Remote API 1.24. Use
+   * {@link #archiveContainer(String, String)} instead.
    * @throws com.spotify.docker.client.exceptions.ContainerNotFoundException
    *                              if container is not found (404)
    * @throws DockerException      if a server error occurred (500)
    * @throws InterruptedException If the thread is interrupted
    */
+  @Deprecated
   InputStream copyContainer(String containerId, String path)
       throws DockerException, InterruptedException;
 

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -905,8 +905,6 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testCopyContainer() throws Exception {
-    requireDockerApiVersionLessThan("1.24", "failCopyToContainer");
-
     // Pull image
     sut.pull(BUSYBOX_LATEST);
 
@@ -929,26 +927,6 @@ public class DefaultDockerClientTest {
 
     // Check that some common files exist
     assertThat(files.build(), both(hasItem("bin/")).and(hasItem("bin/wc")));
-  }
-
-  @Test
-  public void testFailCopyContainer() throws Exception {
-    requireDockerApiVersionAtLeast("1.24", "failCopyToContainer");
-
-    exception.expect(UnsupportedApiVersionException.class);
-
-    // Pull image
-    sut.pull(BUSYBOX_LATEST);
-
-    // Create container
-    final ContainerConfig config = ContainerConfig.builder()
-        .image(BUSYBOX_LATEST)
-        .build();
-    final String name = randomName();
-    final ContainerCreation creation = sut.createContainer(config, name);
-    final String id = creation.id();
-
-    sut.copyContainer(id, "/bin");
   }
 
   @Test


### PR DESCRIPTION
...if API version is 1.24 or greater. This is intended to prevent breaking existing applications that use `copyContainer`, as it will be apparent only at runtime that the command is not supported.

I thought as long as the behavior is the same, `copyContainer` can be easily backed by `archiveContainer`, giving users some time to migrate.