### PR TITLE
Changes to loading and saving

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -1050,22 +1050,33 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   }
 
   @Override
-  public InputStream save(final String image)
+  public InputStream save(final String... images)
       throws DockerException, IOException, InterruptedException {
-    return save(image, authConfig);
-  }
-
-  @Override
-  public InputStream save(final String image, final AuthConfig authConfig)
-      throws DockerException, IOException, InterruptedException {
-    final WebTarget resource = resource().path("images").path(image).path("get");
+    WebTarget resource;
+    if (images.length == 1) {
+      resource = resource().path("images").path(images[0]).path("get");
+    } else {
+      resource = resource().path("images").path("get");
+      if (images.length > 1) {
+        for (final String image : images) {
+          if (!isNullOrEmpty(image)) {
+            resource = resource.queryParam("names", urlEncode(image));
+          }
+        }
+      }
+    }
 
     return request(
         GET,
         InputStream.class,
         resource,
-        resource.request(APPLICATION_JSON_TYPE).header("X-Registry-Auth", authHeader(authConfig))
-    );
+        resource.request(APPLICATION_JSON_TYPE));
+  }
+
+  @Override
+  public InputStream save(final String image, final AuthConfig authConfig)
+          throws DockerException, IOException, InterruptedException {
+    return save(image);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -973,29 +973,46 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   }
 
   @Override
+  @Deprecated
   public void load(final String image, final InputStream imagePayload)
       throws DockerException, InterruptedException {
-    load(image, imagePayload, authConfig, new LoggingPullHandler("image stream"));
+    create(image, imagePayload);
   }
 
   @Override
+  @Deprecated
   public void load(final String image, final InputStream imagePayload,
                    final AuthConfig authConfig)
       throws DockerException, InterruptedException {
-    load(image, imagePayload, authConfig, new LoggingPullHandler("image stream"));
+    create(image, imagePayload);
   }
 
   @Override
+  @Deprecated
   public void load(final String image, final InputStream imagePayload,
                    final ProgressHandler handler)
       throws DockerException, InterruptedException {
-    load(image, imagePayload, authConfig, handler);
+    create(image, imagePayload, handler);
   }
 
   @Override
