### PR TITLE
Do not allow attaching to a non-running container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,12 @@
       <version>2.8.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>2.0.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -1451,6 +1451,11 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   public LogStream attachContainer(final String containerId,
                                    final AttachParameter... params) throws DockerException,
                                                                            InterruptedException {
+    final ContainerInfo containerInfo = inspectContainer(containerId);
+    if (!containerInfo.state().running()) {
+      throw new IllegalStateException("Container " + containerId + " is not running.");
+    }
+
     WebTarget resource = noTimeoutResource().path("containers").path(containerId).path("attach");
 
     for (final AttachParameter param : params) {

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -1829,6 +1829,7 @@ public interface DockerClient extends Closeable {
    *                              if container is not found (404)
    * @throws DockerException            if a server error occurred (500)
    * @throws InterruptedException       If the thread is interrupted
+   * @throws IllegalStateException      If the container is not running
    */
   LogStream attachContainer(String containerId, AttachParameter... params)
       throws DockerException, InterruptedException;

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -2362,6 +2362,27 @@ public class DefaultDockerClientTest {
   }
 
   @Test
+  public void testAttachExitedContainer() throws Exception {
+    sut.pull(BUSYBOX_LATEST);
+
+    final String volumeContainer = randomName();
+
+    final ContainerConfig volumeConfig = ContainerConfig.builder()
+        .image(BUSYBOX_LATEST)
+        .cmd("ls", "-la")
+        .build();
+    sut.createContainer(volumeConfig, volumeContainer);
+    sut.startContainer(volumeContainer);
+
+    exception.expect(IllegalStateException.class);
+    exception.expectMessage(containsString("is not running"));
+
+    sut.attachContainer(volumeContainer,
+        AttachParameter.LOGS, AttachParameter.STDOUT,
+        AttachParameter.STDERR, AttachParameter.STREAM);
+  }
+
+  @Test
   public void testLogNoTimeout() throws Exception {
     final String volumeContainer = createSleepingContainer();
     final StringBuffer result = new StringBuffer();


### PR DESCRIPTION
This is how the Docker CLI behaves. Attaching to a non-running container
hangs indefinitely. Fixes #288