### PR TITLE
Don't test exec on CircleCI

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -2909,8 +2909,8 @@ public class DefaultDockerClientTest {
   @Test
   public void testExec() throws Exception {
     requireDockerApiVersionAtLeast("1.15", "Exec");
-    assumeThat("Only native (libcontainer) driver supports Exec",
-               sut.info().executionDriver(), startsWith("native"));
+    // CircleCI uses lxc, doesn't support exec - https://circleci.com/docs/docker/#docker-exec
+    assumeFalse(CIRCLECI);
 
     sut.pull(BUSYBOX_LATEST);
 
@@ -2946,8 +2946,8 @@ public class DefaultDockerClientTest {
     requireDockerApiVersionAtLeast("1.15", "Exec");
     // Execution driver is removed in Docker API >= 1.24
     if (dockerApiVersionLessThan("1.24")) {
-      assumeThat("Only native (libcontainer) driver supports Exec",
-          sut.info().executionDriver(), startsWith("native"));
+      // CircleCI uses lxc, doesn't support exec - https://circleci.com/docs/docker/#docker-exec
+      assumeFalse(CIRCLECI);
     }
 
     sut.pull(BUSYBOX_LATEST);
@@ -2971,8 +2971,8 @@ public class DefaultDockerClientTest {
   @Test
   public void testExecInspect() throws Exception {
     requireDockerApiVersionAtLeast("1.16", "Exec Inspect");
-    assumeThat("Only native (libcontainer) driver supports Exec",
-               sut.info().executionDriver(), startsWith("native"));
+    // CircleCI uses lxc, doesn't support exec - https://circleci.com/docs/docker/#docker-exec
+    assumeFalse(CIRCLECI);
 
     sut.pull(BUSYBOX_LATEST);
 


### PR DESCRIPTION
Right now CircleCI uses LXC as the Docker execution driver.
LXC doesn't support exec https://circleci.com/docs/docker/#docker-exec.