### PR TITLE
Travis and Tests

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -22,8 +22,9 @@ case "$1" in
     # Remove old docker files that might prevent the installation and starting of other versions
     sudo rm -fr /var/lib/docker || :
 
-    if [[ "$DOCKER_VERSION" =~ ^1\.12\..* ]]; then
-      sudo sh -c 'echo "deb https://apt.dockerproject.org/repo ubuntu-trusty experimental" > /etc/apt/sources.list.d/docker.list'
+    if [[ "$RC" == "true" ]]; then
+        dist_version="$(lsb_release --codename | cut -f2)"
+        sudo sh -c "echo deb [arch=$(dpkg --print-architecture)] https://apt.dockerproject.org/repo ubuntu-${dist_version} testing >> /etc/apt/sources.list.d/docker.list"
     fi
     sudo apt-get -qq update
     sudo apt-get -q -y purge docker-engine

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ language: java
 jdk:
   - oraclejdk7
 
-env: 
+env:
   global:
     - SONATYPE_USERNAME=mattbrownspotify
     - secure: "CTYWMDSX4LOz2TiYBSqC+7klvafj0wvwcbpyL3TJueWmgKzJwysRqSHxw9JR2rfe8ysSxGFFiRO9HEyJ4o6zTF6kIy9tYsPxvSJ8c9wIEdTbUtGMuWlrhKchuMmdDaWt07/0N2llSB4h3fv53UGglSM+5FJu4e5DxvxUmIx/Zn4="
@@ -19,6 +19,7 @@ env:
     - DOCKER_VERSION=1.8.3
     - DOCKER_VERSION=1.9.1
     - DOCKER_VERSION=1.10.3
+    - DOCKER_VERSION=1.11.2
     - DOCKER_VERSION=1.12.1 UPLOAD_SONATYPE=1
 
 before_install:

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -2284,7 +2284,7 @@ public interface DockerClient extends Closeable {
      * Filter volumes by name.
      * @param name Matches all or part of a volume name.
      * @return ListVolumesParam
-     * @since Docker 1.11, API version 1.23
+     * @since Docker 1.12, API version 1.24
      */
     public static ListVolumesParam name(final String name) {
       return filter("name", name);
@@ -2294,7 +2294,7 @@ public interface DockerClient extends Closeable {
      * Filter volumes by volume driver.
      * @param driver Matches all or part of a volume driver name.
      * @return ListVolumesParam
-     * @since Docker 1.11, API version 1.23
+     * @since Docker 1.12, API version 1.24
      */
     public static ListVolumesParam driver(final String driver) {
       return filter("driver", driver);

--- a/src/main/java/com/spotify/docker/client/messages/Info.java
+++ b/src/main/java/com/spotify/docker/client/messages/Info.java
@@ -127,6 +127,11 @@ public class Info {
     return driverStatus;
   }
 
+  /**
+   * @deprecated Removed in API 1.24 https://github.com/docker/docker/pull/24501
+   * @return Execution Driver
+   */
+  @Deprecated
   public String executionDriver() {
     return executionDriver;
   }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -178,6 +178,7 @@ import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
@@ -1113,7 +1114,7 @@ public class DefaultDockerClientTest {
     // between sleeps
     assertThat(topResults.processes(), hasSize(greaterThanOrEqualTo(1)));
 
-    assertThat(topResults.titles(), hasItem("CMD"));
+    assertThat(topResults.titles(), either(hasItem("CMD")).or(hasItem("COMMAND")));
 
     final List<String> firstProcessStatus = topResults.processes().get(0);
     assertThat("All processes will run as 'root'", firstProcessStatus, hasItem("root"));


### PR DESCRIPTION
* Fix a test failure I was seeing on my local machine (`testTopProcessesOfContainer()`)
* Add testing on Docker 1.11.2; 1.11 was left out of travis matrix
* Bump testing on 1.12 from .0 to .1
* Remove the special check of 1.12 from travis.sh. This appears to be a holdover to enable testing from when 1.12 was a release candidate.
* Enable testing on any RC version. To add a release candidate to the matrix, you would add a line in `.travis.yml` like:
```yml
    - DOCKER_VERSION=1.XX.0 RC=1
```