### PR TITLE
Adding ShmSize HostConfig parameter support

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/HostConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/HostConfig.java
@@ -64,6 +64,7 @@ public class HostConfig {
   @JsonProperty("IpcMode") private String ipcMode;
   @JsonProperty("Ulimits") private ImmutableList<Ulimit> ulimits;
   @JsonProperty("PidMode") private String pidMode;
+  @JsonProperty("ShmSize") private Long shmSize;
 
   private HostConfig() {
   }
@@ -97,6 +98,7 @@ public class HostConfig {
     this.ipcMode = builder.ipcMode;
     this.ulimits = builder.ulimits;
     this.pidMode = builder.pidMode;
+    this.shmSize = builder.shmSize;
   }
 
   public List<String> binds() {
@@ -207,6 +209,10 @@ public class HostConfig {
     return ulimits;
   }
 
+  public Long shmSize() {
+    return shmSize;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -253,7 +259,7 @@ public class HostConfig {
                         publishAllPorts, dns, dnsSearch, extraHosts, volumesFrom, capAdd,
                         capDrop, networkMode, securityOpt, devices, memory, memorySwap,
                         memoryReservation, cpuShares, cpusetCpus, cpuQuota, cgroupParent,
-                        restartPolicy, logConfig, ipcMode, ulimits, pidMode);
+                        restartPolicy, logConfig, ipcMode, ulimits, pidMode, shmSize);
   }
 
   @Override
@@ -287,6 +293,7 @@ public class HostConfig {
         .add("ipcMode", ipcMode)
         .add("ulimits", ulimits)
         .add("pidMode", pidMode)
+        .add("shmSize", shmSize)
         .toString();
   }
 
@@ -438,6 +445,7 @@ public class HostConfig {
     private String ipcMode;
     private ImmutableList<Ulimit> ulimits;
     private String pidMode;
+    private Long shmSize;
 
     private Builder() {
     }
@@ -471,6 +479,7 @@ public class HostConfig {
       this.ipcMode = hostConfig.ipcMode;
       this.ulimits = hostConfig.ulimits;
       this.pidMode = hostConfig.pidMode;
+      this.shmSize = hostConfig.shmSize;
     }
 
     /**
@@ -943,6 +952,15 @@ public class HostConfig {
     public Builder hostPidMode() {
       this.pidMode = "host";
       return this;
+    }
+
+    public Builder shmSize(final Long shmSize) {
+      this.shmSize = shmSize;
+      return this;
+    }
+
+    public Long shmSize() {
+      return shmSize;
     }
 
     public HostConfig build() {

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -3041,6 +3041,24 @@ public class DefaultDockerClientTest {
 
   }
 
+  @Test
+  public void testShmSize() throws Exception {
+    requireDockerApiVersionAtLeast("1.22", "ShmSize");
+
+    final ContainerConfig config = ContainerConfig.builder()
+            .image(BUSYBOX_LATEST)
+            .hostConfig(HostConfig.builder()
+                    .shmSize(10000000L)
+                    .build())
+            .build();
+
+    final ContainerCreation container = sut.createContainer(config, randomName());
+    final ContainerInfo info = sut.inspectContainer(container.id());
+
+    assertThat(info.hostConfig().shmSize(), is(10000000L));
+
+  }
+
   private String randomName() {
     return nameTag + '-' + toHexString(ThreadLocalRandom.current().nextLong());
   }


### PR DESCRIPTION
The `ShmSize` parameter of `HostConfig` is missing in current version of docker-client. However this is a part of [v1.22](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.22/).