### PR TITLE
replace pojo boilerplate with AutoValue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - docker version
   - docker info
 
-script: mvn test
+script: mvn clean test
 
 after_success:
   # test coverage reporting

--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,7 @@
               <consoleOutput>true</consoleOutput>
               <failsOnError>true</failsOnError>
               <includeTestSourceDirectory>true</includeTestSourceDirectory>
+              <excludes>**\/AutoValue_*.java</excludes>
             </configuration>
             <goals>
               <goal>check</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,12 @@
       <artifactId>bcpkix-jdk15on</artifactId>
       <version>1.52</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <version>1.3</version>
+      <scope>provided</scope>
+    </dependency>
 
     <!--test deps-->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
       <version>1.3</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.1</version>
+    </dependency>
 
     <!--test deps-->
     <dependency>

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -31,77 +31,102 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 public abstract class ContainerConfig {
 
   @JsonProperty("Hostname")
+  @Nullable
   public abstract String hostname();
 
   @JsonProperty("Domainname")
+  @Nullable
   public abstract String domainname();
 
   @JsonProperty("User")
+  @Nullable
   public abstract String user();
 
   @JsonProperty("AttachStdin")
+  @Nullable
   public abstract Boolean attachStdin();
 
   @JsonProperty("AttachStdout")
+  @Nullable
   public abstract Boolean attachStdout();
 
   @JsonProperty("AttachStderr")
+  @Nullable
   public abstract Boolean attachStderr();
 
   @JsonProperty("PortSpecs")
+  @Nullable
   public abstract ImmutableList<String> portSpecs();
 
   @JsonProperty("ExposedPorts")
+  @Nullable
   public abstract ImmutableSet<String> exposedPorts();
 
   @JsonProperty("Tty")
+  @Nullable
   public abstract Boolean tty();
 
   @JsonProperty("OpenStdin")
+  @Nullable
   public abstract Boolean openStdin();
 
   @JsonProperty("StdinOnce")
+  @Nullable
   public abstract Boolean stdinOnce();
 
   @JsonProperty("Env")
+  @Nullable
   public abstract ImmutableList<String> env();
 
   @JsonProperty("Cmd")
+  @Nullable
   public abstract ImmutableList<String> cmd();
 
   @JsonProperty("Image")
+  @Nullable
   public abstract String image();
 
   @JsonProperty("Volumes")
+  @Nullable
   public abstract Set<String> volumes();
 
   @JsonProperty("WorkingDir")
+  @Nullable
   public abstract String workingDir();
 
   @JsonProperty("Entrypoint")
+  @Nullable
   public abstract ImmutableList<String> entrypoint();
 
   @JsonProperty("NetworkDisabled")
+  @Nullable
   public abstract Boolean networkDisabled();
 
   @JsonProperty("OnBuild")
+  @Nullable
   public abstract ImmutableList<String> onBuild();
 
   @JsonProperty("Labels")
+  @Nullable
   public abstract ImmutableMap<String, String> labels();
 
   @JsonProperty("MacAddress")
+  @Nullable
   public abstract String macAddress();
 
   @JsonProperty("HostConfig")
+  @Nullable
   public abstract HostConfig hostConfig();
 
   @JsonProperty("StopSignal")
+  @Nullable
   public abstract String stopSignal();
 
   public abstract Builder toBuilder();

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -17,627 +17,164 @@
 
 package com.spotify.docker.client.messages;
 
-import com.google.common.base.MoreObjects;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.Maps;
-
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
-import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
-import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
-
+@AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
-public class ContainerConfig {
+public abstract class ContainerConfig {
 
   @JsonProperty("Hostname")
-  private String hostname;
+  public abstract String hostname();
+
   @JsonProperty("Domainname")
-  private String domainname;
+  public abstract String domainname();
+
   @JsonProperty("User")
-  private String user;
+  public abstract String user();
+
   @JsonProperty("AttachStdin")
-  private Boolean attachStdin;
+  public abstract Boolean attachStdin();
+
   @JsonProperty("AttachStdout")
-  private Boolean attachStdout;
+  public abstract Boolean attachStdout();
+
   @JsonProperty("AttachStderr")
-  private Boolean attachStderr;
+  public abstract Boolean attachStderr();
+
   @JsonProperty("PortSpecs")
-  private ImmutableList<String> portSpecs;
+  public abstract ImmutableList<String> portSpecs();
+
   @JsonProperty("ExposedPorts")
-  private ImmutableSet<String> exposedPorts;
+  public abstract ImmutableSet<String> exposedPorts();
+
   @JsonProperty("Tty")
-  private Boolean tty;
+  public abstract Boolean tty();
+
   @JsonProperty("OpenStdin")
-  private Boolean openStdin;
+  public abstract Boolean openStdin();
+
   @JsonProperty("StdinOnce")
-  private Boolean stdinOnce;
+  public abstract Boolean stdinOnce();
+
   @JsonProperty("Env")
-  private ImmutableList<String> env;
+  public abstract ImmutableList<String> env();
+
   @JsonProperty("Cmd")
-  private ImmutableList<String> cmd;
+  public abstract ImmutableList<String> cmd();
+
   @JsonProperty("Image")
-  private String image;
+  public abstract String image();
+
   @JsonProperty("Volumes")
-  private ImmutableMap<String, Map> volumes;
+  public abstract Set<String> volumes();
+
   @JsonProperty("WorkingDir")
-  private String workingDir;
+  public abstract String workingDir();
+
   @JsonProperty("Entrypoint")
-  private ImmutableList<String> entrypoint;
+  public abstract ImmutableList<String> entrypoint();
+
   @JsonProperty("NetworkDisabled")
-  private Boolean networkDisabled;
+  public abstract Boolean networkDisabled();
+
   @JsonProperty("OnBuild")
-  private ImmutableList<String> onBuild;
+  public abstract ImmutableList<String> onBuild();
+
   @JsonProperty("Labels")
-  private ImmutableMap<String, String> labels;
+  public abstract ImmutableMap<String, String> labels();
+
   @JsonProperty("MacAddress")
-  private String macAddress;
+  public abstract String macAddress();
+
   @JsonProperty("HostConfig")
-  private HostConfig hostConfig;
+  public abstract HostConfig hostConfig();
+
   @JsonProperty("StopSignal")
-  private String stopSignal;
+  public abstract String stopSignal();
 
-
-  private ContainerConfig() {
-  }
-
-  private ContainerConfig(final Builder builder) {
-    this.hostname = builder.hostname;
-    this.domainname = builder.domainname;
-    this.user = builder.user;
-    this.attachStdin = builder.attachStdin;
-    this.attachStdout = builder.attachStdout;
-    this.attachStderr = builder.attachStderr;
-    this.portSpecs = builder.portSpecs;
-    this.exposedPorts = builder.exposedPorts;
-    this.tty = builder.tty;
-    this.openStdin = builder.openStdin;
-    this.stdinOnce = builder.stdinOnce;
-    this.env = builder.env;
-    this.cmd = builder.cmd;
-    this.image = builder.image;
-    this.workingDir = builder.workingDir;
-    this.entrypoint = builder.entrypoint;
-    this.networkDisabled = builder.networkDisabled;
-    this.onBuild = builder.onBuild;
-    this.labels = builder.labels;
-    this.macAddress = builder.macAddress;
-    this.hostConfig = builder.hostConfig;
-    this.stopSignal = builder.stopSignal;
-
-    if (builder.volumes != null) {
-      final Map<String, Map> volumesToAdd = Maps.newHashMap();
-      for (final String builderVolume : builder.volumes) {
-        volumesToAdd.put(builderVolume, Maps.newHashMap());
-      }
-      this.volumes = ImmutableMap.copyOf(volumesToAdd);
-    }
-  }
-
-  public String hostname() {
-    return hostname;
-  }
-
-  public String domainname() {
-    return domainname;
-  }
-
-  public String user() {
-    return user;
-  }
-
-  public Boolean attachStdin() {
-    return attachStdin;
-  }
-
-  public Boolean attachStdout() {
-    return attachStdout;
-  }
-
-  public Boolean attachStderr() {
-    return attachStderr;
-  }
-
-  public List<String> portSpecs() {
-    return portSpecs;
-  }
-
-  public Set<String> exposedPorts() {
-    return exposedPorts;
-  }
-
-  public Boolean tty() {
-    return tty;
-  }
-
-  public Boolean openStdin() {
-    return openStdin;
-  }
-
-  public Boolean stdinOnce() {
-    return stdinOnce;
-  }
-
-  public List<String> env() {
-    return env;
-  }
-
-  public List<String> cmd() {
-    return cmd;
-  }
-
-  public String image() {
-    return image;
-  }
-
-  public Set<String> volumes() {
-    return volumes.keySet();
-  }
-
-  public String workingDir() {
-    return workingDir;
-  }
-
-  public List<String> entrypoint() {
-    return entrypoint;
-  }
-
-  public Boolean networkDisabled() {
-    return networkDisabled;
-  }
-
-  public List<String> onBuild() {
-    return onBuild;
-  }
-
-  public Map<String, String> labels() {
-    return labels;
-  }
-
-  public String macAddress() {
-    return macAddress;
-  }
-
-  public HostConfig hostConfig() {
-    return hostConfig;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    final ContainerConfig that = (ContainerConfig) o;
-
-    return Objects.equals(this.hostname, that.hostname) &&
-           Objects.equals(this.domainname, that.domainname) &&
-           Objects.equals(this.user, that.user) &&
-           Objects.equals(this.attachStdin, that.attachStdin) &&
-           Objects.equals(this.attachStdout, that.attachStdout) &&
-           Objects.equals(this.attachStderr, that.attachStderr) &&
-           Objects.equals(this.portSpecs, that.portSpecs) &&
-           Objects.equals(this.exposedPorts, that.exposedPorts) &&
-           Objects.equals(this.tty, that.tty) &&
-           Objects.equals(this.openStdin, that.openStdin) &&
-           Objects.equals(this.stdinOnce, that.stdinOnce) &&
-           Objects.equals(this.env, that.env) &&
-           Objects.equals(this.cmd, that.cmd) &&
-           Objects.equals(this.image, that.image) &&
-           Objects.equals(this.volumes, that.volumes) &&
-           Objects.equals(this.workingDir, that.workingDir) &&
-           Objects.equals(this.entrypoint, that.entrypoint) &&
-           Objects.equals(this.networkDisabled, that.networkDisabled) &&
-           Objects.equals(this.onBuild, that.onBuild) &&
-           Objects.equals(this.labels, that.labels) &&
-           Objects.equals(this.macAddress, that.macAddress) &&
-           Objects.equals(this.hostConfig, that.hostConfig) &&
-           Objects.equals(this.stopSignal, that.stopSignal);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(hostname, domainname, user, attachStdin, attachStdout,
-                        attachStderr, portSpecs, exposedPorts, tty, openStdin, stdinOnce, env,
-                        cmd, image, volumes, workingDir, entrypoint, networkDisabled, onBuild,
-                        labels, macAddress, hostConfig, stopSignal);
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("hostname", hostname)
-        .add("domainname", domainname)
-        .add("username", user)
-        .add("attachStdin", attachStdin)
-        .add("attachStdout", attachStdout)
-        .add("attachStderr", attachStderr)
-        .add("portSpecs", portSpecs)
-        .add("exposedPorts", exposedPorts)
-        .add("tty", tty)
-        .add("openStdin", openStdin)
-        .add("stdinOnce", stdinOnce)
-        .add("env", env)
-        .add("cmd", cmd)
-        .add("image", image)
-        .add("volumes", volumes)
-        .add("workingDir", workingDir)
-        .add("entrypoint", entrypoint)
-        .add("networkDisabled", networkDisabled)
-        .add("onBuild", onBuild)
-        .add("labels", labels)
-        .add("macAddress", macAddress)
-        .add("hostConfig", hostConfig)
-        .add("stopSignal", stopSignal)
-        .toString();
-  }
-
-  public Builder toBuilder() {
-    return new Builder(this);
-  }
+  public abstract Builder toBuilder();
 
   public static Builder builder() {
-    return new Builder();
+    return new AutoValue_ContainerConfig.Builder();
   }
 
-  public static class Builder {
+  @AutoValue.Builder
+  public abstract static class Builder {
 
-    private String hostname;
-    private String domainname;
-    private String user;
-    private Boolean attachStdin;
-    private Boolean attachStdout;
-    private Boolean attachStderr;
-    private ImmutableList<String> portSpecs;
-    private ImmutableSet<String> exposedPorts;
-    private Boolean tty;
-    private Boolean openStdin;
-    private Boolean stdinOnce;
-    private ImmutableList<String> env;
-    private ImmutableList<String> cmd;
-    private String image;
-    private ImmutableSet<String> volumes;
-    private String workingDir;
-    private ImmutableList<String> entrypoint;
-    private Boolean networkDisabled;
-    private ImmutableList<String> onBuild;
-    private ImmutableMap<String, String> labels;
-    private String macAddress;
-    private HostConfig hostConfig;
-    private String stopSignal;
+    public abstract Builder hostname(final String hostname);
 
-    private Builder() {
+    public abstract Builder domainname(final String domainname);
+
+    public abstract Builder user(final String user);
+
+    public abstract Builder attachStdin(final Boolean attachStdin);
+
+    public abstract Builder attachStdout(final Boolean attachStdout);
+
+    public abstract Builder attachStderr(final Boolean attachStderr);
+
+    public abstract Builder portSpecs(final List<String> portSpecs);
+
+    public abstract Builder portSpecs(final String... portSpecs);
+
+    public abstract Builder exposedPorts(final Set<String> exposedPorts);
+
+    public abstract Builder exposedPorts(final String... exposedPorts);
+
+    public abstract Builder tty(final Boolean tty);
+
+    public abstract Builder openStdin(final Boolean openStdin);
+
+    public abstract Builder stdinOnce(final Boolean stdinOnce);
+
+    public abstract Builder env(final List<String> env);
+
+    public abstract Builder env(final String... env);
+
+    public abstract Builder cmd(final List<String> cmd);
+
+    public abstract Builder cmd(final String... cmd);
+
+    public abstract Builder image(final String image);
+
+    public abstract Builder volumes(Set<String> volumes);
+
+    public Builder volumes(String... volumes) {
+      return this.volumes(ImmutableSet.copyOf(volumes));
     }
 
-    private Builder(final ContainerConfig config) {
-      this.hostname = config.hostname;
-      this.domainname = config.domainname;
-      this.user = config.user;
-      this.attachStdin = config.attachStdin;
-      this.attachStdout = config.attachStdout;
-      this.attachStderr = config.attachStderr;
-      this.portSpecs = config.portSpecs;
-      this.exposedPorts = config.exposedPorts;
-      this.tty = config.tty;
-      this.openStdin = config.openStdin;
-      this.stdinOnce = config.stdinOnce;
-      this.env = config.env;
-      this.cmd = config.cmd;
-      this.image = config.image;
-      this.volumes = config.volumes.keySet();
-      this.workingDir = config.workingDir;
-      this.entrypoint = config.entrypoint;
-      this.networkDisabled = config.networkDisabled;
-      this.onBuild = config.onBuild;
-      this.labels = config.labels;
-      this.macAddress = config.macAddress;
-      this.hostConfig = config.hostConfig;
-      this.stopSignal = config.stopSignal;
-    }
+    public abstract Builder workingDir(final String workingDir);
 
-    public Builder hostname(final String hostname) {
-      this.hostname = hostname;
-      return this;
-    }
+    public abstract Builder entrypoint(final List<String> entrypoint);
 
-    public String hostname() {
-      return hostname;
-    }
+    public abstract Builder entrypoint(final String... entrypoint);
 
-    public Builder domainname(final String domainname) {
-      this.domainname = domainname;
-      return this;
-    }
+    public abstract Builder networkDisabled(final Boolean networkDisabled);
 
-    public String domainname() {
-      return domainname;
-    }
+    public abstract Builder onBuild(final List<String> onBuild);
 
-    public Builder user(final String user) {
-      this.user = user;
-      return this;
-    }
+    public abstract Builder onBuild(final String... onBuild);
 
-    public String user() {
-      return user;
-    }
+    public abstract Builder labels(final Map<String, String> labels);
 
-    public Builder attachStdin(final Boolean attachStdin) {
-      this.attachStdin = attachStdin;
-      return this;
-    }
+    public abstract Builder macAddress(final String macAddress);
 
-    public Boolean attachStdin() {
-      return attachStdin;
-    }
+    public abstract Builder hostConfig(final HostConfig hostConfig);
 
-    public Builder attachStdout(final Boolean attachStdout) {
-      this.attachStdout = attachStdout;
-      return this;
-    }
+    public abstract Builder stopSignal(final String stopSignal);
 
-    public Boolean attachStdout() {
-      return attachStdout;
-    }
-
-    public Builder attachStderr(final Boolean attachStderr) {
-      this.attachStderr = attachStderr;
-      return this;
-    }
-
-    public Boolean attachStderr() {
-      return attachStderr;
-    }
-
-    public Builder portSpecs(final List<String> portSpecs) {
-      if (portSpecs != null && !portSpecs.isEmpty()) {
-        this.portSpecs = ImmutableList.copyOf(portSpecs);
-      }
-
-      return this;
-    }
-
-    public Builder portSpecs(final String... portSpecs) {
-      if (portSpecs != null && portSpecs.length > 0) {
-        this.portSpecs = ImmutableList.copyOf(portSpecs);
-      }
-
-      return this;
-    }
-
-    public List<String> portSpecs() {
-      return portSpecs;
-    }
-
-    public Builder exposedPorts(final Set<String> exposedPorts) {
-      if (exposedPorts != null && !exposedPorts.isEmpty()) {
-        this.exposedPorts = ImmutableSet.copyOf(exposedPorts);
-      }
-
-      return this;
-    }
-
-    public Builder exposedPorts(final String... exposedPorts) {
-      if (exposedPorts != null && exposedPorts.length > 0) {
-        this.exposedPorts = ImmutableSet.copyOf(exposedPorts);
-      }
-
-      return this;
-    }
-
-    public Set<String> exposedPorts() {
-      return exposedPorts;
-    }
-
-    public Builder tty(final Boolean tty) {
-      this.tty = tty;
-      return this;
-    }
-
-    public Boolean tty() {
-      return tty;
-    }
-
-    public Builder openStdin(final Boolean openStdin) {
-      this.openStdin = openStdin;
-      return this;
-    }
-
-    public Boolean openStdin() {
-      return openStdin;
-    }
-
-    public Builder stdinOnce(final Boolean stdinOnce) {
-      this.stdinOnce = stdinOnce;
-      return this;
-    }
-
-    public Boolean stdinOnce() {
-      return stdinOnce;
-    }
-
-    public Builder env(final List<String> env) {
-      if (env != null && !env.isEmpty()) {
-        this.env = ImmutableList.copyOf(env);
-      }
-
-      return this;
-    }
-
-    public Builder env(final String... env) {
-      if (env != null && env.length > 0) {
-        this.env = ImmutableList.copyOf(env);
-      }
-
-      return this;
-    }
-
-    public List<String> env() {
-      return env;
-    }
-
-    public Builder cmd(final List<String> cmd) {
-      if (cmd != null && !cmd.isEmpty()) {
-        this.cmd = ImmutableList.copyOf(cmd);
-      }
-
-      return this;
-    }
-
-    public Builder cmd(final String... cmd) {
-      if (cmd != null && cmd.length > 0) {
-        this.cmd = ImmutableList.copyOf(cmd);
-      }
-
-      return this;
-    }
-
-    public List<String> cmd() {
-      return cmd;
-    }
-
-    public Builder image(final String image) {
-      this.image = image;
-      return this;
-    }
-
-    public String image() {
-      return image;
-    }
-
-    public Builder volumes(final Set<String> volumes) {
-      if (volumes != null && !volumes.isEmpty()) {
-        this.volumes = ImmutableSet.copyOf(volumes);
-      }
-
-      return this;
-    }
-
-    public Builder volumes(final String... volumes) {
-      if (volumes != null && volumes.length > 0) {
-        this.volumes = ImmutableSet.copyOf(volumes);
-      }
-
-      return this;
-    }
-
-    public Set<String> volumes() {
-      return volumes;
-    }
-
-    public Builder workingDir(final String workingDir) {
-      this.workingDir = workingDir;
-      return this;
-    }
-
-    public String workingDir() {
-      return workingDir;
-    }
-
-    public Builder entrypoint(final List<String> entrypoint) {
-      if (entrypoint != null && !entrypoint.isEmpty()) {
-        this.entrypoint = ImmutableList.copyOf(entrypoint);
-      }
-
-      return this;
-    }
-
-    public Builder entrypoint(final String... entrypoint) {
-      if (entrypoint != null && entrypoint.length > 0) {
-        this.entrypoint = ImmutableList.copyOf(entrypoint);
-      }
-
-      return this;
-    }
-
-    public List<String> entrypoint() {
-      return entrypoint;
-    }
-
-    public Builder networkDisabled(final Boolean networkDisabled) {
-      this.networkDisabled = networkDisabled;
-      return this;
-    }
-
-    public Boolean networkDisabled() {
-      return networkDisabled;
-    }
-
-    public Builder onBuild(final List<String> onBuild) {
-      if (onBuild != null && !onBuild.isEmpty()) {
-        this.onBuild = ImmutableList.copyOf(onBuild);
-      }
-
-      return this;
-    }
-
-    public Builder onBuild(final String... onBuild) {
-      if (onBuild != null && onBuild.length > 0) {
-        this.onBuild = ImmutableList.copyOf(onBuild);
-      }
-
-      return this;
-    }
-
-    public List<String> onBuild() {
-      return onBuild;
-    }
-
-    public Builder labels(final Map<String, String> labels) {
-      if (labels != null && !labels.isEmpty()) {
-        this.labels = ImmutableMap.copyOf(labels);
-      }
-
-      return this;
-    }
-
-    public Map<String, String> labels() {
-      return labels;
-    }
-
-    public Builder macAddress(final String macAddress) {
-      this.macAddress = macAddress;
-      return this;
-    }
-
-    public String macAddress() {
-      return macAddress;
-    }
-
-    public Builder hostConfig(final HostConfig hostConfig) {
-      this.hostConfig = hostConfig;
-      return this;
-    }
-
-    public HostConfig hostConfig() {
-      return hostConfig;
-    }
-
-    public Builder stopSignal(final String stopSignal) {
-      this.stopSignal = stopSignal;
-      return this;
-    }
-
-    public String stopSignal() {
-      return stopSignal;
-    }
-
-    public ContainerConfig build() {
-      return new ContainerConfig(this);
-    }
-  }
-
-  public String getStopSignal() {
-    return stopSignal;
+    public abstract ContainerConfig build();
   }
 }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -1571,7 +1571,7 @@ public class DefaultDockerClientTest {
     assertThat(actual.publishAllPorts(), equalTo(expected.publishAllPorts()));
     assertThat(actual.dns(), equalTo(expected.dns()));
     assertThat(actual.cpuShares(), equalTo(expected.cpuShares()));
-    assertThat(sut.inspectContainer(id).config().getStopSignal(), equalTo(config.getStopSignal()));
+    assertThat(sut.inspectContainer(id).config().stopSignal(), equalTo(config.stopSignal()));
     assertThat(inspection.appArmorProfile(), equalTo(""));
     assertThat(inspection.execId(), equalTo(null));
     assertThat(inspection.logPath(), containsString(id + "-json.log"));
@@ -3386,7 +3386,7 @@ public class DefaultDockerClientTest {
                     .name(networkName).build());
 
     final String networkId = networkCreation.id();
-    
+
     assertThat(networkId, is(notNullValue()));
 
     final TaskSpec taskSpec = TaskSpec.builder()
@@ -3404,7 +3404,7 @@ public class DefaultDockerClientTest {
 
     final Service inspectService = sut.inspectService(serviceName);
     assertThat(inspectService.spec().networks().size(), is(1));
-    assertThat(Iterables.find(inspectService.spec().networks(), 
+    assertThat(Iterables.find(inspectService.spec().networks(),
       new Predicate<NetworkAttachmentConfig>() {
 
       @Override
@@ -3412,11 +3412,11 @@ public class DefaultDockerClientTest {
         return networkId.equals(config.target());
       }
     }, null), is(notNullValue()));
-    
+
     sut.removeService(serviceName);
     sut.removeNetwork(networkName);
   }
-  
+
   @Test
   public void testCreateService() throws Exception {
     requireDockerApiVersionAtLeast("1.24", "swarm support");


### PR DESCRIPTION
(don't merge, I am opening this just to run tests on Travis)

This is an experiment at using AutoValue to replace all the POJO boilerplate in the `messages` package with AutoValue and AutoValue.Builders. For the most part, the generated classes should be compatible with existing code.