### PR TITLE
Prevent exec start on a non-running container

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -1488,6 +1488,11 @@ public class DefaultDockerClient implements DockerClient, Closeable {
                                  final String[] cmd,
                                  final ExecCreateParam... params)
       throws DockerException, InterruptedException {
+    final ContainerInfo containerInfo = inspectContainer(containerId);
+    if (!containerInfo.state().running()) {
+      throw new IllegalStateException("Container " + containerId + " is not running.");
+    }
+
     final WebTarget resource = resource().path("containers").path(containerId).path("exec");
 
     final StringWriter writer = new StringWriter();


### PR DESCRIPTION
Currently, trying to do run `execStart()` will make docker-client throw
a `DockerRequestException` with a generic 500 error message.

Instead have docker-client check if the container is running and throw
an `IllegalStateException` otherwise.