### PR TITLE
Add swarm mode support

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -82,6 +82,11 @@ end script
       sudo restart docker
     fi
 
+    if [[ "$DOCKER_VERSION" =~ ^1\.12\..* ]]; then
+        # initialize docker swarm to be able to run docker tests
+        sudo docker swarm init --advertise-addr 127.0.0.1
+    fi
+
     # Wait a minute so we can see more docker logs in case something goes wrong
     sleep 60
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ docker-client should be buildable on any platform with Docker, JDK7+, and a rece
 Maven 3.
 
 ### A note on using Docker for Mac
-If you are using Docker for Mac and `DefaultDockerClient.fromEnv()`, it might not be clear 
+If you are using Docker for Mac and `DefaultDockerClient.fromEnv()`, it might not be clear
 what value to use for the `DOCKER_HOST` environment variable. The value you should use is
 `DOCKER_HOST=unix:///var/run/docker.sock`, at least as of version 1.11.1-beta11.
 
@@ -99,6 +99,9 @@ As of version 4.0.8 of docker-client, `DefaultDockerClient.fromEnv()` uses
 `unix:///var/run/docker.sock` on OS X by default.
 
 ## Testing
+
+If you're running a recent version of docker (>= 1.12), which contains native swarm support, please 
+ensure that you run `docker swarm init` to initialize the docker swarm.
 
 Make sure Docker daemon is running and that you can do `docker ps`.
 

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014 Spotify AB.
+ * Copyright (c) 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +38,16 @@ import com.spotify.docker.client.messages.Network;
 import com.spotify.docker.client.messages.NetworkConfig;
 import com.spotify.docker.client.messages.NetworkCreation;
 import com.spotify.docker.client.messages.RemovedImage;
+import com.spotify.docker.client.messages.ServiceCreateOptions;
+import com.spotify.docker.client.messages.ServiceCreateResponse;
 import com.spotify.docker.client.messages.TopResults;
 import com.spotify.docker.client.messages.Version;
 import com.spotify.docker.client.messages.Volume;
 import com.spotify.docker.client.messages.VolumeList;
