### PR TITLE
attempt to include HTTP error bodies in exception

### DIFF
--- a/src/main/java/com/spotify/docker/client/exceptions/DockerRequestException.java
+++ b/src/main/java/com/spotify/docker/client/exceptions/DockerRequestException.java
@@ -21,24 +21,25 @@
 package com.spotify.docker.client.exceptions;
 
 import java.net.URI;
+import javax.annotation.Nullable;
 
 public class DockerRequestException extends DockerException {
 
   private final String method;
   private final URI uri;
   private final int status;
-  private final String message;
+  private final String responseBody;
 
   public DockerRequestException(final String method, final URI uri,
-                                final int status, final String message,
+                                final int status, final String responseBody,
                                 final Throwable cause) {
     super("Request error: " + method + " " + uri + ": " + status
-          + ((message != null) ? ", body: " + message : ""),
+          + ((responseBody != null) ? ", body: " + responseBody : ""),
         cause);
     this.method = method;
     this.uri = uri;
     this.status = status;
-    this.message = message;
+    this.responseBody = responseBody;
   }
 
   public String method() {
@@ -53,7 +54,25 @@ public class DockerRequestException extends DockerException {
     return status;
   }
 
+  /**
+   * The response body from the HTTP response containing an error, if any.
+   *
+   * @deprecated use {@link #getResponseBody()} instead to avoid confusion with {@link
+   * Throwable#getMessage()}.
+   */
+  @Deprecated
+  @Nullable
   public String message() {
-    return message;
+    return responseBody;
+  }
+
+  /**
+   * The response body from the HTTP response containing an error, if any.
+   *
+   * @return response body or null.
+   */
+  @Nullable
+  public String getResponseBody() {
+    return responseBody;
   }
 }

--- a/src/main/java/com/spotify/docker/client/exceptions/DockerRequestException.java
+++ b/src/main/java/com/spotify/docker/client/exceptions/DockerRequestException.java
@@ -29,34 +29,12 @@ public class DockerRequestException extends DockerException {
   private final int status;
   private final String message;
 
-  public DockerRequestException(final String method, final URI uri, final Throwable cause) {
-    this(method, uri, 0, null, cause);
-  }
-
-  public DockerRequestException(final String method, final URI uri,
-                                final int status,
-                                final Throwable cause) {
-    this(method, uri, status, null, cause);
-  }
-
-  public DockerRequestException(final String method, final URI uri) {
-    this(method, uri, 0, null, null);
-  }
-
-  public DockerRequestException(final String method, final URI uri,
-                                final int status) {
-    this(method, uri, status, null, null);
-  }
-
-  public DockerRequestException(final String method, final URI uri,
-                                final int status, final String message) {
-    this(method, uri, status, message, null);
-  }
-
   public DockerRequestException(final String method, final URI uri,
                                 final int status, final String message,
                                 final Throwable cause) {
-    super("Request error: " + method + " " + uri + ": " + status, cause);
+    super("Request error: " + method + " " + uri + ": " + status
+          + ((message != null) ? ", body: " + message : ""),
+        cause);
     this.method = method;
     this.uri = uri;
     this.status = status;

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -3520,15 +3520,15 @@ public class DefaultDockerClientTest {
       if (dockerApiVersionLessThan("1.20")) {
         assertEquals(
             String.format("Cannot resize container %s, container is not running\n", id),
-            e.message());
+            e.getResponseBody());
       } else if (dockerApiVersionLessThan("1.24")) {
         assertEquals(String.format("Container %s is not running\n", id),
-                     e.message());
+                     e.getResponseBody());
       } else {
         final ObjectMapper mapper =
             new ObjectMapperProvider().getContext(DefaultDockerClientTest.class);
         final Map<String, String> jsonMessage =
-            mapper.readValue(e.message(), new TypeReference<Map<String, String>>() {
+            mapper.readValue(e.getResponseBody(), new TypeReference<Map<String, String>>() {
             });
         assertThat(jsonMessage, hasKey("message"));
         assertEquals(String.format("Container %s is not running", id),

--- a/src/test/java/com/spotify/docker/client/exceptions/DockerRequestExceptionTest.java
+++ b/src/test/java/com/spotify/docker/client/exceptions/DockerRequestExceptionTest.java
@@ -1,0 +1,66 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+/*
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker.client.exceptions;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import org.junit.Test;
+
+public class DockerRequestExceptionTest {
+
+  @Test
+  public void testExceptionMessageWithResponseBody() {
+    final URI uri = URI.create("http://example.com");
+    final String responseBody = "uh oh";
+    final DockerRequestException ex =
+        new DockerRequestException("GET", uri, 500, responseBody, new RuntimeException());
+
+    assertEquals(ex.getMessage(), "Request error: GET http://example.com: 500, body: uh oh");
+  }
+
+  @Test
+  public void testExceptionMessageWhenNoResponseBody() {
+    final URI uri = URI.create("http://example.com");
+    final String responseBody = null;
+    final DockerRequestException ex =
+        new DockerRequestException("GET", uri, 500, responseBody, new RuntimeException());
+
+    assertEquals(ex.getMessage(), "Request error: GET http://example.com: 500");
+  }
+}


### PR DESCRIPTION
When a HTTP error (4xx, 5xx, IOException) occurs in communciating with
the Docker Remote API, DefaultDockerClient attempts to read the response
body (if one exists) and passes it to the DockerRequestException which
is thrown.

The message field that is passed to the DockerRequestException is unused
in the "message" passed up to the superclass (which is available via
`getMessage()` and `Exception.toString()`).

This change would include the "message" passed to DockerRequestException
in the superclass's message if possible, to help improve troubleshooting
and debugging.

Also remove the five unused constructors in DockerRequestException.