### PR TITLE
Handle case when TTY is on and output less than 8 bytes. (#530)

### DIFF
--- a/src/main/java/com/spotify/docker/client/LogReader.java
+++ b/src/main/java/com/spotify/docker/client/LogReader.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -54,9 +53,6 @@ public class LogReader implements Closeable {
     final int n = ByteStreams.read(stream, headerBytes, 0, HEADER_SIZE);
     if (n == 0) {
       return null;
-    }
-    if (n != HEADER_SIZE) {
-      throw new EOFException();
     }
     final ByteBuffer header = ByteBuffer.wrap(headerBytes);
     int streamId = header.get();


### PR DESCRIPTION
There is no need to throw an EOFException when TTY is enabled and the
output is less than 8 bytes as this is a valid case. Continue reading
the header information and decide what kind of stream it is.

I haven't created a separate test for this since one can easily reproduce by taking DefaultDockerClientTest#testLogsTty() and changing '.cmd("sh", "-c", "ls")' to '.cmd("echo", "123")' .

Note that calling header.get(), header.getInt(0) is still safe in this case because our header byte buffer will always have a size of 8 (since the underlying byte array has length 8)