+import com.spotify.docker.client.messages.swarm.Service;
+import com.spotify.docker.client.messages.swarm.ServiceSpec;
+import com.spotify.docker.client.messages.swarm.Swarm;
+import com.spotify.docker.client.messages.swarm.Task;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -1206,6 +1213,111 @@ public interface DockerClient extends Closeable {
    */
   LogStream execStart(String execId, ExecStartParameter... params)
       throws DockerException, InterruptedException;
+
+  /**
+   * Inspect the Swarm cluster. Only available in Docker API &gt;= 1.24.
+   *
+   * @return Info about a swarm
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  Swarm inspectSwarm() throws DockerException, InterruptedException;
+
+  /**
+   * Create a new service. Only available in Docker API &gt;= 1.24.
+   *
+   * @param spec the service spec
+   * @param options the service creation parameters
+   * @return Service creation result with service id.
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  ServiceCreateResponse createService(ServiceSpec spec, ServiceCreateOptions options)
+          throws DockerException, InterruptedException;
+
+  /**
+   * Inspect an existing service. Only available in Docker API &gt;= 1.24.
+   *
+   * @param serviceId the id of the service to inspect
+   * @return Info about the service
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  Service inspectService(String serviceId) throws DockerException, InterruptedException;
+
+  /**
+   * Update an existing service. Only available in Docker API &gt;= 1.24.
+   *
+   * @param serviceId the identifier of the service
+   * @param version the version of the service
+   * @param spec the new service spec
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  void updateService(String serviceId, Long version, ServiceSpec spec)
+          throws DockerException, InterruptedException;
+
+  /**
+   * List all services. Only available in Docker API &gt;= 1.24.
+   *
+   * @return A list of services.
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  List<Service> listServices() throws DockerException, InterruptedException;
+
+  /**
+   * List services that match the given criteria. Only available in Docker API &gt;= 1.24.
+   *
+   * @param criteria Service listing and filtering options.
+   * @return
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  List<Service> listServices(Service.Criteria criteria)
+          throws DockerException, InterruptedException;
+
+  /**
+   * Remove an existing service. Only available in Docker API &gt;= 1.24.
+   *
+   * @param serviceId the id of the service to remove
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  void removeService(String serviceId)
+          throws DockerException, InterruptedException;
+
+  /**
+   * Inspect an existing task. Only available in Docker API &gt;= 1.24.
+   *
+   * @param taskId the id of the task to inspect
+   * @return Info about the task
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  Task inspectTask(String taskId)
+          throws DockerException, InterruptedException;
+
+  /**
+   * List all tasks. Only available in Docker API &gt;= 1.24.
+   *
+   * @return A list of tasks.
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  List<Task> listTasks()
+          throws DockerException, InterruptedException;
+
+  /**
+   * List tasks that match the given criteria. Only available in Docker API &gt;= 1.24.
+   *
+   * @param criteria
+   * @return A list of tasks.
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  List<Task> listTasks(Task.Criteria criteria)
+          throws DockerException, InterruptedException;
 
   /**
    * Supported parameters for {@link #execStart}

--- a/src/main/java/com/spotify/docker/client/exceptions/ServiceNotFoundException.java
+++ b/src/main/java/com/spotify/docker/client/exceptions/ServiceNotFoundException.java
@@ -14,17 +14,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package com.spotify.docker.client.exceptions;
 
-public class UnsupportedApiVersionException extends DockerException {
+public class ServiceNotFoundException extends NotFoundException {
 
-  public UnsupportedApiVersionException(final String version, final Throwable cause) {
-    super("Unsupported Api Version: " + version, cause);
-  }
+    private static final long serialVersionUID = 124167900943701078L;
 
-  public UnsupportedApiVersionException(final String version) {
-    this(version, null);
-  }
+    private final String serviceId;
 
+    public ServiceNotFoundException(final String serviceId, final Throwable cause) {
+        super("Service not found: " + serviceId, cause);
+        this.serviceId = serviceId;
+    }
+
+    public ServiceNotFoundException(final String serviceId) {
+        this(serviceId, null);
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
 }

--- a/src/main/java/com/spotify/docker/client/exceptions/TaskNotFoundException.java
+++ b/src/main/java/com/spotify/docker/client/exceptions/TaskNotFoundException.java
@@ -14,17 +14,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package com.spotify.docker.client.exceptions;
 
-public class UnsupportedApiVersionException extends DockerException {
+public class TaskNotFoundException extends NotFoundException {
 
-  public UnsupportedApiVersionException(final String version, final Throwable cause) {
-    super("Unsupported Api Version: " + version, cause);
-  }
+    private static final long serialVersionUID = 4974524646762384518L;
 
-  public UnsupportedApiVersionException(final String version) {
-    this(version, null);
-  }
+    private final String taskId;
 
+    public TaskNotFoundException(final String taskId, final Throwable cause) {
+        super("Task not found: " + taskId, cause);
+        this.taskId = taskId;
+    }
+
+    public TaskNotFoundException(final String taskId) {
+        this(taskId, null);
+    }
+
+    public String getTaskId() {
+        return taskId;
+    }
 }

--- a/src/main/java/com/spotify/docker/client/messages/ServiceCreateOptions.java
+++ b/src/main/java/com/spotify/docker/client/messages/ServiceCreateOptions.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class ServiceCreateOptions {
+
+    @JsonProperty("EncodedRegistryAuth")
+    private String encodedRegistryAuth;
+
+    public String encodedRegistryAuth() {
+        return encodedRegistryAuth;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ServiceCreateOptions that = (ServiceCreateOptions) o;
+
+        return Objects.equals(this.encodedRegistryAuth, that.encodedRegistryAuth);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(encodedRegistryAuth);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("encodedRegistryAuth", encodedRegistryAuth)
+                .toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/ServiceCreateResponse.java
+++ b/src/main/java/com/spotify/docker/client/messages/ServiceCreateResponse.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class ServiceCreateResponse {
+
+    @JsonProperty("ID")
+    private String id;
+
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ServiceCreateResponse that = (ServiceCreateResponse) o;
+
+        return Objects.equals(this.id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("id", id).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/mount/BindOptions.java
+++ b/src/main/java/com/spotify/docker/client/messages/mount/BindOptions.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.mount;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class BindOptions {
+
+    @JsonProperty("Propagation")
+    private String propagation;
+
+    public String propagation() {
+        return propagation;
+    }
+
+    public static class Builder {
+
+        private BindOptions bind = new BindOptions();
+
+        public Builder withPropagation(String propagation) {
+            bind.propagation = propagation;
+            return this;
+        }
+
+        public BindOptions build() {
+            return bind;
+        }
+    }
+
+    public static BindOptions.Builder builder() {
+        return new BindOptions.Builder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final BindOptions that = (BindOptions) o;
+
+        return Objects.equals(this.propagation, that.propagation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(propagation);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("propagation", propagation).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/mount/Driver.java
+++ b/src/main/java/com/spotify/docker/client/messages/mount/Driver.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.mount;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class Driver {
+
+    @JsonProperty("Name")
+    private String name;
+
+    @JsonProperty("Options")
+    private Map<String, String> options;
+
+    public String name() {
+        return name;
+    }
+
+    public Map<String, String> options() {
+        return options;
+    }
+
+    public static class Builder {
+
+        private Driver driver = new Driver();
+
+        public Builder withName(String name) {
+            driver.name = name;
+            return this;
+        }
+
+        public Builder withOption(String name, String value) {
+            if (driver.options == null) {
+                driver.options = new HashMap<String, String>();
+            }
+            driver.options.put(name, value);
+            return this;
+        }
+
+        public Driver build() {
+            return driver;
+        }
+    }
+
+    public static Driver.Builder builder() {
+        return new Driver.Builder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Driver that = (Driver) o;
+
+        return Objects.equals(this.name, that.name) && Objects.equals(this.options, that.options);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, options);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("name", name).add("options", options)
+                .toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/mount/Mount.java
+++ b/src/main/java/com/spotify/docker/client/messages/mount/Mount.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.mount;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class Mount {
+
+    @JsonProperty("Type")
+    private String type;
+
+    @JsonProperty("Source")
+    private String source;
+
+    @JsonProperty("Target")
+    private String target;
+
+    @JsonProperty("ReadOnly")
+    private Boolean readOnly;
+
+    @JsonProperty("BindOptions")
+    private BindOptions bindOptions;
+
+    @JsonProperty("VolumeOptions")
+    private VolumeOptions volumeOptions;
+
+    public String type() {
+        return type;
+    }
+
+    public String source() {
+        return source;
+    }
+
+    public String target() {
+        return target;
+    }
+
+    public Boolean readOnly() {
+        return readOnly;
+    }
+
+    public BindOptions bindOptions() {
+        return bindOptions;
+    }
+
+    public VolumeOptions volumeOptions() {
+        return volumeOptions;
+    }
+
+    public static class Builder {
+
+        private Mount mount = new Mount();
+
+        public Builder withType(String type) {
+            mount.type = type;
+            return this;
+        }
+
+        public Builder withSource(String source) {
+            mount.source = source;
+            return this;
+        }
+
+        public Builder withTarget(String target) {
+            mount.target = target;
+            return this;
+        }
+
+        public Builder makeReadOnly() {
+            mount.readOnly = true;
+            return this;
+        }
+
+        public Builder makeReadOnly(boolean readOnly) {
+            mount.readOnly = readOnly;
+            return this;
+        }
+
+        public Builder withBindOptions(BindOptions bindOptions) {
+            mount.bindOptions = bindOptions;
+            return this;
+        }
+
+        public Builder withVolumeOptions(VolumeOptions volumeOptions) {
+            mount.volumeOptions = volumeOptions;
+            return this;
+        }
+
+        public Mount build() {
+            return mount;
+        }
+    }
+
+    public static Mount.Builder builder() {
+        return new Mount.Builder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Mount that = (Mount) o;
+
+        return Objects.equals(this.type, that.type) && Objects.equals(this.source, that.source)
+                && Objects.equals(this.target, that.target)
+                && Objects.equals(this.readOnly, that.readOnly)
+                && Objects.equals(this.bindOptions, that.bindOptions)
+                && Objects.equals(this.volumeOptions, that.volumeOptions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, source, target, readOnly, bindOptions, volumeOptions);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("type", type).add("source", source)
+                .add("target", target).add("readOnly", readOnly).add("bindOptions", bindOptions)
+                .add("volumeOptions", volumeOptions).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/mount/VolumeOptions.java
+++ b/src/main/java/com/spotify/docker/client/messages/mount/VolumeOptions.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.mount;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class VolumeOptions {
+
+    @JsonProperty("NoCopy")
+    private Boolean noCopy;
+
+    @JsonProperty("Labels")
+    private Map<String, String> labels;
+
+    @JsonProperty("DriverConfig")
+    private Driver driverConfig;
+
+    public Boolean noCopy() {
+        return noCopy;
+    }
+
+    public Map<String, String> labels() {
+        return labels;
+    }
+
+    public Driver driverConfig() {
+        return driverConfig;
+    }
+
+    public static class Builder {
+
+        private VolumeOptions volume = new VolumeOptions();
+
+        public Builder withNoCopy() {
+            volume.noCopy = true;
+            return this;
+        }
+
+        public Builder withNoCopy(boolean noCopy) {
+            volume.noCopy = noCopy;
+            return this;
+        }
+
+        public Builder withLabel(String label, String value) {
+            if (volume.labels == null) {
+                volume.labels = new HashMap<String, String>();
+            }
+            volume.labels.put(label, value);
+            return this;
+        }
+
+        public Builder withDriverConfig(Driver driverConfig) {
+            volume.driverConfig = driverConfig;
+            return this;
+        }
+
+        public VolumeOptions build() {
+            return volume;
+        }
+    }
+
+    public static VolumeOptions.Builder builder() {
+        return new VolumeOptions.Builder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final VolumeOptions that = (VolumeOptions) o;
+
+        return Objects.equals(this.noCopy, that.noCopy) && Objects.equals(this.labels, that.labels)
+                && Objects.equals(this.driverConfig, that.driverConfig);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(noCopy, labels, driverConfig);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("noCopy", noCopy).add("labels", labels)
+                .add("driverConfig", driverConfig).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/CaConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/CaConfig.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class CaConfig {
+
+    @JsonProperty("NodeCertExpiry")
+    private Long nodeCertExpiry;
+
+    @JsonProperty("ExternalCAs")
+    private ImmutableList<ExternalCa> externalCas;
+
+    public Long nodeCertExpiry() {
+        return nodeCertExpiry;
+    }
+
+    public List<ExternalCa> externalCas() {
+        return externalCas;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final CaConfig that = (CaConfig) o;
+
+        return Objects.equals(this.nodeCertExpiry, that.nodeCertExpiry)
+                && Objects.equals(this.externalCas, that.externalCas);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nodeCertExpiry, externalCas);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("nodeCertExpiry", nodeCertExpiry)
+                .add("externalCas", externalCas).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ContainerSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ContainerSpec.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.spotify.docker.client.messages.mount.Mount;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class ContainerSpec {
+
+    @JsonProperty("Image")
+    private String image;
+
+    @JsonProperty("Labels")
+    private Map<String, String> labels;
+
+    @JsonProperty("Command")
+    private ImmutableList<String> command;
+
+    @JsonProperty("Args")
+    private ImmutableList<String> args;
+
+    @JsonProperty("Env")
+    private ImmutableList<String> env;
+
+    @JsonProperty("Dir")
+    private String dir;
+
+    @JsonProperty("User")
+    private String user;
+
+    @JsonProperty("Groups")
+    private ImmutableList<String> groups;
+
+    @JsonProperty("TTY")
+    private Boolean tty;
+
+    @JsonProperty("Mounts")
+    private ImmutableList<Mount> mounts;
+
+    @JsonProperty("StopGracePeriod")
+    private Long stopGracePeriod;
+
+    public String image() {
+        return image;
+    }
+
+    public Map<String, String> labels() {
+        return labels;
+    }
+
+    public List<String> command() {
+        return command;
+    }
+
+    public List<String> args() {
+        return args;
+    }
+
+    public List<String> env() {
+        return env;
+    }
+
+    public String dir() {
+        return dir;
+    }
+
+    public String user() {
+        return user;
+    }
+
+    public List<String> groups() {
+        return groups;
+    }
+
+    public Boolean tty() {
+        return tty;
+    }
+
+    public List<Mount> mounts() {
+        return mounts;
+    }
+
+    public Long stopGracePeriod() {
+        return stopGracePeriod;
+    }
+
+    public static class Builder {
+
+        private ContainerSpec spec = new ContainerSpec();
+
+        public Builder withImage(String image) {
+            spec.image = image;
+            return this;
+        }
+
+        public Builder withLabel(String label, String value) {
+            if (spec.labels == null) {
+                spec.labels = new HashMap<String, String>();
+            }
+            spec.labels.put(label, value);
+            return this;
+        }
+
+        public Builder withCommands(String... commands) {
+            if (commands != null && commands.length > 0) {
+                spec.command = ImmutableList.copyOf(commands);
+            }
+            return this;
+        }
+
+        public Builder withCommands(List<String> commands) {
+            if (commands != null && !commands.isEmpty()) {
+                spec.command = ImmutableList.copyOf(commands);
+            }
+            return this;
+        }
+
+        public Builder withArgs(String... args) {
+            if (args != null && args.length > 0) {
+                spec.args = ImmutableList.copyOf(args);
+            }
+            return this;
+        }
+
+        public Builder withArgs(List<String> args) {
+            if (args != null && !args.isEmpty()) {
+                spec.args = ImmutableList.copyOf(args);
+            }
+            return this;
+        }
+
+        public Builder withEnv(String... env) {
+            if (env != null && env.length > 0) {
+                spec.env = ImmutableList.copyOf(env);
+            }
+            return this;
+        }
+
+        public Builder withEnv(List<String> env) {
+            spec.env = ImmutableList.copyOf(env);
+            return this;
+        }
+
+        public Builder withDir(String dir) {
+            spec.dir = dir;
+            return this;
+        }
+
+        public Builder withUser(String user) {
+            spec.user = user;
+            return this;
+        }
+
+        public Builder withGroups(String... groups) {
+            if (groups != null && groups.length > 0) {
+                spec.groups = ImmutableList.copyOf(groups);
+            }
+            return this;
+        }
+
+        public Builder withGroups(List<String> groups) {
+            if (groups != null && !groups.isEmpty()) {
+                spec.groups = ImmutableList.copyOf(groups);
+            }
+            return this;
+        }
+
+        public Builder withTty() {
+            spec.tty = true;
+            return this;
+        }
+
+        public Builder withTty(boolean tty) {
+            spec.tty = tty;
+            return this;
+        }
+
+        public Builder withMounts(Mount... mounts) {
+            if (mounts != null && mounts.length > 0) {
+                spec.mounts = ImmutableList.copyOf(mounts);
+            }
+            return this;
+        }
+
+        public Builder withMounts(List<Mount> mounts) {
+            if (mounts != null && !mounts.isEmpty()) {
+                spec.mounts = ImmutableList.copyOf(mounts);
+            }
+            return this;
+        }
+
+        public Builder withStopGracePeriod(long stopGracePeriod) {
+            spec.stopGracePeriod = stopGracePeriod;
+            return this;
+        }
+
+        public ContainerSpec build() {
+            return spec;
+        }
+    }
+
+    public static ContainerSpec.Builder builder() {
+        return new ContainerSpec.Builder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ContainerSpec that = (ContainerSpec) o;
+
+        return Objects.equals(this.image, that.image) && Objects.equals(this.labels, that.labels)
+                && Objects.equals(this.command, that.command)
+                && Objects.equals(this.args, that.args) && Objects.equals(this.env, that.env)
+                && Objects.equals(this.dir, that.dir) && Objects.equals(this.user, that.user)
+                && Objects.equals(this.groups, that.groups) && Objects.equals(this.tty, that.tty)
+                && Objects.equals(this.mounts, that.mounts)
+                && Objects.equals(this.stopGracePeriod, that.stopGracePeriod);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(image, labels, command, args, env, dir, user, groups, tty, mounts,
+                stopGracePeriod);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("image", image).add("labels", labels)
+                .add("command", command).add("args", args).add("env", env).add("dir", dir)
+                .add("user", user).add("groups", groups).add("tty", tty).add("mounts", mounts)
+                .add("stopGracePeriod", stopGracePeriod).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ContainerStatus.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ContainerStatus.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class ContainerStatus {
+
+    @JsonProperty("ContainerID")
+    private String containerId;
+
+    @JsonProperty("PID")
+    private Integer pid;
+
+    @JsonProperty("ExitCode")
+    private Integer exitCode;
+
+    // Checkstyle complains if using containerId()
+    public String containerID() {
+        return containerId;
+    }
+
+    public Integer pid() {
+        return pid;
+    }
+
+    public Integer exitCode() {
+        return exitCode;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ContainerStatus that = (ContainerStatus) o;
+
+        return Objects.equals(this.containerId, that.containerId)
+                && Objects.equals(this.pid, that.pid)
+                && Objects.equals(this.exitCode, that.exitCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(containerId, pid, exitCode);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("containerId", containerId).add("pid", pid)
+                .add("exitCode", exitCode).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/DispatcherConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/DispatcherConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class DispatcherConfig {
+
+    @JsonProperty("HeartbeatPeriod")
+    private Long heartbeatPeriod;
+
+    public Long heartbeatPeriod() {
+        return heartbeatPeriod;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final DispatcherConfig that = (DispatcherConfig) o;
+
+        return Objects.equals(this.heartbeatPeriod, that.heartbeatPeriod);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(heartbeatPeriod);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("heartbeatPeriod", heartbeatPeriod).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Driver.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Driver.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class Driver {
+
+    @JsonProperty("Name")
+    private String name;
+
+    @JsonProperty("Options")
+    private Map<String, String> options;
+
+    public String name() {
+        return name;
+    }
+
+    public Map<String, String> options() {
+        return options;
+    }
+
+    public static class Builder {
+
+        private Driver driver = new Driver();
+
+        public Builder withName(String name) {
+            driver.name = name;
+            return this;
+        }
+
+        public Builder withOption(String name, String value) {
+            if (driver.options == null) {
+                driver.options = new HashMap<String, String>();
+            }
+            driver.options.put(name, value);
+            return this;
+        }
+
+        public Driver build() {
+            return driver;
+        }
+    }
+
+    public static Driver.Builder builder() {
+        return new Driver.Builder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Driver that = (Driver) o;
+
+        return Objects.equals(this.name, that.name) && Objects.equals(this.options, that.options);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, options);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("name", name).add("options", options)
+                .toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Endpoint.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Endpoint.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class Endpoint {
+
+    @JsonProperty("Spec")
+    private EndpointSpec spec;
+
+    @JsonProperty("ExposedPorts")
+    private ImmutableList<PortConfig> exposedPorts;
+
+    @JsonProperty("VirtualIPs")
+    private ImmutableList<EndpointVirtualIp> virtualIps;
+
+    public EndpointSpec spec() {
+        return spec;
+    }
+
+    public List<PortConfig> exposedPorts() {
+        return exposedPorts;
+    }
+
+    public List<EndpointVirtualIp> virtualIps() {
+        return virtualIps;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Endpoint that = (Endpoint) o;
+
+        return Objects.equals(this.spec, that.spec)
+                && Objects.equals(this.exposedPorts, that.exposedPorts)
+                && Objects.equals(this.virtualIps, that.virtualIps);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(spec, exposedPorts, virtualIps);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("spec", spec).add("ports", exposedPorts)
+                .add("virtualIps", virtualIps).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/EndpointSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/EndpointSpec.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class EndpointSpec {
+
+    public static final String RESOLUTION_MODE_VIP = "vip";
+    public static final String RESOLUTION_MODE_DNSRR = "dnsrr";
+
+    @JsonProperty("Mode")
+    private String mode;
+
+    @JsonProperty("Ports")
+    private ImmutableList<PortConfig> ports;
+
+    public String mode() {
+        return mode;
+    }
+
+    public List<PortConfig> ports() {
+        return ports;
+    }
+
+    public static class Builder {
+
+        private EndpointSpec spec = new EndpointSpec();
+
+        public Builder withVipMode() {
+            spec.mode = RESOLUTION_MODE_VIP;
+            return this;
+        }
+
+        public Builder withDnsrrMode() {
+            spec.mode = RESOLUTION_MODE_DNSRR;
+            return this;
+        }
+
+        public Builder withPorts(PortConfig... ports) {
+            if (ports != null && ports.length > 0) {
+                spec.ports = ImmutableList.copyOf(ports);
+            }
+            return this;
+        }
+
+        public Builder withPorts(List<PortConfig> ports) {
+            if (ports != null && !ports.isEmpty()) {
+                spec.ports = ImmutableList.copyOf(ports);
+            }
+            return this;
+        }
+
+        public EndpointSpec build() {
+            return spec;
+        }
+    }
+
+    public static EndpointSpec.Builder builder() {
+        return new EndpointSpec.Builder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final EndpointSpec that = (EndpointSpec) o;
+
+        return Objects.equals(this.mode, that.mode) && Objects.equals(this.ports, that.ports);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mode, ports);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("mode", mode).add("ports", ports).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/EndpointVirtualIp.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/EndpointVirtualIp.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class EndpointVirtualIp {
+
+    @JsonProperty("NetworkID")
+    private String networkId;
+
+    @JsonProperty("Addr")
+    private String addr;
+
+    public String networkId() {
+        return networkId;
+    }
+
+    public String addr() {
+        return addr;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final EndpointVirtualIp that = (EndpointVirtualIp) o;
+
+        return Objects.equals(this.networkId, that.networkId)
+                && Objects.equals(this.addr, that.addr);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(networkId, addr);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("networkId", networkId).add("addr", addr)
+                .toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ExternalCa.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ExternalCa.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class ExternalCa {
+
+    public static final String PROTOCOL_CFSSL = "cfssl";
+
+    @JsonProperty("Protocol")
+    private String protocol;
+
+    @JsonProperty("URL")
+    private String url;
+
+    @JsonProperty("Options")
+    private Map<String, String> options;
+
+    public String protocol() {
+        return protocol;
+    }
+
+    public String url() {
+        return url;
+    }
+
+    public Map<String, String> options() {
+        return options;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ExternalCa that = (ExternalCa) o;
+
+        return Objects.equals(this.protocol, that.protocol) && Objects.equals(this.url, that.url)
+                && Objects.equals(this.options, that.options);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(protocol, url, options);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("protocol", protocol).add("url", url)
+                .add("options", options).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/GlobalService.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/GlobalService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Spotify AB.
+ * Copyright (c) 2015 Spotify AB.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package com.spotify.docker.client.messages.swarm;
 
-package com.spotify.docker.client.exceptions;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 
-public class UnsupportedApiVersionException extends DockerException {
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
-  public UnsupportedApiVersionException(final String version, final Throwable cause) {
-    super("Unsupported Api Version: " + version, cause);
-  }
-
-  public UnsupportedApiVersionException(final String version) {
-    this(version, null);
-  }
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class GlobalService {
 
 }

--- a/src/main/java/com/spotify/docker/client/messages/swarm/IpamConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/IpamConfig.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class IpamConfig {
+
+    @JsonProperty("Subnet")
+    private String subnet;
+
+    @JsonProperty("Range")
+    private String range;
+
+    @JsonProperty("Gateway")
+    private String gateway;
+
+    public String subnet() {
+        return subnet;
+    }
+
+    public String range() {
+        return range;
+    }
+
+    public String gateway() {
+        return gateway;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final IpamConfig that = (IpamConfig) o;
+
+        return Objects.equals(this.subnet, that.subnet) && Objects.equals(this.range, that.range)
+                && Objects.equals(this.gateway, that.gateway);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subnet, range, gateway);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("subnet", subnet).add("range", range)
+                .add("gateway", gateway).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/IpamOptions.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/IpamOptions.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class IpamOptions {
+
+    @JsonProperty("Driver")
+    private Driver driver;
+
+    @JsonProperty("Configs")
+    private ImmutableList<IpamConfig> configs;
+
+    public Driver driver() {
+        return driver;
+    }
+
+    public List<IpamConfig> configs() {
+        return configs;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final IpamOptions that = (IpamOptions) o;
+
+        return Objects.equals(this.driver, that.driver)
+                && Objects.equals(this.configs, that.configs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(driver, configs);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("driver", driver).add("configs", configs)
+                .toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/JoinTokens.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/JoinTokens.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class JoinTokens {
+
+    @JsonProperty("Worker")
+    private String worker;
+
+    @JsonProperty("Manager")
+    private String manager;
+
+    public String worker() {
+        return worker;
+    }
+
+    public String manager() {
+        return manager;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final JoinTokens that = (JoinTokens) o;
+
+        return Objects.equals(this.worker, that.worker)
+                && Objects.equals(this.manager, that.manager);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(worker, manager);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("worker", worker).add("manager", manager)
+                .toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Network.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Network.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Date;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class Network {
+
+    @JsonProperty("ID")
+    private String id;
+
+    @JsonProperty("Version")
+    private Version version;
+
+    @JsonProperty("CreatedAt")
+    private Date createdAt;
+
+    @JsonProperty("UpdatedAt")
+    private Date updatedAt;
+
+    @JsonProperty("Spec")
+    private NetworkSpec spec;
+
+    @JsonProperty("DriverState")
+    private Driver driverState;
+
+    @JsonProperty("IPAMOptions")
+    private IpamOptions ipamOptions;
+
+    public String id() {
+        return id;
+    }
+
+    public Version version() {
+        return version;
+    }
+
+    public Date createdAt() {
+    return createdAt == null ? null : new Date(createdAt.getTime());
+}
+
+    public Date updatedAt() {
+    return updatedAt == null ? null : new Date(updatedAt.getTime());
+}
+
+    public NetworkSpec spec() {
+        return spec;
+    }
+
+    public Driver driverState() {
+        return driverState;
+    }
+
+    public IpamOptions ipamOptions() {
+        return ipamOptions;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Network that = (Network) o;
+
+        return Objects.equals(this.id, that.id) && Objects.equals(this.version, that.version)
+                && Objects.equals(this.createdAt, that.createdAt)
+                && Objects.equals(this.updatedAt, that.updatedAt)
+                && Objects.equals(this.spec, that.spec)
+                && Objects.equals(this.driverState, that.driverState)
+                && Objects.equals(this.ipamOptions, that.ipamOptions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, version, createdAt, updatedAt, spec, driverState, ipamOptions);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("id", id).add("version", version)
+                .add("createdAt", createdAt).add("updatedAt", updatedAt).add("spec", spec)
+                .add("driverState", driverState).add("ipamOptions", ipamOptions).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/NetworkAttachment.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/NetworkAttachment.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class NetworkAttachment {
+
+    @JsonProperty("Network")
+    private Network network;
+
+    @JsonProperty("Addresses")
+    private ImmutableList<String> addresses;
+
+    public Network network() {
+        return network;
+    }
+
+    public List<String> addresses() {
+        return addresses;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final NetworkAttachment that = (NetworkAttachment) o;
+
+        return Objects.equals(this.network, that.network)
+                && Objects.equals(this.addresses, that.addresses);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(network, addresses);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("network", network).add("addresses", addresses)
+                .toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/NetworkAttachmentConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/NetworkAttachmentConfig.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class NetworkAttachmentConfig {
+
+    @JsonProperty("Target")
+    private String target;
+
+    @JsonProperty("Aliases")
+    private ImmutableList<String> aliases;
+
+    public String target() {
+        return target;
+    }
+
+    public List<String> aliases() {
+        return aliases;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final NetworkAttachmentConfig that = (NetworkAttachmentConfig) o;
+
+        return Objects.equals(this.target, that.target)
+                && Objects.equals(this.aliases, that.aliases);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(target, aliases);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("target", target).add("aliases", aliases)
+                .toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/NetworkSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/NetworkSpec.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class NetworkSpec {
+
+    @JsonProperty("Name")
+    private String name;
+
+    @JsonProperty("Labels")
+    private Map<String, String> labels;
+
+    @JsonProperty("DriverConfiguration")
+    private Driver driverConfiguration;
+
+    @JsonProperty("IPv6Enabled")
+    private Boolean ipv6Enabled;
+
+    @JsonProperty("Internal")
+    private Boolean internal;
+
+    @JsonProperty("Attachable")
+    private Boolean attachable;
+
+    @JsonProperty("IPAMOptions")
+    private IpamOptions ipamOptions;
+
+    public String name() {
+        return name;
+    }
+
+    public Map<String, String> labels() {
+        return labels;
+    }
+
+    public Driver driverConfiguration() {
+        return driverConfiguration;
+    }
+
+    public Boolean ipv6Enabled() {
+        return ipv6Enabled;
+    }
+
+    public Boolean internal() {
+        return internal;
+    }
+
+    public Boolean attachable() {
+        return attachable;
+    }
+
+    public IpamOptions ipamOptions() {
+        return ipamOptions;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final NetworkSpec that = (NetworkSpec) o;
+
+        return Objects.equals(this.name, that.name) && Objects.equals(this.labels, that.labels)
+                && Objects.equals(this.driverConfiguration, that.driverConfiguration)
+                && Objects.equals(this.ipv6Enabled, that.ipv6Enabled)
+                && Objects.equals(this.internal, that.internal)
+                && Objects.equals(this.attachable, that.attachable)
+                && Objects.equals(this.ipamOptions, that.ipamOptions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, labels, driverConfiguration, ipv6Enabled, internal, attachable,
+                ipamOptions);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("name", name).add("labels", labels)
+                .add("driverConfiguration", driverConfiguration).add("ipv6Enabled", ipv6Enabled)
+                .add("internal", internal).add("attachable", attachable)
+                .add("ipamOptions", ipamOptions).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/OrchestrationConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/OrchestrationConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class OrchestrationConfig {
+
+    @JsonProperty("TaskHistoryRetentionLimit")
+    private Integer taskHistoryRetentionLimit;
+
+    public Integer taskHistoryRetentionLimit() {
+        return taskHistoryRetentionLimit;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final OrchestrationConfig that = (OrchestrationConfig) o;
+
+        return Objects.equals(this.taskHistoryRetentionLimit, that.taskHistoryRetentionLimit);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(taskHistoryRetentionLimit);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("taskHistoryRetentionLimit", taskHistoryRetentionLimit).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Placement.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Placement.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class Placement {
+
+    @JsonProperty("Constraints")
+    private ImmutableList<String> constraints;
+
+    public List<String> constraints() {
+        return constraints;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Placement that = (Placement) o;
+
+        return Objects.equals(this.constraints, that.constraints);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(constraints);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("constraints", constraints).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/PortConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/PortConfig.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class PortConfig {
+
+    public static final String PROTOCOL_TCP = "tcp";
+    public static final String PROTOCOL_UDP = "udp";
+
+    @JsonProperty("Name")
+    private String name;
+
+    @JsonProperty("Protocol")
+    private String protocol;
+
+    @JsonProperty("TargetPort")
+    private Integer targetPort;
+
+    @JsonProperty("PublishedPort")
+    private Integer publishedPort;
+
+    public String name() {
+        return name;
+    }
+
+    public String protocol() {
+        return protocol;
+    }
+
+    public Integer targetPort() {
+        return targetPort;
+    }
+
+    public Integer publishedPort() {
+        return publishedPort;
+    }
+
+    public static class Builder {
+
+        private PortConfig config = new PortConfig();
+
+        public Builder withName(String name) {
+            config.name = name;
+            return this;
+        }
+
+        public Builder withProtocol(String protocol) {
+            config.protocol = protocol;
+            return this;
+        }
+
+        public Builder withTargetPort(int targetPort) {
+            config.targetPort = targetPort;
+            return this;
+        }
+
+        public Builder withPublishedPort(int publishedPort) {
+            config.publishedPort = publishedPort;
+            return this;
+        }
+
+        public PortConfig build() {
+            return config;
+        }
+    }
+
+    public static PortConfig.Builder builder() {
+        return new PortConfig.Builder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final PortConfig that = (PortConfig) o;
+
+        return Objects.equals(this.name, that.name) && Objects.equals(this.protocol, that.protocol)
+                && Objects.equals(this.targetPort, that.targetPort)
+                && Objects.equals(this.publishedPort, that.publishedPort);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, protocol, targetPort, publishedPort);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("name", name).add("protocol", protocol)
+                .add("targetPort", targetPort).add("publishedPort", publishedPort).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/RaftConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/RaftConfig.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class RaftConfig {
+
+    @JsonProperty("SnapshotInterval")
+    private Integer snapshotInterval;
+
+    @JsonProperty("KeepOldSnapshots")
+    private Integer keepOldSnapshots;
+
+    @JsonProperty("LogEntriesForSlowFollowers")
+    private Integer logEntriesForSlowFollowers;
+
+    @JsonProperty("ElectionTick")
+    private Integer electionTick;
+
+    @JsonProperty("HeartbeatTick")
+    private Integer heartbeatTick;
+
+    public Integer snapshotInterval() {
+        return snapshotInterval;
+    }
+
+    public Integer keepOldSnapshots() {
+        return keepOldSnapshots;
+    }
+
+    public Integer logEntriesForSlowFollowers() {
+        return logEntriesForSlowFollowers;
+    }
+
+    public Integer electionTick() {
+        return electionTick;
+    }
+
+    public Integer heartbeatTick() {
+        return heartbeatTick;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final RaftConfig that = (RaftConfig) o;
+
+        return Objects.equals(this.snapshotInterval, that.snapshotInterval)
+                && Objects.equals(this.keepOldSnapshots, that.keepOldSnapshots)
+                && Objects.equals(this.logEntriesForSlowFollowers, that.logEntriesForSlowFollowers)
+                && Objects.equals(this.electionTick, that.electionTick)
+                && Objects.equals(this.heartbeatTick, that.heartbeatTick);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(snapshotInterval, keepOldSnapshots, logEntriesForSlowFollowers,
+                electionTick, heartbeatTick);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("snapshotInterval", snapshotInterval)
+                .add("keepOldSnapshots", keepOldSnapshots)
+                .add("logEntriesForSlowFollowers", logEntriesForSlowFollowers)
+                .add("electionTick", electionTick).add("heartbeatTick", heartbeatTick).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ReplicatedService.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ReplicatedService.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class ReplicatedService {
+
+    @JsonProperty("Replicas")
+    private Long replicas;
+
+    public Long replicas() {
+        return replicas;
+    }
+
+    public static class Builder {
+
+        private ReplicatedService replicated = new ReplicatedService();
+
+        public Builder withReplicas(long replicas) {
+            replicated.replicas = replicas;
+            return this;
+        }
+
+        public ReplicatedService build() {
+            return replicated;
+        }
+    }
+
+    public static ReplicatedService.Builder builder() {
+        return new ReplicatedService.Builder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ReplicatedService that = (ReplicatedService) o;
+
+        return Objects.equals(this.replicas, that.replicas);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(replicas);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("replicas", replicas).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ResourceRequirements.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ResourceRequirements.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class ResourceRequirements {
+
+    @JsonProperty("Limits")
+    private Resources limits;
+
+    @JsonProperty("Reservations")
+    private Resources reservations;
+
+    public Resources limits() {
+        return limits;
+    }
+
+    public Resources reservations() {
+        return reservations;
+    }
+
+    public static class Builder {
+
+        private ResourceRequirements req = new ResourceRequirements();
+
+        public Builder withLimits(Resources limits) {
+            req.limits = limits;
+            return this;
+        }
+
+        public Builder withReservations(Resources reservations) {
+            req.reservations = reservations;
+            return this;
+        }
+
+        public ResourceRequirements build() {
+            return req;
+        }
+    }
+
+    public static ResourceRequirements.Builder builder() {
+        return new ResourceRequirements.Builder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ResourceRequirements that = (ResourceRequirements) o;
+
+        return Objects.equals(this.limits, that.limits)
+                && Objects.equals(this.reservations, that.reservations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(limits, reservations);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("limits", limits)
+                .add("reservations", reservations).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Resources.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Resources.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class Resources {
+
+    @JsonProperty("NanoCPUs")
+    private Integer nanoCpus;
+
+    @JsonProperty("MemoryBytes")
+    private Integer memoryBytes;
+
+    public Integer nanoCpus() {
+        return nanoCpus;
+    }
+
+    public Integer memoryBytes() {
+        return memoryBytes;
+    }
+
+    public static class Builder {
+
+        private Resources resources = new Resources();
+
+        public Builder withNanoCpus(int nanoCpus) {
+            resources.nanoCpus = nanoCpus;
+            return this;
+        }
+
+        public Builder withMemoryBytes(int memoryBytes) {
+            resources.memoryBytes = memoryBytes;
+            return this;
+        }
+
+        public Resources build() {
+            return resources;
+        }
+    }
+
+    public static Resources.Builder builder() {
+        return new Resources.Builder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Resources that = (Resources) o;
+
+        return Objects.equals(this.nanoCpus, that.nanoCpus)
+                && Objects.equals(this.memoryBytes, that.memoryBytes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nanoCpus, memoryBytes);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("nanoCpus", nanoCpus)
+                .add("memoryBytes", memoryBytes).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/RestartPolicy.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/RestartPolicy.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class RestartPolicy {
+
+    public static final String RESTART_POLICY_NONE = "none";
+    public static final String RESTART_POLICY_ON_FAILURE = "on-failure";
+    public static final String RESTART_POLICY_ANY = "any";
+
+    @JsonProperty("Condition")
+    private String condition;
+
+    @JsonProperty("Delay")
+    private Long delay;
+
+    @JsonProperty("MaxAttempts")
+    private Integer maxAttempts;
+
+    @JsonProperty("Window")
+    private Long window;
+
+    public String condition() {
+        return condition;
+    }
+
+    public Long delay() {
+        return delay;
+    }
+
+    public Integer maxAttempts() {
+        return maxAttempts;
+    }
+
+    public Long window() {
+        return window;
+    }
+
+    public static class Builder {
+
+        private RestartPolicy restart = new RestartPolicy();
+
+        public Builder withCondition(String condition) {
+            restart.condition = condition;
+            return this;
+        }
+
+        public Builder withDelay(long delay) {
+            restart.delay = delay;
+            return this;
+        }
+
+        public Builder withMaxAttempts(int maxAttempts) {
+            restart.maxAttempts = maxAttempts;
+            return this;
+        }
+
+        public Builder withWindow(long window) {
+            restart.window = window;
+            return this;
+        }
+
+        public RestartPolicy build() {
+            return restart;
+        }
+    }
+
+    public static RestartPolicy.Builder builder() {
+        return new RestartPolicy.Builder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final RestartPolicy that = (RestartPolicy) o;
+
+        return Objects.equals(this.condition, that.condition)
+                && Objects.equals(this.delay, that.delay)
+                && Objects.equals(this.maxAttempts, that.maxAttempts)
+                && Objects.equals(this.window, that.window);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(condition, delay, maxAttempts, window);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("condition", condition).add("delay", delay)
+                .add("maxAttempts", maxAttempts).add("window", window).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Service.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Service.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Date;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class Service {
+
+    @JsonProperty("ID")
+    private String id;
+
+    @JsonProperty("Version")
+    private Version version;
+
+    @JsonProperty("CreatedAt")
+    private Date createdAt;
+
+    @JsonProperty("UpdatedAt")
+    private Date updatedAt;
+
+    @JsonProperty("Spec")
+    private ServiceSpec spec;
+
+    @JsonProperty("Endpoint")
+    private Endpoint endpoint;
+
+    @JsonProperty("UpdateStatus")
+    private UpdateStatus updateStatus;
+
+    public String id() {
+        return id;
+    }
+
+    public Version version() {
+        return version;
+    }
+
+    public Date createdAt() {
+    return createdAt == null ? null : new Date(createdAt.getTime());
+}
+
+    public Date updatedAt() {
+    return updatedAt == null ? null : new Date(updatedAt.getTime());
+}
+
+    public ServiceSpec spec() {
+        return spec;
+    }
+
+    public Endpoint endpoint() {
+        return endpoint;
+    }
+
+    public UpdateStatus updateStatus() {
+        return updateStatus;
+    }
+
+    public static class Criteria {
+
+        /** Filter by service id */
+        String serviceId;
+
+        /** Filter by service name */
+        String serviceName;
+
+        public String getServiceId() {
+            return serviceId;
+        }
+
+        public void setServiceId(String serviceId) {
+            this.serviceId = serviceId;
+        }
+
+        public String getServiceName() {
+            return serviceName;
+        }
+
+        public void setServiceName(String serviceName) {
+            this.serviceName = serviceName;
+        }
+    }
+
+    public static class CriteriaBuilder {
+
+        /** Criteria being built */
+        private Criteria criteria = new Criteria();
+
+        public CriteriaBuilder withServiceId(String serviceId) {
+            criteria.setServiceId(serviceId);
+            return this;
+        }
+
+        public CriteriaBuilder withServiceName(String serviceName) {
+            criteria.setServiceName(serviceName);
+            return this;
+        }
+
+        public Criteria build() {
+            return criteria;
+        }
+    }
+
+    public static CriteriaBuilder find() {
+        return new Service.CriteriaBuilder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Service that = (Service) o;
+
+        return Objects.equals(this.id, that.id) && Objects.equals(this.version, that.version)
+                && Objects.equals(this.createdAt, that.createdAt)
+                && Objects.equals(this.updatedAt, that.updatedAt)
+                && Objects.equals(this.spec, that.spec)
+                && Objects.equals(this.endpoint, that.endpoint)
+                && Objects.equals(this.updateStatus, that.updateStatus);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, version, createdAt, updatedAt, spec, endpoint, updateStatus);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("id", id).add("version", version)
+                .add("createdAt", createdAt).add("updatedAt", updatedAt).add("spec", spec)
+                .add("endpoint", endpoint).add("updateStatus", updateStatus).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ServiceMode.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ServiceMode.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class ServiceMode {
+
+    @JsonProperty("Replicated")
+    private ReplicatedService replicated;
+
+    @JsonProperty("Global")
+    private GlobalService global;
+
+    public ReplicatedService replicated() {
+        return replicated;
+    }
+
+    public GlobalService global() {
+        return global;
+    }
+
+    public static ServiceMode withReplicas(long replicas) {
+        return ServiceMode.builder()
+                .withReplicatedService(ReplicatedService.builder().withReplicas(replicas).build())
+                .build();
+    }
+
+    public static ServiceMode withGlobal() {
+        return ServiceMode.builder().withGlobalService(new GlobalService()).build();
+    }
+
+    public static class Builder {
+
+        private ServiceMode mode = new ServiceMode();
+
+        public Builder withReplicatedService(ReplicatedService replicated) {
+            mode.replicated = replicated;
+            return this;
+        }
+
+        public Builder withGlobalService(GlobalService global) {
+            mode.global = global;
+            return this;
+        }
+
+        public ServiceMode build() {
+            return mode;
+        }
+    }
+
+    public static ServiceMode.Builder builder() {
+        return new ServiceMode.Builder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ServiceMode that = (ServiceMode) o;
+
+        return Objects.equals(this.replicated, that.replicated)
+                && Objects.equals(this.global, that.global);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(replicated, global);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("replicated", replicated).add("global", global)
+                .toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ServiceSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ServiceSpec.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class ServiceSpec {
+
+    @JsonProperty("Name")
+    private String name;
+
+    @JsonProperty("Labels")
+    private Map<String, String> labels;
+
+    @JsonProperty("TaskTemplate")
+    private TaskSpec taskTemplate;
+
+    @JsonProperty("Mode")
+    private ServiceMode mode;
+
+    @JsonProperty("UpdateConfig")
+    private UpdateConfig updateConfig;
+
+    @JsonProperty("Networks")
+    private ImmutableList<NetworkAttachmentConfig> networks;
+
+    @JsonProperty("EndpointSpec")
+    private EndpointSpec endpointSpec;
+
+    public String name() {
+        return name;
+    }
+
+    public Map<String, String> labels() {
+        return labels;
+    }
+
+    public TaskSpec taskTemplate() {
+        return taskTemplate;
+    }
+
+    public ServiceMode mode() {
+        return mode;
+    }
+
+    public UpdateConfig updateConfig() {
+        return updateConfig;
+    }
+
+    public List<NetworkAttachmentConfig> networks() {
+        return networks;
+    }
+
+    public EndpointSpec endpointSpec() {
+        return endpointSpec;
+    }
+
+    public static class Builder {
+
+        private ServiceSpec spec = new ServiceSpec();
+
+        public Builder withName(String name) {
+            spec.name = name;
+            return this;
+        }
+
+        public Builder withLabel(String label, String value) {
+            if (spec.labels == null) {
+                spec.labels = new HashMap<String, String>();
+            }
+            spec.labels.put(label, value);
+            return this;
+        }
+
+        public Builder withLabels(Map<String, String> labels) {
+            if (spec.labels == null) {
+                spec.labels = new HashMap<String, String>();
+            }
+
+            spec.labels.putAll(labels);
+            return this;
+        }
+
+        public Builder withTaskTemplate(TaskSpec taskTemplate) {
+            spec.taskTemplate = taskTemplate;
+            return this;
+        }
+
+        public Builder withServiceMode(ServiceMode mode) {
+            spec.mode = mode;
+            return this;
+        }
+
+        public Builder withUpdateConfig(UpdateConfig updateConfig) {
+            spec.updateConfig = updateConfig;
+            return this;
+        }
+
+        public Builder withNetworks(NetworkAttachmentConfig... networks) {
+            spec.networks = ImmutableList.copyOf(networks);
+            return this;
+        }
+
+        public Builder withNetworks(List<NetworkAttachmentConfig> networks) {
+            spec.networks = ImmutableList.copyOf(networks);
+            return this;
+        }
+
+        public Builder withEndpointSpec(EndpointSpec endpointSpec) {
+            spec.endpointSpec = endpointSpec;
+            return this;
+        }
+
+        public ServiceSpec build() {
+            return spec;
+        }
+    }
+
+    public static ServiceSpec.Builder builder() {
+        return new ServiceSpec.Builder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ServiceSpec that = (ServiceSpec) o;
+
+        return Objects.equals(this.name, that.name) && Objects.equals(this.labels, that.labels)
+                && Objects.equals(this.taskTemplate, that.taskTemplate)
+                && Objects.equals(this.mode, that.mode)
+                && Objects.equals(this.updateConfig, that.updateConfig)
+                && Objects.equals(this.networks, that.networks)
+                && Objects.equals(this.endpointSpec, that.endpointSpec);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, labels, taskTemplate, mode, updateConfig, networks, endpointSpec);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("name", name).add("labels", labels)
+                .add("taskTemplate", taskTemplate).add("mode", mode)
+                .add("updateConfig", updateConfig).add("networks", networks)
+                .add("endpointSpec", endpointSpec).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Spec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Spec.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class Spec {
+
+    @JsonProperty("Name")
+    private String name;
+
+    @JsonProperty("Labels")
+    private Map<String, String> labels;
+
+    @JsonProperty("Orchestration")
+    private OrchestrationConfig orchestration;
+
+    @JsonProperty("Raft")
+    private RaftConfig raft;
+
+    @JsonProperty("Dispatcher")
+    private DispatcherConfig dispatcher;
+
+    @JsonProperty("CAConfig")
+    private CaConfig caConfig;
+
+    @JsonProperty("TaskDefaults")
+    private TaskDefaults taskDefaults;
+
+    public String name() {
+        return name;
+    }
+
+    public Map<String, String> labels() {
+        return labels;
+    }
+
+    public OrchestrationConfig orchestration() {
+        return orchestration;
+    }
+
+    public RaftConfig raft() {
+        return raft;
+    }
+
+    public DispatcherConfig dispatcher() {
+        return dispatcher;
+    }
+
+    public CaConfig caConfig() {
+        return caConfig;
+    }
+
+    public TaskDefaults taskDefaults() {
+        return taskDefaults;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Spec that = (Spec) o;
+
+        return Objects.equals(this.name, that.name) && Objects.equals(this.labels, that.labels)
+                && Objects.equals(this.orchestration, that.orchestration)
+                && Objects.equals(this.raft, that.raft)
+                && Objects.equals(this.dispatcher, that.dispatcher)
+                && Objects.equals(this.caConfig, that.caConfig)
+                && Objects.equals(this.taskDefaults, that.taskDefaults);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, labels, orchestration, raft, dispatcher, caConfig, taskDefaults);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("name", name).add("labels", labels)
+                .add("orchestration", orchestration).add("raft", raft).add("dispatcher", dispatcher)
+                .add("caConfig", caConfig).add("taskDefaults", taskDefaults).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Swarm.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Swarm.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Date;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class Swarm {
+
+    @JsonProperty("ID")
+    private String id;
+
+    @JsonProperty("Version")
+    private Version version;
+
+    @JsonProperty("CreatedAt")
+    private Date createdAt;
+
+    @JsonProperty("UpdatedAt")
+    private Date updatedAt;
+
+    @JsonProperty("Spec")
+    private Spec spec;
+
+    @JsonProperty("JoinTokens")
+    private JoinTokens joinTokens;
+
+    public String id() {
+        return id;
+    }
+
+    public Version version() {
+        return version;
+    }
+
+    public Date createdAt() {
+    return createdAt == null ? null : new Date(createdAt.getTime());
+}
+
+    public Date updatedAt() {
+    return updatedAt == null ? null : new Date(updatedAt.getTime());
+}
+
+    public Spec spec() {
+        return spec;
+    }
+
+    public JoinTokens joinTokens() {
+        return joinTokens;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Swarm that = (Swarm) o;
+
+        return Objects.equals(this.id, that.id) && Objects.equals(this.version, that.version)
+                && Objects.equals(this.createdAt, that.createdAt)
+                && Objects.equals(this.updatedAt, that.updatedAt)
+                && Objects.equals(this.spec, that.spec)
+                && Objects.equals(this.joinTokens, that.joinTokens);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, version, createdAt, updatedAt, spec, joinTokens);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("id", id).add("version", version)
+                .add("createdAt", createdAt).add("updatedAt", updatedAt).add("spec", spec)
+                .add("joinTokens", joinTokens).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Task.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Task.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class Task {
+
+    @JsonProperty("ID")
+    private String id;
+
+    @JsonProperty("Version")
+    private Version version;
+
+    @JsonProperty("CreatedAt")
+    private Date createdAt;
+
+    @JsonProperty("UpdatedAt")
+    private Date updatedAt;
+
+    @JsonProperty("Name")
+    private String name;
+
+    @JsonProperty("Labels")
+    private Map<String, String> labels;
+
+    @JsonProperty("Spec")
+    private TaskSpec spec;
+
+    @JsonProperty("ServiceID")
+    private String serviceId;
+
+    @JsonProperty("Slot")
+    private Integer slot;
+
+    @JsonProperty("NodeID")
+    private String nodeId;
+
+    @JsonProperty("Status")
+    private TaskStatus status;
+
+    @JsonProperty("DesiredState")
+    private String desiredState;
+
+    @JsonProperty("NetworksAttachments")
+    private ImmutableList<NetworkAttachment> networkAttachments;
+
+    public String id() {
+        return id;
+    }
+
+    public Version version() {
+        return version;
+    }
+
+    public Date createdAt() {
+    return createdAt == null ? null : new Date(createdAt.getTime());
+}
+
+    public Date updatedAt() {
+    return updatedAt == null ? null : new Date(updatedAt.getTime());
+}
+
+    public String name() {
+        return name;
+    }
+
+    public Map<String, String> labels() {
+        return labels;
+    }
+
+    public TaskSpec spec() {
+        return spec;
+    }
+
+    public String serviceId() {
+        return serviceId;
+    }
+
+    public Integer slot() {
+        return slot;
+    }
+
+    public String nodeId() {
+        return nodeId;
+    }
+
+    public TaskStatus status() {
+        return status;
+    }
+
+    public String desiredState() {
+        return desiredState;
+    }
+
+    public List<NetworkAttachment> networkAttachments() {
+        return networkAttachments;
+    }
+
+    public static class Criteria {
+
+        /** Filter by task id */
+        String taskId;
+
+        /** Filter by task name */
+        String taskName;
+
+        /** Filter by service name */
+        String serviceName;
+
+        /** Filter by node id */
+        String nodeId;
+
+        /** Filter by label */
+        String label;
+
+        /** Filter by desired state */
+        String desiredState;
+
+        public String getTaskId() {
+            return taskId;
+        }
+
+        public void setTaskId(String taskId) {
+            this.taskId = taskId;
+        }
+
+        public String getTaskName() {
+            return taskName;
+        }
+
+        public void setTaskName(String taskName) {
+            this.taskName = taskName;
+        }
+
+        public String getServiceName() {
+            return serviceName;
+        }
+
+        public void setServiceName(String serviceName) {
+            this.serviceName = serviceName;
+        }
+
+        public String getNodeId() {
+            return nodeId;
+        }
+
+        public void setNodeId(String nodeId) {
+            this.nodeId = nodeId;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
+        }
+
+        public String getDesiredState() {
+            return desiredState;
+        }
+
+        public void setDesiredState(String desiredState) {
+            this.desiredState = desiredState;
+        }
+    }
+
+    public static class CriteriaBuilder {
+
+        /** Criteria being built */
+        private Criteria criteria = new Criteria();
+
+        public CriteriaBuilder withTaskId(String taskId) {
+            criteria.setTaskId(taskId);
+            return this;
+        }
+
+        public CriteriaBuilder withTaskName(String taskName) {
+            criteria.setTaskName(taskName);
+            return this;
+        }
+
+        public CriteriaBuilder withServiceName(String serviceName) {
+            criteria.setServiceName(serviceName);
+            return this;
+        }
+
+        public CriteriaBuilder withNodeId(String nodeId) {
+            criteria.setNodeId(nodeId);
+            return this;
+        }
+
+        public CriteriaBuilder withLabel(String label) {
+            criteria.setLabel(label);
+            return this;
+        }
+
+        public CriteriaBuilder withDesiredState(String desiredState) {
+            criteria.setDesiredState(desiredState);
+            return this;
+        }
+
+        public Criteria build() {
+            return criteria;
+        }
+    }
+
+    public static CriteriaBuilder find() {
+        return new Task.CriteriaBuilder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Task that = (Task) o;
+
+        return Objects.equals(this.id, that.id) && Objects.equals(this.version, that.version)
+                && Objects.equals(this.createdAt, that.createdAt)
+                && Objects.equals(this.updatedAt, that.updatedAt)
+                && Objects.equals(this.name, that.name) && Objects.equals(this.labels, that.labels)
+                && Objects.equals(this.spec, that.spec)
+                && Objects.equals(this.serviceId, that.serviceId)
+                && Objects.equals(this.slot, that.slot) && Objects.equals(this.nodeId, that.nodeId)
+                && Objects.equals(this.status, that.status)
+                && Objects.equals(this.desiredState, that.desiredState)
+                && Objects.equals(this.networkAttachments, that.networkAttachments);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, version, createdAt, updatedAt, name, labels, spec, serviceId, slot,
+                nodeId, status, desiredState, networkAttachments);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("id", id).add("version", version)
+                .add("createdAt", createdAt).add("updatedAt", updatedAt).add("name", name)
+                .add("labels", labels).add("spec", spec).add("serviceId", serviceId)
+                .add("slot", slot).add("nodeId", nodeId).add("status", status)
+                .add("desiredState", desiredState).add("networkAttachments", networkAttachments)
+                .toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/TaskDefaults.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/TaskDefaults.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class TaskDefaults {
+
+    @JsonProperty("LogDriver")
+    private Driver logDriver;
+
+    public Driver logDriver() {
+        return logDriver;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final TaskDefaults that = (TaskDefaults) o;
+
+        return Objects.equals(this.logDriver, that.logDriver);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(logDriver);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("logDriver", logDriver).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/TaskSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/TaskSpec.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class TaskSpec {
+
+    @JsonProperty("ContainerSpec")
+    private ContainerSpec containerSpec;
+
+    @JsonProperty("Resources")
+    private ResourceRequirements resources;
+
+    @JsonProperty("RestartPolicy")
+    private RestartPolicy restartPolicy;
+
+    @JsonProperty("Placement")
+    private Placement placement;
+
+    @JsonProperty("Networks")
+    private ImmutableList<NetworkAttachmentConfig> networks;
+
+    @JsonProperty("LogDriver")
+    private Driver logDriver;
+
+    public ContainerSpec containerSpec() {
+        return containerSpec;
+    }
+
+    public ResourceRequirements resources() {
+        return resources;
+    }
+
+    public RestartPolicy restartPolicy() {
+        return restartPolicy;
+    }
+
+    public Placement placement() {
+        return placement;
+    }
+
+    public List<NetworkAttachmentConfig> networks() {
+        return networks;
+    }
+
+    public Driver logDriver() {
+        return logDriver;
+    }
+
+    public static class Builder {
+
+        private TaskSpec spec = new TaskSpec();
+
+        public Builder withContainerSpec(ContainerSpec containerSpec) {
+            spec.containerSpec = containerSpec;
+            return this;
+        }
+
+        public Builder withResources(ResourceRequirements resources) {
+            spec.resources = resources;
+            return this;
+        }
+
+        public Builder withRestartPolicy(RestartPolicy restartPolicy) {
+            spec.restartPolicy = restartPolicy;
+            return this;
+        }
+
+        public Builder withPlacement(Placement placement) {
+            spec.placement = placement;
+            return this;
+        }
+
+        public Builder withNetworks(NetworkAttachmentConfig... networks) {
+            if (networks != null && networks.length > 0) {
+                spec.networks = ImmutableList.copyOf(networks);
+            }
+            return this;
+        }
+
+        public Builder withNetworks(List<NetworkAttachmentConfig> networks) {
+            if (networks != null && !networks.isEmpty()) {
+                spec.networks = ImmutableList.copyOf(networks);
+            }
+            return this;
+        }
+
+        public Builder withLogDriver(Driver logDriver) {
+            spec.logDriver = logDriver;
+            return this;
+        }
+
+        public TaskSpec build() {
+            return spec;
+        }
+    }
+
+    public static TaskSpec.Builder builder() {
+        return new TaskSpec.Builder();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final TaskSpec that = (TaskSpec) o;
+
+        return Objects.equals(this.containerSpec, that.containerSpec)
+                && Objects.equals(this.resources, that.resources)
+                && Objects.equals(this.restartPolicy, that.restartPolicy)
+                && Objects.equals(this.placement, that.placement)
+                && Objects.equals(this.networks, that.networks)
+                && Objects.equals(this.logDriver, that.logDriver);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(containerSpec, resources, restartPolicy, placement, networks,
+                logDriver);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("containerSpec", containerSpec)
+                .add("resources", resources).add("restartPolicy", restartPolicy)
+                .add("placement", placement).add("networks", networks).add("logDriver", logDriver)
+                .toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/TaskStatus.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/TaskStatus.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class TaskStatus {
+
+    public static final String TASK_STATE_NEW = "new";
+    public static final String TASK_STATE_ALLOCATED = "allocated";
+    public static final String TASK_STATE_PENDING = "pending";
+    public static final String TASK_STATE_ASSIGNED = "assigned";
+    public static final String TASK_STATE_ACCEPTED = "accepted";
+    public static final String TASK_STATE_PREPARING = "preparing";
+    public static final String TASK_STATE_READY = "ready";
+    public static final String TASK_STATE_STARTING = "starting";
+    public static final String TASK_STATE_RUNNING = "running";
+    public static final String TASK_STATE_COMPLETE = "complete";
+    public static final String TASK_STATE_SHUTDOWN = "shutdown";
+    public static final String TASK_STATE_FAILED = "failed";
+    public static final String TASK_STATE_REJECTED = "rejected";
+
+    @JsonProperty("Timestamp")
+    private String timestamp;
+
+    @JsonProperty("State")
+    private String state;
+
+    @JsonProperty("Message")
+    private String message;
+
+    @JsonProperty("Err")
+    private String err;
+
+    @JsonProperty("ContainerStatus")
+    private ContainerStatus containerStatus;
+
+    public String timestamp() {
+        return timestamp;
+    }
+
+    public String state() {
+        return state;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    public String err() {
+        return err;
+    }
+
+    public ContainerStatus containerStatus() {
+        return containerStatus;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final TaskStatus that = (TaskStatus) o;
+
+        return Objects.equals(this.timestamp, that.timestamp)
+                && Objects.equals(this.state, that.state)
+                && Objects.equals(this.message, that.message) && Objects.equals(this.err, that.err)
+                && Objects.equals(this.containerStatus, that.containerStatus);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(timestamp, state, message, err, containerStatus);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("timestamp", timestamp).add("state", state)
+                .add("message", message).add("err", err).add("containerStatus", containerStatus)
+                .toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/UpdateConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/UpdateConfig.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class UpdateConfig {
+
+    @JsonProperty("Parallelism")
+    private Long parallelism;
+
+    @JsonProperty("Delay")
+    private Long delay;
+
+    @JsonProperty("FailureAction")
+    private String failureAction;
+
+    public Long parallelism() {
+        return parallelism;
+    }
+
+    public Long delay() {
+        return delay;
+    }
+
+    public String failureAction() {
+        return failureAction;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final UpdateConfig that = (UpdateConfig) o;
+
+        return Objects.equals(this.parallelism, that.parallelism)
+                && Objects.equals(this.delay, that.delay)
+                && Objects.equals(this.failureAction, that.failureAction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parallelism, delay, failureAction);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("parallelism", parallelism).add("delay", delay)
+                .add("failureAction", failureAction).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/UpdateStatus.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/UpdateStatus.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Date;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class UpdateStatus {
+
+    @JsonProperty("State")
+    private String state;
+
+    @JsonProperty("StartedAt")
+    private Date startedAt;
+
+    @JsonProperty("CompletedAt")
+    private Date completedAt;
+
+    @JsonProperty("Message")
+    private String message;
+
+    public String state() {
+        return state;
+    }
+
+    public Date startedAt() {
+    return startedAt == null ? null : new Date(startedAt.getTime());
+}
+
+    public Date completedAt() {
+    return completedAt == null ? null : new Date(completedAt.getTime());
+}
+
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final UpdateStatus that = (UpdateStatus) o;
+
+        return Objects.equals(this.state, that.state)
+                && Objects.equals(this.startedAt, that.startedAt)
+                && Objects.equals(this.completedAt, that.completedAt)
+                && Objects.equals(this.message, that.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(state, startedAt, completedAt, message);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("state", state).add("startedAt", startedAt)
+                .add("completedAt", completedAt).add("message", message).toString();
+    }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Version.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Version.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class Version {
+
+    @JsonProperty("Index")
+    private Long index;
+
+    public Long index() {
+        return index;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Version that = (Version) o;
+
+        return Objects.equals(this.index, that.index);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("index", index).toString();
+    }
+}

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014 Spotify AB.
+ * Copyright (c) 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +20,20 @@ package com.spotify.docker.client;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.io.Resources;
+import com.google.common.util.concurrent.SettableFuture;
 import com.spotify.docker.client.DockerClient.AttachParameter;
 import com.spotify.docker.client.DockerClient.BuildParam;
 import com.spotify.docker.client.DockerClient.ExecCreateParam;
@@ -65,26 +80,24 @@ import com.spotify.docker.client.messages.NetworkCreation;
 import com.spotify.docker.client.messages.ProcessConfig;
 import com.spotify.docker.client.messages.ProgressMessage;
 import com.spotify.docker.client.messages.RemovedImage;
+import com.spotify.docker.client.messages.ServiceCreateOptions;
+import com.spotify.docker.client.messages.ServiceCreateResponse;
 import com.spotify.docker.client.messages.TopResults;
 import com.spotify.docker.client.messages.Version;
 import com.spotify.docker.client.messages.Volume;
 import com.spotify.docker.client.messages.VolumeList;
-
-import com.fasterxml.jackson.databind.util.StdDateFormat;
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.base.Throwables;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import com.google.common.io.Resources;
-import com.google.common.util.concurrent.SettableFuture;
-
+import com.spotify.docker.client.messages.swarm.ContainerSpec;
+import com.spotify.docker.client.messages.swarm.Driver;
+import com.spotify.docker.client.messages.swarm.EndpointSpec;
+import com.spotify.docker.client.messages.swarm.PortConfig;
+import com.spotify.docker.client.messages.swarm.ResourceRequirements;
+import com.spotify.docker.client.messages.swarm.RestartPolicy;
+import com.spotify.docker.client.messages.swarm.Service;
+import com.spotify.docker.client.messages.swarm.ServiceMode;
+import com.spotify.docker.client.messages.swarm.ServiceSpec;
+import com.spotify.docker.client.messages.swarm.Swarm;
+import com.spotify.docker.client.messages.swarm.Task;
+import com.spotify.docker.client.messages.swarm.TaskSpec;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
@@ -121,6 +134,7 @@ import java.net.URLEncoder;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -266,11 +280,20 @@ public class DefaultDockerClientTest {
 
   @After
   public void tearDown() throws Exception {
+    if (dockerApiVersionAtLeast("1.24")) {
+      final List<Service> services = sut.listServices();
+      for (final Service service : services) {
+        if (service.spec().name().startsWith(nameTag)) {
+          sut.removeService(service.id());
+        }
+      }
+    }
+
     // Remove containers
     final List<Container> containers = sut.listContainers();
     for (final Container container : containers) {
       final ContainerInfo info = sut.inspectContainer(container.id());
-      if (info != null && info.name().contains(nameTag)) {
+      if (info != null && info.name().startsWith(nameTag)) {
         try {
           sut.killContainer(info.id());
         } catch (DockerRequestException e) {
@@ -3265,6 +3288,199 @@ public class DefaultDockerClientTest {
     final ContainerInfo info = sut.inspectContainer(container.id());
 
     assertThat(info.hostConfig().oomScoreAdj(), is(500));
+  }
+
+  @Test
+  public void testInspectSwarm() throws Exception {
+    requireDockerApiVersionAtLeast("1.24", "swarm support");
+
+    final Swarm swarm = sut.inspectSwarm();
+    assertThat(swarm.createdAt(), is(notNullValue()));
+    assertThat(swarm.updatedAt(), is(notNullValue()));
+    assertThat(swarm.id(), is(not(isEmptyOrNullString())));
+    assertThat(swarm.joinTokens().worker(), is(not(isEmptyOrNullString())));
+    assertThat(swarm.joinTokens().manager(), is(not(isEmptyOrNullString())));
+  }
+
+  @Test
+  public void testCreateService() throws Exception {
+    requireDockerApiVersionAtLeast("1.24", "swarm support");
+
+    final ServiceSpec spec = createServiceSpec(randomName());
+
+    final ServiceCreateResponse response = sut.createService(spec, new ServiceCreateOptions());
+    assertThat(response.id(), is(notNullValue()));
+  }
+
+  @Test
+  public void testInspectService() throws Exception {
+    requireDockerApiVersionAtLeast("1.24", "swarm support");
+
+    final String[] commandLine = {"ping", "-c4", "localhost"};
+    final TaskSpec taskSpec = TaskSpec
+            .builder()
+            .withContainerSpec(ContainerSpec.builder().withImage("alpine")
+                    .withCommands(commandLine).build())
+            .withLogDriver(Driver.builder().withName("json-file").withOption("max-file", "3")
+                    .withOption("max-size", "10M").build())
+            .withResources(ResourceRequirements.builder()
+                    .withLimits(com.spotify.docker.client.messages.swarm.Resources.builder().
+                            withMemoryBytes(10 * 1024 * 1024).build())
+                    .build())
+            .withRestartPolicy(RestartPolicy.builder().withCondition("on-failure")
+                    .withDelay(10000000).withMaxAttempts(10).build())
+            .build();
+
+    final EndpointSpec endpointSpec = EndpointSpec.builder()
+            .withPorts(new PortConfig[]{PortConfig.builder().withName("web")
+                    .withProtocol("tcp").withPublishedPort(8080)
+                    .withTargetPort(80).build()})
+            .build();
+    final ServiceMode serviceMode = ServiceMode.withReplicas(4);
+
+    final String serviceName = randomName();
+    final ServiceSpec spec = ServiceSpec.builder().withName(serviceName).withTaskTemplate(taskSpec)
+            .withServiceMode(serviceMode)
+            .withEndpointSpec(endpointSpec)
+            .build();
+
+    final ServiceCreateResponse response = sut.createService(spec, new ServiceCreateOptions());
+
+    final Service service = sut.inspectService(response.id());
+
+    assertThat(service.spec().name(), is(serviceName));
+    assertThat(service.spec().taskTemplate().containerSpec().image(), is("alpine"));
+    assertThat(service.spec().taskTemplate().containerSpec().command(),
+            equalTo(Arrays.asList(commandLine)));
+  }
+
+  @Test
+  public void testUpdateService() throws Exception {
+    requireDockerApiVersionAtLeast("1.24", "swarm support");
+    final ServiceSpec spec = createServiceSpec(randomName());
+
+    final ServiceCreateResponse response = sut.createService(spec, new ServiceCreateOptions());
+    assertThat(response.id(), is(notNullValue()));
+
+    Service service = sut.inspectService(response.id());
+    assertThat(service.spec().mode().replicated().replicas(), is(4L));
+
+    // update service with same spec, but bump the number of replicas by 1
+    sut.updateService(response.id(), service.version().index(), ServiceSpec.builder()
+            .withName(service.spec().name())
+            .withTaskTemplate(service.spec().taskTemplate())
+            .withServiceMode(ServiceMode.withReplicas(5))
+            .withEndpointSpec(service.spec().endpointSpec())
+            .withUpdateConfig(service.spec().updateConfig())
+            .build());
+    service = sut.inspectService(response.id());
+    assertThat(service.spec().mode().replicated().replicas(), is(5L));
+  }
+
+
+  @Test
+  public void testListServices() throws Exception {
+    requireDockerApiVersionAtLeast("1.24", "swarm support");
+    List<Service> services = sut.listServices();
+    assertThat(services, is(empty()));
+
+    final ServiceSpec spec = createServiceSpec(randomName());
+
+    sut.createService(spec, new ServiceCreateOptions());
+
+    services = sut.listServices();
+    assertThat(services.size(), is(1));
+  }
+
+  @Test
+  public void testListServicesFilterById() throws Exception {
+    requireDockerApiVersionAtLeast("1.24", "swarm support");
+    final ServiceSpec spec = createServiceSpec(randomName());
+    final ServiceCreateResponse response = sut.createService(spec, new ServiceCreateOptions());
+
+    final List<Service> services = sut
+        .listServices(Service.find().withServiceId(response.id()).build());
+    assertThat(services.size(), is(1));
+    assertThat(services.get(0).id(), is(response.id()));
+  }
+
+  @Test
+  public void testListServicesFilterByName() throws Exception {
+    requireDockerApiVersionAtLeast("1.24", "swarm support");
+    final String serviceName = randomName();
+    final ServiceSpec spec = createServiceSpec(serviceName);
+    sut.createService(spec, new ServiceCreateOptions());
+
+    final List<Service> services =
+            sut.listServices(Service.find().withServiceName(serviceName).build());
+    assertThat(services.size(), is(1));
+    assertThat(services.get(0).spec().name(), is(serviceName));
+  }
+
+  @Test
+  public void testRemoveService() throws Exception {
+    requireDockerApiVersionAtLeast("1.24", "swarm support");
+
+    final ServiceSpec spec = createServiceSpec(randomName());
+    final ServiceCreateResponse response = sut.createService(spec, new ServiceCreateOptions());
+    assertThat(sut.listServices(), is(not(empty())));
+    sut.removeService(response.id());
+    assertThat(sut.listServices(), is(empty()));
+  }
+
+  @Test
+  public void testInspectTask() throws Exception {
+    requireDockerApiVersionAtLeast("1.24", "swarm support");
+
+    final ServiceSpec spec = createServiceSpec(randomName());
+    assertThat(sut.listTasks().size(), is(0));
+    final ServiceCreateResponse response = sut.createService(spec, new ServiceCreateOptions());
+    Thread.sleep(2000); // to give it a while to spin containers
+    final Task task = sut.listTasks().get(0);
+    final Task inspectTask = sut.inspectTask(task.id());
+    assertThat(task, equalTo(inspectTask));
+  }
+
+  @Test
+  public void testListTasks() throws Exception {
+    requireDockerApiVersionAtLeast("1.24", "swarm support");
+
+    final ServiceSpec spec = createServiceSpec(randomName());
+    assertThat(sut.listTasks().size(), is(0));
+    final ServiceCreateResponse response = sut.createService(spec, new ServiceCreateOptions());
+    Thread.sleep(2000); // to give it a while to spin containers
+    assertThat(sut.listTasks().size(), is(4));
+  }
+
+  @Test
+  public void testListTaskWithCriteria() throws Exception {
+    requireDockerApiVersionAtLeast("1.24", "swarm support");
+
+    final ServiceSpec spec = createServiceSpec(randomName());
+    assertThat(sut.listTasks().size(), is(0));
+    final ServiceCreateResponse response = sut.createService(spec, new ServiceCreateOptions());
+    Thread.sleep(2000); // to give it a while to spin containers
+
+    final Task task = sut.listTasks().get(1);
+
+    final List<Task> tasksWithId = sut.listTasks(Task.find().withTaskId(task.id()).build());
+
+    assertThat(tasksWithId.size(), is(1));
+    assertThat(tasksWithId.get(0), equalTo(task));
+  }
+
+  private ServiceSpec createServiceSpec(String serviceName) {
+    final TaskSpec taskSpec = TaskSpec
+            .builder()
+            .withContainerSpec(ContainerSpec.builder().withImage("alpine")
+                    .withCommands(new String[]{"ping", "-c1000", "localhost"}).build())
+            .build();
+
+    final ServiceMode serviceMode = ServiceMode.withReplicas(4);
+
+    return ServiceSpec.builder().withName(serviceName).withTaskTemplate(taskSpec)
+            .withServiceMode(serviceMode)
+            .build();
   }
 
   private String randomName() {


### PR DESCRIPTION
This was based off #491, with a few changes -
* all commits were squashed into one
* the `SwarmModeDockerClient` and `DefaultSwarmModeDockerClient` subclasses
  were removed and pushed into `DockerClient` and `DefaultDockerClient`