### PR TITLE
Add missing OOM attributes to HostConfig

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/HostConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/HostConfig.java
@@ -64,6 +64,8 @@ public class HostConfig {
   @JsonProperty("IpcMode") private String ipcMode;
   @JsonProperty("Ulimits") private ImmutableList<Ulimit> ulimits;
   @JsonProperty("PidMode") private String pidMode;
+  @JsonProperty("OomKillDisable") private Boolean oomKillDisable;
+  @JsonProperty("OomScoreAdj") private Integer oomScoreAdj;
 
   private HostConfig() {
   }
@@ -97,6 +99,8 @@ public class HostConfig {
     this.ipcMode = builder.ipcMode;
     this.ulimits = builder.ulimits;
     this.pidMode = builder.pidMode;
+    this.oomKillDisable = builder.oomKillDisable;
+    this.oomScoreAdj = builder.oomScoreAdj;
   }
 
   public List<String> binds() {
@@ -207,6 +211,14 @@ public class HostConfig {
     return ulimits;
   }
 
+  public Boolean oomKillDisable() {
+    return oomKillDisable;
+  }
+
+  public Integer oomScoreAdj() {
+    return oomScoreAdj;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -244,7 +256,9 @@ public class HostConfig {
         Objects.equals(this.restartPolicy, that.restartPolicy) &&
         Objects.equals(this.logConfig, that.logConfig) &&
         Objects.equals(this.ipcMode, that.ipcMode) &&
-        Objects.equals(this.ulimits, that.ulimits);
+        Objects.equals(this.ulimits, that.ulimits) &&
+        Objects.equals(this.oomKillDisable, that.oomKillDisable) &&
+        Objects.equals(this.oomScoreAdj, that.oomScoreAdj);
   }
 
   @Override
@@ -253,7 +267,8 @@ public class HostConfig {
                         publishAllPorts, dns, dnsSearch, extraHosts, volumesFrom, capAdd,
                         capDrop, networkMode, securityOpt, devices, memory, memorySwap,
                         memoryReservation, cpuShares, cpusetCpus, cpuQuota, cgroupParent,
-                        restartPolicy, logConfig, ipcMode, ulimits, pidMode);
+                        restartPolicy, logConfig, ipcMode, ulimits, pidMode, oomKillDisable,
+                        oomScoreAdj);
   }
 
   @Override
@@ -287,6 +302,8 @@ public class HostConfig {
         .add("ipcMode", ipcMode)
         .add("ulimits", ulimits)
         .add("pidMode", pidMode)
+        .add("oomKillDisable", oomKillDisable)
+        .add("oomScoreAdj", oomScoreAdj)
         .toString();
   }
 
@@ -438,6 +455,8 @@ public class HostConfig {
     private String ipcMode;
     private ImmutableList<Ulimit> ulimits;
     private String pidMode;
+    private Boolean oomKillDisable;
+    private Integer oomScoreAdj;
 
     private Builder() {
     }
@@ -471,6 +490,8 @@ public class HostConfig {
       this.ipcMode = hostConfig.ipcMode;
       this.ulimits = hostConfig.ulimits;
       this.pidMode = hostConfig.pidMode;
+      this.oomKillDisable = hostConfig.oomKillDisable;
+      this.oomScoreAdj = hostConfig.oomScoreAdj;
     }
 
     /**
@@ -943,6 +964,24 @@ public class HostConfig {
     public Builder hostPidMode() {
       this.pidMode = "host";
       return this;
+    }
+
+    public Builder oomKillDisable(final Boolean oomKillDisable) {
+      this.oomKillDisable = oomKillDisable;
+      return this;
+    }
+
+    public Boolean oomKillDisable() {
+      return oomKillDisable;
+    }
+
+    public Builder oomScoreAdj(final Integer oomScoreAdj) {
+      this.oomScoreAdj = oomScoreAdj;
+      return this;
+    }
+
+    public Integer oomScoreAdj() {
+      return oomScoreAdj;
     }
 
     public HostConfig build() {


### PR DESCRIPTION
Adds:
- --oom-kill-disable
- --oom-score-adj

 https://docs.docker.com/engine/reference/run/#/runtime-constraints-on-resources

Resolves https://github.com/spotify/docker-client/issues/481