### PR TITLE
Add more swarm functionality

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -83,11 +83,6 @@ end script
       sudo restart docker
     fi
 
-    if [[ "$DOCKER_VERSION" =~ ^1\.12\..* ]]; then
-        # initialize docker swarm to be able to run docker tests
-        sudo docker swarm init --advertise-addr 127.0.0.1
-    fi
-
     # Wait a minute so we can see more docker logs in case something goes wrong
     sleep 60
 

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -47,6 +47,7 @@ import com.spotify.docker.client.messages.VolumeList;
 import com.spotify.docker.client.messages.swarm.Service;
 import com.spotify.docker.client.messages.swarm.ServiceSpec;
 import com.spotify.docker.client.messages.swarm.Swarm;
+import com.spotify.docker.client.messages.swarm.SwarmInitRequest;
 import com.spotify.docker.client.messages.swarm.Task;
 
 import java.io.Closeable;
@@ -1213,6 +1214,33 @@ public interface DockerClient extends Closeable {
    */
   LogStream execStart(String execId, ExecStartParameter... params)
       throws DockerException, InterruptedException;
+
+  /**
+   * Initialize a new swarm.
+   * @return node ID
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  String initializeSwarm() throws DockerException, InterruptedException;
+
+  /**
+   * Initialize a new swarm.
+   * @param swarmInitRequest {@link SwarmInitRequest}
+   * @return node ID
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  String initializeSwarm(SwarmInitRequest swarmInitRequest)
+      throws DockerException, InterruptedException;
+
+  /**
+   * Leave a swarm.
+   * @param force Force leave swarm, even if this is the last manager or that it will break the
+   *              cluster.
+   * @throws DockerException
+   * @throws InterruptedException
+   */
+  void leaveSwarm(boolean force) throws DockerException, InterruptedException;
 
   /**
    * Inspect the Swarm cluster. Only available in Docker API &gt;= 1.24.

--- a/src/main/java/com/spotify/docker/client/messages/swarm/SwarmInitRequest.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/SwarmInitRequest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.docker.client.messages.swarm;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public class SwarmInitRequest {
+
+    private static final String DEFAULT_LISTEN_ADDR = "0.0.0.0:2377";
+
+    @JsonProperty("ListenAddr")
+    private String listenAddr;
+
+    @JsonProperty("AdvertiseAddr")
+    private String advertiseAddr;
+
+    @JsonProperty("ForceNewCluster")
+    private Boolean forceNewCluster;
+
+    @JsonProperty("Spec")
+    private SwarmSpec spec;
+
+    private SwarmInitRequest(final Builder builder) {
+        this.listenAddr = isNullOrEmpty(builder.listenAddr)
+                          ? DEFAULT_LISTEN_ADDR :  builder.listenAddr;
+        this.advertiseAddr = builder.advertiseAddr;
+        this.forceNewCluster = builder.forceNewCluster;
+        this.spec = builder.spec;
+    }
+
+    public String listenAddr() {
+        return listenAddr;
+    }
+
+    public String advertiseAddr() {
+        return advertiseAddr;
+    }
+
+    public Boolean forceNewCluster() {
+        return forceNewCluster;
+    }
+
+    public SwarmSpec spec() {
+        return spec;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final SwarmInitRequest that = (SwarmInitRequest) o;
+
+        return Objects.equals(this.listenAddr, that.listenAddr)
+               && Objects.equals(this.advertiseAddr, that.advertiseAddr)
+               && Objects.equals(this.spec, that.spec);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(listenAddr, advertiseAddr, spec);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("listenAddr", listenAddr)
+            .add("advertiseAddr", advertiseAddr)
+            .add("forceNewCluster", forceNewCluster)
+            .add("spec", spec)
+            .toString();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String listenAddr;
+        private String advertiseAddr;
+        private boolean forceNewCluster;
+        private SwarmSpec spec;
+
+        public Builder listenAddr(final String listenAddr) {
+            this.listenAddr = listenAddr;
+            return this;
+        }
+
+        public Builder advertiseAddr(final String advertiseAddr) {
+            this.advertiseAddr = advertiseAddr;
+            return this;
+        }
+
+        public Builder forceNewCluster(final boolean forceNewCluster) {
+            this.forceNewCluster = forceNewCluster;
+            return this;
+        }
+
+        public Builder spec(final SwarmSpec spec) {
+            this.spec = spec;
+            return this;
+        }
+
+        public SwarmInitRequest build() {
+            return new SwarmInitRequest(this);
+        }
+    }
+}

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -97,6 +97,7 @@ import com.spotify.docker.client.messages.swarm.Service;
 import com.spotify.docker.client.messages.swarm.ServiceMode;
 import com.spotify.docker.client.messages.swarm.ServiceSpec;
 import com.spotify.docker.client.messages.swarm.Swarm;
+import com.spotify.docker.client.messages.swarm.SwarmInitRequest;
 import com.spotify.docker.client.messages.swarm.Task;
 import com.spotify.docker.client.messages.swarm.TaskSpec;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -277,18 +278,19 @@ public class DefaultDockerClientTest {
 
     dockerApiVersion = sut.version().apiVersion();
 
+    if (dockerApiVersionAtLeast("1.24")) {
+      // Make sure node isn't part of a swarm
+      leaveSwarm(sut, true);
+    }
+
     System.out.printf("- %s\n", testName.getMethodName());
   }
 
   @After
   public void tearDown() throws Exception {
     if (dockerApiVersionAtLeast("1.24")) {
-      final List<Service> services = sut.listServices();
-      for (final Service service : services) {
-        if (service.spec().name().startsWith(nameTag)) {
-          sut.removeService(service.id());
-        }
-      }
+      // No need to remove services in the swarm because leaving a swarm removes them automatically
+      leaveSwarm(sut, true);
     }
 
     // Remove containers
@@ -3355,8 +3357,10 @@ public class DefaultDockerClientTest {
   }
 
   @Test
-  public void testInspectSwarm() throws Exception {
+  public void testInitInspectAndLeaveSwarm() throws Exception {
     requireDockerApiVersionAtLeast("1.24", "swarm support");
+    final String nodeId = initializeSwarm(sut);
+    assertThat(nodeId, is(notNullValue()));
 
     final Swarm swarm = sut.inspectSwarm();
     assertThat(swarm.createdAt(), is(notNullValue()));
@@ -3364,11 +3368,14 @@ public class DefaultDockerClientTest {
     assertThat(swarm.id(), is(not(isEmptyOrNullString())));
     assertThat(swarm.joinTokens().worker(), is(not(isEmptyOrNullString())));
     assertThat(swarm.joinTokens().manager(), is(not(isEmptyOrNullString())));
+
+    sut.leaveSwarm(true);
   }
 
   @Test
   public void testCreateService() throws Exception {
     requireDockerApiVersionAtLeast("1.24", "swarm support");
+    initializeSwarm(sut);
 
     final ServiceSpec spec = createServiceSpec(randomName());
 
@@ -3379,6 +3386,7 @@ public class DefaultDockerClientTest {
   @Test
   public void testInspectService() throws Exception {
     requireDockerApiVersionAtLeast("1.24", "swarm support");
+    initializeSwarm(sut);
 
     final String[] commandLine = {"ping", "-c4", "localhost"};
     final TaskSpec taskSpec = TaskSpec
@@ -3421,6 +3429,7 @@ public class DefaultDockerClientTest {
   @Test
   public void testUpdateService() throws Exception {
     requireDockerApiVersionAtLeast("1.24", "swarm support");
+    initializeSwarm(sut);
     final ServiceSpec spec = createServiceSpec(randomName());
 
     final ServiceCreateResponse response = sut.createService(spec, new ServiceCreateOptions());
@@ -3445,6 +3454,7 @@ public class DefaultDockerClientTest {
   @Test
   public void testListServices() throws Exception {
     requireDockerApiVersionAtLeast("1.24", "swarm support");
+    initializeSwarm(sut);
     List<Service> services = sut.listServices();
     assertThat(services, is(empty()));
 
@@ -3459,6 +3469,7 @@ public class DefaultDockerClientTest {
   @Test
   public void testListServicesFilterById() throws Exception {
     requireDockerApiVersionAtLeast("1.24", "swarm support");
+    initializeSwarm(sut);
     final ServiceSpec spec = createServiceSpec(randomName());
     final ServiceCreateResponse response = sut.createService(spec, new ServiceCreateOptions());
 
@@ -3471,6 +3482,7 @@ public class DefaultDockerClientTest {
   @Test
   public void testListServicesFilterByName() throws Exception {
     requireDockerApiVersionAtLeast("1.24", "swarm support");
+    initializeSwarm(sut);
     final String serviceName = randomName();
     final ServiceSpec spec = createServiceSpec(serviceName);
     sut.createService(spec, new ServiceCreateOptions());
@@ -3484,6 +3496,7 @@ public class DefaultDockerClientTest {
   @Test
   public void testRemoveService() throws Exception {
     requireDockerApiVersionAtLeast("1.24", "swarm support");
+    initializeSwarm(sut);
 
     final ServiceSpec spec = createServiceSpec(randomName());
     final ServiceCreateResponse response = sut.createService(spec, new ServiceCreateOptions());
@@ -3495,6 +3508,7 @@ public class DefaultDockerClientTest {
   @Test
   public void testInspectTask() throws Exception {
     requireDockerApiVersionAtLeast("1.24", "swarm support");
+    initializeSwarm(sut);
 
     final ServiceSpec spec = createServiceSpec(randomName());
     assertThat(sut.listTasks().size(), is(0));
@@ -3508,6 +3522,7 @@ public class DefaultDockerClientTest {
   @Test
   public void testListTasks() throws Exception {
     requireDockerApiVersionAtLeast("1.24", "swarm support");
+    initializeSwarm(sut);
 
     final ServiceSpec spec = createServiceSpec(randomName());
     assertThat(sut.listTasks().size(), is(0));
@@ -3519,10 +3534,11 @@ public class DefaultDockerClientTest {
   @Test
   public void testListTaskWithCriteria() throws Exception {
     requireDockerApiVersionAtLeast("1.24", "swarm support");
+    initializeSwarm(sut);
 
     final ServiceSpec spec = createServiceSpec(randomName());
     assertThat(sut.listTasks().size(), is(0));
-    final ServiceCreateResponse response = sut.createService(spec, new ServiceCreateOptions());
+    sut.createService(spec, new ServiceCreateOptions());
     Thread.sleep(2000); // to give it a while to spin containers
 
     final Task task = sut.listTasks().get(1);
@@ -3621,5 +3637,22 @@ public class DefaultDockerClientTest {
       }
     };
     return Lists.transform(images, imageToShortId);
+  }
+
+  private static String initializeSwarm(final DefaultDockerClient client)
+      throws DockerException, InterruptedException {
+    final SwarmInitRequest swarmInitRequest = SwarmInitRequest.builder()
+        .advertiseAddr(client.getHost())
+        .build();
+    return client.initializeSwarm(swarmInitRequest);
+  }
+
+  private static void leaveSwarm(final DockerClient client, final boolean force)
+      throws InterruptedException {
+    try {
+      client.leaveSwarm(force);
+    } catch (DockerException e) {
+      // ignore
+    }
   }
 }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -3641,9 +3641,7 @@ public class DefaultDockerClientTest {
 
   private static String initializeSwarm(final DefaultDockerClient client)
       throws DockerException, InterruptedException {
-    final SwarmInitRequest swarmInitRequest = SwarmInitRequest.builder()
-        .advertiseAddr(client.getHost())
-        .build();
+    final SwarmInitRequest swarmInitRequest = SwarmInitRequest.builder().build();
     return client.initializeSwarm(swarmInitRequest);
   }
 


### PR DESCRIPTION
DockerClient can now initialize and leave a swarm.

Make DefaultDockerClientTest initialize swarm automatically for tests.
