### PR TITLE
Redefine LogStream.close() to not throw

### DIFF
--- a/src/main/java/com/spotify/docker/client/LogStream.java
+++ b/src/main/java/com/spotify/docker/client/LogStream.java
@@ -94,4 +94,9 @@ public interface LogStream extends Iterator<LogMessage>, Closeable {
    * @see java.io.PipedOutputStream
    */
   void attach(OutputStream stdout, OutputStream stderr, boolean closeAtEof) throws IOException;
+
+  /**
+   * Redefine to not throw checked exceptions.
+   */
+  void close();
 }


### PR DESCRIPTION
The implementing `DefaultLogStream` doesn't throw
any checked exceptions.