### PR TITLE
Add ImageNotFoundException to client.pull()

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -1153,6 +1153,13 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       pull.tail(handler, POST, resource.getUri());
     } catch (IOException e) {
       throw new DockerException(e);
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
+        case 404:
+          throw new ImageNotFoundException(image, e);
+        default:
+          throw e;
+      }
     }
   }
 
@@ -1197,6 +1204,8 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       switch (e.status()) {
         case 404:
           throw new ImageNotFoundException(image, e);
+        default:
+          throw e;
       }
     }
   }

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -416,6 +416,8 @@ public interface DockerClient extends Closeable {
    * Pull a docker container image.
    *
    * @param image The image to pull.
+   * @throws com.spotify.docker.client.exceptions.ImageNotFoundException
+   *                            if image was not found (404)
    * @throws DockerException      if a server error occurred (500)
    * @throws InterruptedException If the thread is interrupted
    */
@@ -426,6 +428,8 @@ public interface DockerClient extends Closeable {
    *
    * @param image   The image to pull.
    * @param handler The handler to use for processing each progress message received from Docker.
+   * @throws com.spotify.docker.client.exceptions.ImageNotFoundException
+   *                            if image was not found (404)
    * @throws DockerException      if a server error occurred (500)
    * @throws InterruptedException If the thread is interrupted
    */
@@ -436,6 +440,8 @@ public interface DockerClient extends Closeable {
    *
    * @param image      The image to pull.
    * @param authConfig The authentication config needed to pull the image.
+   * @throws com.spotify.docker.client.exceptions.ImageNotFoundException
+   *                            if image was not found (404)
    * @throws DockerException      if a server error occurred (500)
    * @throws InterruptedException If the thread is interrupted
    */
@@ -448,6 +454,8 @@ public interface DockerClient extends Closeable {
    * @param authConfig The authentication config needed to pull the image.
    * @param handler    The handler to use for processing each progress message received from
    *                   Docker.
+   * @throws com.spotify.docker.client.exceptions.ImageNotFoundException
+   *                            if image was not found (404)
    * @throws DockerException      if a server error occurred (500)
    * @throws InterruptedException If the thread is interrupted
    */
@@ -458,6 +466,8 @@ public interface DockerClient extends Closeable {
    * Push a docker container image.
    *
    * @param image The image to push.
+   * @throws com.spotify.docker.client.exceptions.ImageNotFoundException
+   *                            if image was not found (404)
    * @throws DockerException      if a server error occurred (500)
    * @throws InterruptedException If the thread is interrupted
    */
@@ -468,6 +478,8 @@ public interface DockerClient extends Closeable {
    *
    * @param image   The image to push.
    * @param handler The handler to use for processing each progress message received from Docker.
+   * @throws com.spotify.docker.client.exceptions.ImageNotFoundException
+   *                            if image was not found (404)
    * @throws DockerException      if a server error occurred (500)
    * @throws InterruptedException If the thread is interrupted
    */


### PR DESCRIPTION
I added a new `catch` clause to `DefaultDockerClient.pull(...)` that throws an `ImageNotFoundException` when `/images/create` returns a 404. This 404 response is not documented, which is why we didn't add the catch/rethrow before. 

See docker/docker#28993. 