### PR TITLE
Test with Docker 1.12.1 instead of 1.12.0 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ env:
     - SONATYPE_USERNAME=mattbrownspotify
     - secure: "CTYWMDSX4LOz2TiYBSqC+7klvafj0wvwcbpyL3TJueWmgKzJwysRqSHxw9JR2rfe8ysSxGFFiRO9HEyJ4o6zTF6kIy9tYsPxvSJ8c9wIEdTbUtGMuWlrhKchuMmdDaWt07/0N2llSB4h3fv53UGglSM+5FJu4e5DxvxUmIx/Zn4="
   matrix:
-    - DOCKER_VERSION=1.6.0 UPLOAD_SONATYPE=1
+    - DOCKER_VERSION=1.6.0
     - DOCKER_VERSION=1.7.1
     - DOCKER_VERSION=1.8.3
     - DOCKER_VERSION=1.9.1
     - DOCKER_VERSION=1.10.3
-    - DOCKER_VERSION=1.12.0
+    - DOCKER_VERSION=1.12.1 UPLOAD_SONATYPE=1
 
 before_install:
   # check what version of docker is installed beforehand

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Docker Client [![Build Status](https://travis-ci.org/spotify/docker-client.svg?branch=master)](https://travis-ci.org/spotify/docker-client) [![codecov.io](https://codecov.io/github/spotify/docker-client/coverage.svg?branch=master)](https://codecov.io/github/spotify/docker-client?branch=master)
 
 This is a simple [Docker](https://github.com/docker/docker) client written in Java.
-We build and test docker-client on Docker versions 1.6 - 1.10 (specifically the ones [here][1]).
+We build and test docker-client on Docker versions 1.6 - 1.12 (specifically the ones [here][1]).
+We upload the artifact tested on Docker 1.12.1.
 See [Docker docs on the mapping between Docker version and API version][3].
 
 * [Usage Example](#usage-example)


### PR DESCRIPTION
Update README. Upload artifact tested on 1.12.1 to Sonatype instead
of the one tested on 1.6.0.