### PR TITLE
ignore swarm exceptions in DefaultDockerClientTest teardown

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -286,11 +286,15 @@ public class DefaultDockerClientTest {
   @After
   public void tearDown() throws Exception {
     if (dockerApiVersionAtLeast("1.24")) {
-      final List<Service> services = sut.listServices();
-      for (final Service service : services) {
-        if (service.spec().name().startsWith(nameTag)) {
-          sut.removeService(service.id());
+      try {
+        final List<Service> services = sut.listServices();
+        for (final Service service : services) {
+          if (service.spec().name().startsWith(nameTag)) {
+            sut.removeService(service.id());
+          }
         }
+      } catch (DockerException e) {
+        log.warn("Ignoring DockerException in teardown", e);
       }
     }
 


### PR DESCRIPTION
if the docker instance being tested against is not a part of a swarm,
then listServices will throw an exception as the remote api seems to
return HTTP 406 in this case.

Avoid extra errors during tearDown - if the daemon is not a part of a
docker swarm then there is nothing swarm-related to clean up.