### PR TITLE
Make Ulimit use Long instead of Integer

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/HostConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/HostConfig.java
@@ -1297,9 +1297,9 @@ public class HostConfig {
     @JsonProperty("Name")
     private String name;
     @JsonProperty("Soft")
-    private Integer soft;
+    private Long soft;
     @JsonProperty("Hard")
-    private Integer hard;
+    private Long hard;
 
     public Ulimit() {
     }
@@ -1318,11 +1318,11 @@ public class HostConfig {
       return name;
     }
 
-    public Integer soft() {
+    public Long soft() {
       return soft;
     }
 
-    public Integer hard() {
+    public Long hard() {
       return hard;
     }
 
@@ -1359,8 +1359,8 @@ public class HostConfig {
     public static class Builder {
 
       private String name;
-      private Integer soft;
-      private Integer hard;
+      private Long soft;
+      private Long hard;
 
       private Builder() {
       }
@@ -1374,12 +1374,12 @@ public class HostConfig {
         return this;
       }
 
-      public Builder soft(final Integer soft) {
+      public Builder soft(final Long soft) {
         this.soft = soft;
         return this;
       }
 
-      public Builder hard(final Integer hard) {
+      public Builder hard(final Long hard) {
         this.hard = hard;
         return this;
       }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -1517,15 +1517,15 @@ public class DefaultDockerClientTest {
         newArrayList(
             Ulimit.builder()
                 .name("nofile")
-                .soft(1024)
-                .hard(2048)
+                .soft(1024L)
+                .hard(2048L)
                 .build()
         );
     final HostConfig expected = HostConfig.builder()
         .privileged(privileged)
         .publishAllPorts(publishAllPorts)
         .dns(dns)
-        .cpuShares((long) 4096)
+        .cpuShares(4096L)
         .ulimits(ulimits)
         .build();
 
@@ -1558,7 +1558,7 @@ public class DefaultDockerClientTest {
     final boolean publishAllPorts = true;
     final String dns = "1.2.3.4";
     final HostConfig expected = HostConfig.builder().privileged(privileged)
-        .publishAllPorts(publishAllPorts).dns(dns).cpuShares((long) 4096).build();
+        .publishAllPorts(publishAllPorts).dns(dns).cpuShares(4096L).build();
 
     final String stopSignal = "SIGTERM";
 
@@ -1615,7 +1615,7 @@ public class DefaultDockerClientTest {
         .privileged(privileged)
         .publishAllPorts(publishAllPorts)
         .dns(dns)
-        .cpuQuota((long) 50000)
+        .cpuQuota(50000L)
         .build();
 
     final ContainerConfig config = ContainerConfig.builder()


### PR DESCRIPTION
We need to store values greater than Integer can represent.

Fixes #550.