### PR TITLE
Add link to user manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ We consider this library pretty stable and use it in many critical production sy
 * [Releasing](#releasing)
 * [A Note on Shading](#a-note-on-shading)
 * [Code of Conduct](#code-of-conduct)
+* [User Manual](https://github.com/spotify/docker-client/blob/master/docs/user_manual.md)
 
 
 ## Download


### PR DESCRIPTION
Add a link to the user manual to the readme. I always find myself coming to the repo looking for a direct link and never know which section to look in to find it.