+  @Deprecated
   public void load(final String image, final InputStream imagePayload,
                    final AuthConfig authConfig, final ProgressHandler handler)
       throws DockerException, InterruptedException {
+    create(image, imagePayload, handler);
+  }
+
+  @Override
+  public void create(final String image, final InputStream imagePayload)
+          throws DockerException, InterruptedException {
+    create(image, imagePayload, new LoggingPullHandler("image stream"));
+  }
+
+  @Override
+  public void create(final String image, final InputStream imagePayload,
+                     final ProgressHandler handler)
+          throws DockerException, InterruptedException {
     WebTarget resource = resource().path("images").path("create");
 
     resource = resource
@@ -1007,13 +1024,26 @@ public class DefaultDockerClient implements DockerClient, Closeable {
                                                      MediaType.APPLICATION_OCTET_STREAM);
     try (final ProgressStream load =
              request(POST, ProgressStream.class, resource,
-                     resource
-                         .request(APPLICATION_JSON_TYPE)
-                         .header("X-Registry-Auth", authHeader(authConfig)), entity)) {
+                     resource.request(APPLICATION_JSON_TYPE), entity)) {
       load.tail(loadProgressHandler, POST, resource.getUri());
       tag(loadProgressHandler.getImageId(), image, true);
     } catch (IOException e) {
       throw new DockerException(e);
+    } finally {
+      IOUtils.closeQuietly(imagePayload);
+    }
+  }
+
+  @Override
+  public void load(final InputStream imagePayload)
+          throws DockerException, InterruptedException {
+    final WebTarget resource = resource().path("images").path("load");
+
+    final Entity<InputStream> entity = Entity.entity(imagePayload,
+            MediaType.APPLICATION_OCTET_STREAM);
+    try {
+      request(POST, ProgressStream.class, resource,
+              resource.request(APPLICATION_JSON_TYPE), entity);
     } finally {
       IOUtils.closeQuietly(imagePayload);
     }

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -214,7 +214,7 @@ public interface DockerClient extends Closeable {
 
 
   /**
-   * Loads an image (the given input stream is closed internally). This method also tags the image
+   * Creates a single image from a tarball. This method also tags the image
    * with the given image name upon loading completion.
    *
    * @param image        the name to assign to the image.
@@ -222,13 +222,17 @@ public interface DockerClient extends Closeable {
    *                     file).
    * @throws DockerException      if a server error occurred (500).
    * @throws InterruptedException if the thread is interrupted.
+   *
+   * @deprecated Use {@link #load(InputStream)} to load a set of image layers from a tarball. Use
+   * {@link #create(String, InputStream)} to create a single image from the contents of a tarball.
    */
+  @Deprecated
   void load(String image, InputStream imagePayload)
       throws DockerException, InterruptedException;
 
 
   /**
-   * Loads an image (the given input stream is closed internally). This method also tags the image
+   * Creates a single image from a tarball. This method also tags the image
    * with the given image name upon loading completion.
    *
    * @param image        the name to assign to the image.
@@ -238,13 +242,18 @@ public interface DockerClient extends Closeable {
    *                     Docker.
    * @throws DockerException      if a server error occurred (500).
    * @throws InterruptedException if the thread is interrupted.
+   *
+   * @deprecated Use {@link #load(InputStream)} to load a set of image layers from a tarball. Use
+   * {@link #create(String, InputStream, ProgressHandler)} to create a single image from the
+   * contents of a tarball.
    */
+  @Deprecated
   void load(String image, InputStream imagePayload, ProgressHandler handler)
       throws DockerException, InterruptedException;
 
 
   /**
-   * Loads an image (the given input stream is closed internally). This method also tags the image
+   * Creates a single image from a tarball. This method also tags the image
    * with the given image name upon loading completion.
    *
    * @param image        the name to assign to the image.
@@ -253,13 +262,17 @@ public interface DockerClient extends Closeable {
    * @param authConfig   The authentication config needed to pull the image.
    * @throws DockerException      if a server error occurred (500).
    * @throws InterruptedException if the thread is interrupted.
+   *
+   * @deprecated Use {@link #load(InputStream)} to load a set of image layers from a tarball. Use
+   * {@link #create(String, InputStream)} to create a single image from the contents of a tarball.
    */
+  @Deprecated
   void load(String image, InputStream imagePayload, AuthConfig authConfig)
       throws DockerException, InterruptedException;
 
 
   /**
-   * Loads an image (the given input stream is closed internally). This method also tags the image
+   * Creates a single image from a tarball. This method also tags the image
    * with the given image name upon loading completion.
    *
    * @param image        the name to assign to the image.
@@ -270,10 +283,52 @@ public interface DockerClient extends Closeable {
    *                     Docker.
    * @throws DockerException      if a server error occurred (500).
    * @throws InterruptedException if the thread is interrupted.
+   *
+   * @deprecated Use {@link #load(InputStream)} to load a set of image layers from a tarball. Use
+   * {@link #create(String, InputStream, ProgressHandler)} to create a single image from the
+   * contents of a tarball.
    */
+  @Deprecated
   void load(String image, InputStream imagePayload, AuthConfig authConfig,
             ProgressHandler handler) throws DockerException, InterruptedException;
 
+  /**
+   * Load a set of images and tags from a tarball.
+   *
+   * @param imagePayload the image's payload (i.e.: the stream corresponding to the image's .tar
+   *                     file).
+   * @throws DockerException      if a server error occurred (500).
+   * @throws InterruptedException if the thread is interrupted.
+   */
+  void load(InputStream imagePayload) throws DockerException, InterruptedException;
+
+  /**
+   * Creates a single image from a tarball. This method also tags the image
+   * with the given image name upon loading completion.
+   *
+   * @param image        the name to assign to the image.
+   * @param imagePayload the image's payload (i.e.: the stream corresponding to the image's .tar
+   *                     file).
+   * @throws DockerException      if a server error occurred (500).
+   * @throws InterruptedException if the thread is interrupted.
+   */
+  void create(String image, InputStream imagePayload)
+          throws DockerException, InterruptedException;
+
+  /**
+   * Creates a single image from a tarball. This method also tags the image
+   * with the given image name upon loading completion.
+   *
+   * @param image        the name to assign to the image.
+   * @param imagePayload the image's payload (i.e.: the stream corresponding to the image's .tar
+   *                     file).
+   * @param handler      The handler to use for processing each progress message received from
+   *                     Docker.
+   * @throws DockerException      if a server error occurred (500).
+   * @throws InterruptedException if the thread is interrupted.
+   */
+  void create(String image, InputStream imagePayload, ProgressHandler handler)
+          throws DockerException, InterruptedException;
 
   /**
    * Get a tarball containing all images and metadata for the repository specified.

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -332,18 +332,18 @@ public interface DockerClient extends Closeable {
 
   /**
    * Get a tarball containing all images and metadata for the repository specified.
-   * @param image the name or id of the image to save. If a specific name and tag
+   * @param images the name(s) of one or more images to save. If a specific name and tag
    *              (e.g. ubuntu:latest), then only that image (and its parents) are returned.
    *              If an image ID, similarly only that image (and its parents) are returned,
    *              but with the exclusion of the 'repositories' file in the tarball,
    *              as there were no image names referenced.
-   * @return the image's .tar stream.
+   * @return the images' .tar streams.
    * @throws DockerException      if a server error occurred (500).
    * @throws IOException          if the server started returning, but an I/O error occurred in the
    *                              context of processing it on the client-side.
    * @throws InterruptedException if the thread is interrupted.
    */
-  InputStream save(String image) throws DockerException, IOException, InterruptedException;
+  InputStream save(String... images) throws DockerException, IOException, InterruptedException;
 
   /**
    * Get a tarball containing all images and metadata for the repository specified.
@@ -358,7 +358,10 @@ public interface DockerClient extends Closeable {
    * @throws IOException          if the server started returning, but an I/O error occurred in the
    *                              context of processing it on the client-side.
    * @throws InterruptedException if the thread is interrupted.
+   *
+   * @deprecated AuthConfig is not required. Use {@link #save(String...)}.
    */
+  @Deprecated
   InputStream save(String image, AuthConfig authConfig)
       throws DockerException, IOException, InterruptedException;
 

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -410,14 +410,14 @@ public class DefaultDockerClientTest {
   }
 
   @Test
-  public void testLoad() throws Exception {
+  public void testCreate() throws Exception {
     // Ensure the local Docker instance has the busybox image so that save() will work
     sut.pull(BUSYBOX_LATEST);
     final File imageFile = save(BUSYBOX);
     final String image = BUSYBOX + "test" + System.nanoTime();
 
     try (InputStream imagePayload = new BufferedInputStream(new FileInputStream(imageFile))) {
-      sut.load(image, imagePayload, authConfig);
+      sut.create(image, imagePayload);
     }
 
     final Collection<Image> images = Collections2.filter(sut.listImages(), new Predicate<Image>() {

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -390,7 +390,7 @@ public class DefaultDockerClientTest {
     assertTrue(imageFile.length() > 0);
   }
 
-  private File save(String image) throws Exception {
+  private File save(final String image) throws Exception {
     final File tmpDir = new File(System.getProperty("java.io.tmpdir"));
     assertTrue("Temp directory " + tmpDir.getAbsolutePath() + " does not exist", tmpDir.exists());
     final File imageFile = new File(tmpDir, "busybox-" + System.nanoTime() + ".tar");
@@ -400,7 +400,7 @@ public class DefaultDockerClientTest {
     final byte[] buffer = new byte[2048];
     int read;
     try (OutputStream imageOutput = new BufferedOutputStream(new FileOutputStream(imageFile))) {
-      try (InputStream imageInput = sut.save(image, authConfig)) {
+      try (InputStream imageInput = sut.save(image)) {
         while ((read = imageInput.read(buffer)) > -1) {
           imageOutput.write(buffer, 0, read);
         }


### PR DESCRIPTION
Fix for #154 and #464.

## Load and Create
Previously, the various `DockerClient.load(...)` methods all wrapped the `/images/create` docker API endpoint, not the `/images/load` endpoint as the method name implies. In fact, no methods in `DockerClient` wrapped `/images/load`.

This PR:
* Deprecates all existing `DockerClient.load(...)` methods;
* Creates two `DockerClient.create(...)` methods, the implementations of which perform the functions that `DefaultDockerClient.load(...)` used to perform;
* Creates a new `DockerClient.load(ImageStream)` method, the implementation of which calls `/images/load`.

## Save
* There was no reason to use the `AuthConfig` when calling `/images/{name}/get`. The method `DockerClient.save(String, AuthConfig)` has been deprecated.
* The other `save` method, `DockerClient.save(String)` has been changed to `DockerClient.save(String...)`. This is to make use of the two related APIs `/images/{name}/get` and `/images/get?names=name1&names=name2...`.