### PR TITLE
Fix broken builds for Docker 1.9 and 1.10 on TravisCI

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -19,6 +19,8 @@ case "$1" in
 
     # stop docker service if running
     sudo stop docker || :
+    # Remove old docker files that might prevent the installation and starting of other versions
+    sudo rm -fr /var/lib/docker || :
 
     if [[ "$DOCKER_VERSION" =~ ^1\.12\..* ]]; then
       sudo sh -c 'echo "deb https://apt.dockerproject.org/repo ubuntu-trusty experimental" > /etc/apt/sources.list.d/docker.list'
@@ -79,6 +81,9 @@ end script
       # installing the package
       sudo restart docker
     fi
+
+    # Wait a minute so we can see more docker logs in case something goes wrong
+    sleep 60
 
     ;;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 
 services:
   - docker


### PR DESCRIPTION
These versions of Docker cannot start if there are old files left over
in `/var/lib/docker/network`. We delete the entire `/var/lib/docker`
directory to be safe.