### PR TITLE
Fixes #580 - support identityToken based repositories

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/AuthConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/AuthConfig.java
@@ -65,6 +65,9 @@ public class AuthConfig {
   @JsonProperty("ServerAddress")
   private String serverAddress;
 
+  @JsonProperty("IdentityToken")
+  private String identityToken;
+
   @SuppressWarnings("unused")
   private AuthConfig() {
   }
@@ -74,6 +77,7 @@ public class AuthConfig {
     this.password = builder.password;
     this.email = builder.email;
     this.serverAddress = builder.serverAddress;
+    this.identityToken = builder.identityToken;
   }
 
   public String username() {
@@ -92,6 +96,10 @@ public class AuthConfig {
     return serverAddress;
   }
 
+  public String identityToken() {
+    return identityToken;
+  }
+
   @Override
   public boolean equals(final Object obj) {
     if (this == obj) {
@@ -106,7 +114,8 @@ public class AuthConfig {
     return Objects.equals(this.username, that.username)
            && Objects.equals(this.password, that.password)
            && Objects.equals(this.email, that.email)
-           && Objects.equals(this.serverAddress, that.serverAddress);
+           && Objects.equals(this.serverAddress, that.serverAddress)
+           && Objects.equals(this.identityToken, that.identityToken);
   }
 
   @Override
@@ -121,6 +130,7 @@ public class AuthConfig {
         // don't log the password
         .add("email", email)
         .add("serverAddress", serverAddress)
+        .add("identityToken", identityToken)
         .toString();
   }
 
@@ -227,6 +237,9 @@ public class AuthConfig {
       if (authParams.length == 2) {
         authBuilder.username(authParams[0].trim());
         authBuilder.password(authParams[1].trim());
+      } else if (serverAuth.has("identityToken")) {
+        authBuilder.identityToken(serverAuth.get("identityToken").asText());
+        return authBuilder;
       } else {
         log.warn("Failed to parse auth string for {}", serverAddress);
         return authBuilder;
@@ -264,6 +277,7 @@ public class AuthConfig {
     private String email;
     // Default to the public Docker registry.
     private String serverAddress = "https://index.docker.io/v1/";
+    private String identityToken;
 
     private Builder() {
     }
@@ -273,6 +287,7 @@ public class AuthConfig {
       this.password = config.password;
       this.email = config.email;
       this.serverAddress = config.serverAddress;
+      this.identityToken = config.identityToken;
     }
 
     public Builder username(final String username) {
@@ -309,6 +324,15 @@ public class AuthConfig {
 
     public String serverAddress() {
       return serverAddress;
+    }
+
+    public Builder identityToken(final String identityToken) {
+      this.identityToken = identityToken;
+      return this;
+    }
+
+    public String identityToken() {
+      return identityToken;
     }
 
     public AuthConfig build() {

--- a/src/test/java/com/spotify/docker/client/messages/AuthConfigTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/AuthConfigTest.java
@@ -45,6 +45,10 @@ public class AuthConfigTest {
       .password("sw4gy0lo")
       .email("dockerman@hub.com")
       .build();
+  private static final AuthConfig IDENTITY_TOKEN_AUTH_CONFIG = AuthConfig.builder()
+      .serverAddress("docker.customdomain.com")
+      .identityToken("52ce5fd5-eb60-42bf-931f-5eeec128211a")
+      .build();
   private static final AuthConfig MY_AUTH_CONFIG = AuthConfig.builder()
       .serverAddress("https://narnia.mydock.io/v1/")
       .username("megaman")
@@ -109,6 +113,13 @@ public class AuthConfigTest {
     final AuthConfig authConfig = AuthConfig.fromDockerConfig(getTestFilePath(
         "dockerConfig/fullDockerCfg")).build();
     assertThat(authConfig, equalTo(DOCKER_AUTH_CONFIG));
+  }
+
+  @Test
+  public void testFromDockerConfig_IdentityToken() throws Exception {
+    final AuthConfig authConfig = AuthConfig.fromDockerConfig(getTestFilePath(
+            "dockerConfig/identityTokenConfig.json")).build();
+    assertThat(authConfig, equalTo(IDENTITY_TOKEN_AUTH_CONFIG));
   }
 
   @Test

--- a/src/test/resources/dockerConfig/identityTokenConfig.json
+++ b/src/test/resources/dockerConfig/identityTokenConfig.json
@@ -1,0 +1,9 @@
+{
+  "auths": {
+    "docker.customdomain.com": {
+      "auth": "ZG9ja2VybWFuOg==",
+      "email": "dockerman@hub.com",
+      "identityToken": "52ce5fd5-eb60-42bf-931f-5eeec128211a"
+    }
+  }
+}


### PR DESCRIPTION
I do not know of a docker repository I can use (outside of our company's private repository) to include an integration test to run against. I did however write one that hits our internal repository and verified this works.

Note: the token and image are fake for purposes of protecting my credentials. This is however an example of the test I verified to pass.
```
  @Test
  public void testPullPrivateRepoWithIdentityTokenAuth() throws Exception {
    final AuthConfig authConfig = AuthConfig.builder()
            .identityToken("00000000-0000-0000-0000-000000000000")
            .build();

    client.pull("docker.customdomain.com/my_org/my_project:23", authConfig);
  }
```