### PR TITLE
Update Events

### DIFF
--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -2229,8 +2229,9 @@ public interface DockerClient extends Closeable {
      *
      * @param until Return events up until this Unix timestamp.
      * @return {@link EventsParam}
+     * @since API 1.18
      */
-    public static EventsParam until(Long until) {
+    public static EventsParam until(final Long until) {
       return new EventsParam("until", String.valueOf(until));
     }
 
@@ -2239,8 +2240,9 @@ public interface DockerClient extends Closeable {
      *
      * @param since Return events since this Unix timestamp.
      * @return {@link EventsParam}
+     * @since API 1.18
      */
-    public static EventsParam since(Long since) {
+    public static EventsParam since(final Long since) {
       return new EventsParam("since", String.valueOf(since));
     }
 
@@ -2250,8 +2252,9 @@ public interface DockerClient extends Closeable {
      * @param name  Name
      * @param value Value
      * @return {@link EventsParam}
+     * @since API 1.18
      */
-    private static EventsParam filter(String name, String value) {
+    private static EventsParam filter(final String name, final String value) {
       return new EventsFilterParam(name, value);
     }
 
@@ -2259,6 +2262,7 @@ public interface DockerClient extends Closeable {
      * Show only certain events. For example, "event=pull" for image pull events.
      * @param event Type of event to show
      * @return EventsParam
+     * @since API 1.21
      */
     public static EventsParam event(final String event) {
       return filter("event", event);
@@ -2268,6 +2272,7 @@ public interface DockerClient extends Closeable {
      * Show events for an image.
      * @param image An image tag or id
      * @return EventsParam
+     * @since API 1.18
      */
     public static EventsParam image(final String image) {
       return filter("image", image);
@@ -2277,6 +2282,7 @@ public interface DockerClient extends Closeable {
      * Show events for a container.
      * @param container A container name or id
      * @return EventsParam
+     * @since API 1.18
      */
     public static EventsParam container(final String container) {
       return filter("container", container);
@@ -2286,6 +2292,7 @@ public interface DockerClient extends Closeable {
      * Show events for a volume.
      * @param volume A volume name or id
      * @return EventsParam
+     * @since API 1.22
      */
     public static EventsParam volume(final String volume) {
       return filter("volume", volume);
@@ -2295,6 +2302,7 @@ public interface DockerClient extends Closeable {
      * Show events for a network.
      * @param network A network name or id
      * @return EventsParam
+     * @since API 1.22
      */
     public static EventsParam network(final String network) {
       return filter("network", network);
@@ -2304,6 +2312,7 @@ public interface DockerClient extends Closeable {
      * Show events for a daemon.
      * @param daemon A daemon name or id
      * @return EventsParam
+     * @since API 1.24
      */
     public static EventsParam daemon(final String daemon) {
       return filter("daemon", daemon);
@@ -2313,9 +2322,22 @@ public interface DockerClient extends Closeable {
      * Show events of a given type. For instance, "type=image" for all image events.
      * @param type A type of event. Possible values: container, image, volume, network, or daemon
      * @return EventsParam
+     * @deprecated Use {@link #type(EventType)}.
+     * @since API 1.22
      */
+    @Deprecated
     public static EventsParam type(final String type) {
       return filter("type", type);
+    }
+
+    /**
+     * Show events of a given type. For instance, "type=image" for all image events.
+     * @param type A type of event. Possible values: container, image, volume, network, or daemon
+     * @return EventsParam
+     * @since API 1.22
+     */
+    public static EventsParam type(final EventType type) {
+      return filter("type", type.getName());
     }
 
     /**
@@ -2324,6 +2346,7 @@ public interface DockerClient extends Closeable {
      * @param label The label to filter on
      * @param value The value of the label
      * @return EventsParam
+     * @since API 1.21
      */
     public static EventsParam label(final String label, final String value) {
       return isNullOrEmpty(value) ? filter("label", label) : filter("label", label + "=" + value);
@@ -2334,10 +2357,33 @@ public interface DockerClient extends Closeable {
      *
      * @param label The label to filter on
      * @return EventsParam
+     * @since API 1.21
      */
     public static EventsParam label(final String label) {
       return label(label, null);
     }
+
+    /**
+     * Valid event types for EventsParam.type
+     */
+    public enum EventType {
+      CONTAINER("container"),
+      IMAGE("image"),
+      VOLUME("volume"),
+      NETWORK("network"),
+      DAEMON("daemon");
+
+      private final String name;
+
+      EventType(final String name) {
+        this.name = name;
+      }
+
+      public String getName() {
+        return name;
+      }
+    }
+
   }
 
   /**

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -42,6 +42,7 @@ import com.spotify.docker.client.messages.ContainerCreation;
 import com.spotify.docker.client.messages.ContainerExit;
 import com.spotify.docker.client.messages.ContainerInfo;
 import com.spotify.docker.client.messages.ContainerStats;
+import com.spotify.docker.client.messages.Event;
 import com.spotify.docker.client.messages.ExecCreation;
 import com.spotify.docker.client.messages.ExecState;
 import com.spotify.docker.client.messages.Image;
@@ -2322,7 +2323,7 @@ public interface DockerClient extends Closeable {
      * Show events of a given type. For instance, "type=image" for all image events.
      * @param type A type of event. Possible values: container, image, volume, network, or daemon
      * @return EventsParam
-     * @deprecated Use {@link #type(EventType)}.
+     * @deprecated Use {@link #type(Event.Type)}.
      * @since API 1.22
      */
     @Deprecated
@@ -2336,7 +2337,7 @@ public interface DockerClient extends Closeable {
      * @return EventsParam
      * @since API 1.22
      */
-    public static EventsParam type(final EventType type) {
+    public static EventsParam type(final Event.Type type) {
       return filter("type", type.getName());
     }
 
@@ -2361,27 +2362,6 @@ public interface DockerClient extends Closeable {
      */
     public static EventsParam label(final String label) {
       return label(label, null);
-    }
-
-    /**
-     * Valid event types for EventsParam.type
-     */
-    public enum EventType {
-      CONTAINER("container"),
-      IMAGE("image"),
-      VOLUME("volume"),
-      NETWORK("network"),
-      DAEMON("daemon");
-
-      private final String name;
-
-      EventType(final String name) {
-        this.name = name;
-      }
-
-      public String getName() {
-        return name;
-      }
     }
 
   }

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -2262,7 +2262,7 @@ public interface DockerClient extends Closeable {
      * Show only certain events. For example, "event=pull" for image pull events.
      * @param event Type of event to show
      * @return EventsParam
-     * @since API 1.21
+     * @since API 1.18
      */
     public static EventsParam event(final String event) {
       return filter("event", event);

--- a/src/main/java/com/spotify/docker/client/messages/Event.java
+++ b/src/main/java/com/spotify/docker/client/messages/Event.java
@@ -153,13 +153,13 @@ public class Event {
 
   public static class Actor {
     @JsonProperty("ID") private String id;
-    @JsonProperty("Attributes") private ImmutableMap<String, Object> attributes;
+    @JsonProperty("Attributes") private ImmutableMap<String, String> attributes;
 
     public String id() {
       return id;
     }
 
-    public ImmutableMap<String, Object> attributes() {
+    public ImmutableMap<String, String> attributes() {
       return attributes;
     }
 

--- a/src/main/java/com/spotify/docker/client/messages/Event.java
+++ b/src/main/java/com/spotify/docker/client/messages/Event.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
 import com.spotify.docker.client.jackson.UnixTimestampDeserializer;
 
 import java.util.Date;
@@ -35,31 +36,78 @@ import java.util.Objects;
 @JsonAutoDetect(fieldVisibility = ANY, setterVisibility = NONE, getterVisibility = NONE)
 public class Event {
 
-  @JsonProperty("status")
-  private String status;
-  @JsonProperty("id")
-  private String id;
-  @JsonProperty("from")
-  private String from;
-
+  @JsonProperty("status") private String status;
+  @JsonProperty("id") private String id;
+  @JsonProperty("from") private String from;
+  @JsonProperty("Type") private String type;
+  @JsonProperty("Action") private String action;
+  @JsonProperty("Actor") private Actor actor;
   @JsonProperty("time")
   @JsonDeserialize(using = UnixTimestampDeserializer.class)
   private Date time;
+  @JsonProperty("timeNano") private Long timeNano;
 
+  /**
+   * Event status.
+   * @return status
+   * @deprecated Use {@link #action()} instead
+   */
+  @Deprecated
   public String status() {
     return status;
   }
 
+  /**
+   * Event actor id. When the event type is "container" this is the container id.
+   * @return id
+   * @deprecated Use the {@link com.spotify.docker.client.messages.Event.Actor#id()}
+   *     field from {@link #actor()}
+   */
+  @Deprecated
   public String id() {
     return id;
   }
 
+  /**
+   * When the event type is "container" this is the image id.
+   * @return from
+   * @deprecated Use the "image" attribute in the
+   *     {@link com.spotify.docker.client.messages.Event.Actor#attributes()}
+   *     map from {@link #actor()}
+   */
+  @Deprecated
   public String from() {
     return from;
   }
 
+  public String type() {
+    return type;
+  }
+
+  /**
+   * Event action.
+   * @return action
+   * @since API 1.22
+   */
+  public String action() {
+    return action;
+  }
+
+  /**
+   * Event actor.
+   * @return actor
+   * @since API 1.22
+   */
+  public Actor actor() {
+    return actor;
+  }
+
   public Date time() {
     return time == null ? null : new Date(time.getTime());
+  }
+
+  public Long timeNano() {
+    return timeNano;
   }
 
   @Override
@@ -76,7 +124,11 @@ public class Event {
     return Objects.equals(this.status, that.status)
            && Objects.equals(this.id, that.id)
            && Objects.equals(this.from, that.from)
-           && Objects.equals(this.time, that.time);
+           && Objects.equals(this.type, that.type)
+           && Objects.equals(this.action, that.action)
+           && Objects.equals(this.actor, that.actor)
+           && Objects.equals(this.time, that.time)
+           && Objects.equals(this.timeNano, that.timeNano);
 
   }
 
@@ -91,7 +143,50 @@ public class Event {
         .add("status", status)
         .add("id", id)
         .add("from", from)
+        .add("type", type)
+        .add("action", action)
+        .add("actor", actor)
         .add("time", time)
+        .add("timeNano", timeNano)
         .toString();
+  }
+
+  public static class Actor {
+    @JsonProperty("ID") private String id;
+    @JsonProperty("Attributes") private ImmutableMap<String, Object> attributes;
+
+    public String id() {
+      return id;
+    }
+
+    public ImmutableMap<String, Object> attributes() {
+      return attributes;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null || getClass() != obj.getClass()) {
+        return false;
+      }
+      final Actor that = (Actor) obj;
+      return Objects.equals(this.id, that.id)
+             && Objects.equals(this.attributes, that.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, attributes);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("id", id)
+          .add("attributes", attributes)
+          .toString();
+    }
   }
 }

--- a/src/main/java/com/spotify/docker/client/messages/Event.java
+++ b/src/main/java/com/spotify/docker/client/messages/Event.java
@@ -24,7 +24,9 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
@@ -39,7 +41,7 @@ public class Event {
   @JsonProperty("status") private String status;
   @JsonProperty("id") private String id;
   @JsonProperty("from") private String from;
-  @JsonProperty("Type") private String type;
+  @JsonProperty("Type") private Type type;
   @JsonProperty("Action") private String action;
   @JsonProperty("Actor") private Actor actor;
   @JsonProperty("time")
@@ -80,7 +82,7 @@ public class Event {
     return from;
   }
 
-  public String type() {
+  public Type type() {
     return type;
   }
 
@@ -187,6 +189,26 @@ public class Event {
           .add("id", id)
           .add("attributes", attributes)
           .toString();
+    }
+  }
+
+  public enum Type {
+    CONTAINER("container"),
+    IMAGE("image"),
+    VOLUME("volume"),
+    NETWORK("network"),
+    DAEMON("daemon");
+
+    private final String name;
+
+    @JsonCreator
+    Type(final String name) {
+      this.name = name;
+    }
+
+    @JsonValue
+    public String getName() {
+      return name;
     }
   }
 }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -1856,6 +1856,12 @@ public class DefaultDockerClientTest {
               eventStream.hasNext());
       containerEventAssertions(eventStream.next(), containerId, containerName,
               "destroy", BUSYBOX_LATEST);
+
+      // assertFalse("Expect no more image or container events", eventStream.hasNext());
+      // NOTE: we cannot make this assertion here. It is a valid assertion, because there
+      // are no more events in the stream. However, the connection is still open. Calling
+      // hasNext() on a stream with an open connection and no events will hang indefinitely.
+      // This will trigger the test's timeout, causing an ERROR and a test failure.
     }
   }
 

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -1824,7 +1824,7 @@ public class DefaultDockerClientTest {
       assertTrue("Docker did not return any events. "
                       + "Expected to see an event for pulling an image.",
               eventStream.hasNext());
-      imagePullEventAssertions(eventStream.next());
+      imageEventAssertions(eventStream.next(), BUSYBOX_LATEST, "pull");
 
       // Container create
       final ContainerCreation container = sut.createContainer(config, containerName);
@@ -1899,7 +1899,7 @@ public class DefaultDockerClientTest {
     assertNotNull(eventList);
     assertThat(eventList, not(empty()));
 
-    imagePullEventAssertions(eventList.get(0));
+    imageEventAssertions(eventList.get(0), BUSYBOX_LATEST, "pull");
 
     // create and start event assertions
     containerEventAssertions(eventList.get(1), containerId, containerName,
@@ -1951,7 +1951,7 @@ public class DefaultDockerClientTest {
                  sut.events(since(startTime), until(endTime), type(IMAGE))) {
       assertTrue("Docker did not return any image events.",
               stream.hasNext());
-      imagePullEventAssertions(stream.next());
+      imageEventAssertions(stream.next(), BUSYBOX_LATEST, "pull");
     }
 
     // Container events
@@ -2061,17 +2061,19 @@ public class DefaultDockerClientTest {
   }
 
   @SuppressWarnings("deprecation")
-  private void imagePullEventAssertions(final Event pullEvent) throws Exception {
-    assertThat(pullEvent.time(), notNullValue());
+  private void imageEventAssertions(final Event event,
+                                    final String imageName,
+                                    final String action) throws Exception {
+    assertThat(event.time(), notNullValue());
     if (dockerApiVersionAtLeast("1.22")) {
-      assertEquals(IMAGE.getName(), pullEvent.type());
-      assertEquals("pull", pullEvent.action());
-      assertEquals(BUSYBOX_LATEST, pullEvent.actor().id());
+      assertEquals(IMAGE.getName(), event.type());
+      assertEquals(action, event.action());
+      assertEquals(imageName, event.actor().id());
 
-      assertNotNull(pullEvent.timeNano());
+      assertNotNull(event.timeNano());
     } else {
-      assertEquals("pull", pullEvent.status());
-      assertThat(pullEvent.id(), equalTo(BUSYBOX_LATEST));
+      assertEquals(action, event.status());
+      assertThat(event.id(), equalTo(imageName));
     }
   }
 

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -1819,9 +1819,21 @@ public class DefaultDockerClientTest {
       final ContainerCreation container = sut.createContainer(config, randomName());
       sut.startContainer(container.id());
 
+      assertTrue("Docker did not return any events. "
+                      + "Expected to see an event for pulling an image.",
+              eventStream.hasNext());
       final Event pullEvent = eventStream.next();
+
+      assertTrue("Docker did not return enough events. "
+                      + "Expected to see an event for creating a container.",
+              eventStream.hasNext());
       final Event createEvent = eventStream.next();
+
+      assertTrue("Docker did not return enough events. "
+                      + "Expected to see an event for starting a container.",
+              eventStream.hasNext());
       final Event startEvent = eventStream.next();
+
       eventStreamAssertions(pullEvent, createEvent, startEvent, container.id(), BUSYBOX_LATEST);
     }
   }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -2003,7 +2003,7 @@ public class DefaultDockerClientTest {
       assertThat(mountAttributes, hasEntry("container", containerId));
       assertThat(mountAttributes, hasEntry("destination", mountPath));
       assertThat(mountAttributes, hasEntry("read/write", "true"));
-      assertThat(mountAttributes, hasEntry("propagation", ""));
+      assertThat(mountAttributes, hasKey("propagation")); // Default value is system-dependent
       assertNotNull(volumeMount.timeNano());
 
       assertTrue("Docker did not return enough volume events."

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -1885,7 +1885,7 @@ public class DefaultDockerClientTest {
     final ContainerCreation container = sut.createContainer(config, containerName);
     final String containerId = container.id();
     sut.startContainer(containerId);
-    Thread.sleep(1000);
+    Thread.sleep(1000); // Wait for container to start, then exit
     sut.removeContainer(containerId);
 
     // Wait again to ensure we get back events for everything we did
@@ -1945,7 +1945,7 @@ public class DefaultDockerClientTest {
     final ContainerCreation container = sut.createContainer(config, containerName);
     final String containerId = container.id();
     sut.startContainer(containerId);
-    Thread.sleep(1000);
+    Thread.sleep(1000); // Wait for container to start, then exit
     sut.removeContainer(containerId);
 
     // Wait again to ensure we get back events for everything we did

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -88,6 +88,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -1897,7 +1898,7 @@ public class DefaultDockerClientTest {
     }
 
     assertNotNull(eventList);
-    assertThat(eventList, not(empty()));
+    assertThat(eventList, hasSize(5));
 
     imageEventAssertions(eventList.get(0), BUSYBOX_LATEST, "pull");
 
@@ -1952,6 +1953,7 @@ public class DefaultDockerClientTest {
       assertTrue("Docker did not return any image events.",
               stream.hasNext());
       imageEventAssertions(stream.next(), BUSYBOX_LATEST, "pull");
+      assertFalse("Expect no more image events", stream.hasNext());
     }
 
     // Container events
@@ -1976,6 +1978,7 @@ public class DefaultDockerClientTest {
               stream.hasNext());
       containerEventAssertions(stream.next(), containerId, containerName,
               "destroy", BUSYBOX_LATEST);
+      assertFalse("Expect no more container events", stream.hasNext());
     }
 
     // Volume events
@@ -2016,6 +2019,8 @@ public class DefaultDockerClientTest {
       assertThat(volumeUnmount.actor().attributes(), hasEntry("driver", "local"));
       assertThat(volumeUnmount.actor().attributes(), hasEntry("container", containerId));
       assertNotNull(volumeUnmount.timeNano());
+
+      assertFalse("Expect no more volume events", stream.hasNext());
     }
 
     // Network events
@@ -2041,6 +2046,8 @@ public class DefaultDockerClientTest {
       assertThat(networkDisconnect.actor().attributes(), hasEntry("container", containerId));
       assertThat(networkDisconnect.actor().attributes(), hasEntry("name", "bridge"));
       assertThat(networkDisconnect.actor().attributes(), hasEntry("type", "bridge"));
+
+      assertFalse("Expect no more network events", stream.hasNext());
     }
   }
 

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -26,10 +26,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.spotify.docker.client.DefaultDockerClient.NO_TIMEOUT;
-import static com.spotify.docker.client.DockerClient.EventsParam.EventType.CONTAINER;
-import static com.spotify.docker.client.DockerClient.EventsParam.EventType.IMAGE;
-import static com.spotify.docker.client.DockerClient.EventsParam.EventType.NETWORK;
-import static com.spotify.docker.client.DockerClient.EventsParam.EventType.VOLUME;
 import static com.spotify.docker.client.DockerClient.EventsParam.since;
 import static com.spotify.docker.client.DockerClient.EventsParam.type;
 import static com.spotify.docker.client.DockerClient.EventsParam.until;
@@ -53,6 +49,10 @@ import static com.spotify.docker.client.DockerClient.LogsParam.stdout;
 import static com.spotify.docker.client.DockerClient.LogsParam.tail;
 import static com.spotify.docker.client.DockerClient.LogsParam.timestamps;
 import static com.spotify.docker.client.VersionCompare.compareVersion;
+import static com.spotify.docker.client.messages.Event.Type.CONTAINER;
+import static com.spotify.docker.client.messages.Event.Type.IMAGE;
+import static com.spotify.docker.client.messages.Event.Type.NETWORK;
+import static com.spotify.docker.client.messages.Event.Type.VOLUME;
 import static com.spotify.docker.client.messages.RemovedImage.Type.UNTAGGED;
 import static java.lang.Long.toHexString;
 import static java.lang.String.format;
@@ -1994,7 +1994,7 @@ public class DefaultDockerClientTest {
               stream.hasNext());
 
       final Event volumeCreate = stream.next();
-      assertEquals(VOLUME.getName(), volumeCreate.type());
+      assertEquals(VOLUME, volumeCreate.type());
       assertEquals("create", volumeCreate.action());
       assertEquals(volumeName, volumeCreate.actor().id());
       assertThat(volumeCreate.actor().attributes(), hasEntry("driver", "local"));
@@ -2004,7 +2004,7 @@ public class DefaultDockerClientTest {
                       + "Expected a volume mount event.",
               stream.hasNext());
       final Event volumeMount = stream.next();
-      assertEquals(VOLUME.getName(), volumeMount.type());
+      assertEquals(VOLUME, volumeMount.type());
       assertEquals("mount", volumeMount.action());
       assertEquals(volumeName, volumeMount.actor().id());
       final Map<String, String> mountAttributes = volumeMount.actor().attributes();
@@ -2019,7 +2019,7 @@ public class DefaultDockerClientTest {
                       + "Expected a volume unmount event.",
               stream.hasNext());
       final Event volumeUnmount = stream.next();
-      assertEquals(VOLUME.getName(), volumeUnmount.type());
+      assertEquals(VOLUME, volumeUnmount.type());
       assertEquals("unmount", volumeUnmount.action());
       assertEquals(volumeName, volumeUnmount.actor().id());
       assertThat(volumeUnmount.actor().attributes(), hasEntry("driver", "local"));
@@ -2035,7 +2035,7 @@ public class DefaultDockerClientTest {
       assertTrue("Docker did not return any network events.",
               stream.hasNext());
       final Event networkConnect = stream.next();
-      assertEquals(NETWORK.getName(), networkConnect.type());
+      assertEquals(NETWORK, networkConnect.type());
       assertEquals("connect", networkConnect.action());
       assertNotNull(networkConnect.actor().id()); // not sure how to get the network id
       assertThat(networkConnect.actor().attributes(), hasEntry("container", containerId));
@@ -2046,7 +2046,7 @@ public class DefaultDockerClientTest {
                       + "Expected a network disconnect event.",
               stream.hasNext());
       final Event networkDisconnect = stream.next();
-      assertEquals(NETWORK.getName(), networkDisconnect.type());
+      assertEquals(NETWORK, networkDisconnect.type());
       assertEquals("disconnect", networkDisconnect.action());
       assertEquals(networkDisconnect.actor().id(), networkDisconnect.actor().id());
       assertThat(networkDisconnect.actor().attributes(), hasEntry("container", containerId));
@@ -2079,7 +2079,7 @@ public class DefaultDockerClientTest {
                                     final String action) throws Exception {
     assertThat(event.time(), notNullValue());
     if (dockerApiVersionAtLeast("1.22")) {
-      assertEquals(IMAGE.getName(), event.type());
+      assertEquals(IMAGE, event.type());
       assertEquals(action, event.action());
       assertEquals(imageName, event.actor().id());
 
@@ -2098,7 +2098,7 @@ public class DefaultDockerClientTest {
                                         final String imageName) throws Exception {
     assertThat(event.time(), notNullValue());
     if (dockerApiVersionAtLeast("1.22")) {
-      assertEquals(CONTAINER.getName(), event.type());
+      assertEquals(CONTAINER, event.type());
       assertEquals(action, event.action());
 
       assertNotNull(event.actor());


### PR DESCRIPTION
* Add event fields from docker updates
* Document the version each had been added
* Deprecate older fields
* Update event tests to assert on new fields
* Refactor event tests (now explicitly test event streaming and polling modes)