### PR TITLE
Adding NetworkConnection abstraction to allow aliases & more parameters on connection

### DIFF
--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -53,6 +53,7 @@ import com.spotify.docker.client.messages.ImageSearchResult;
 import com.spotify.docker.client.messages.Info;
 import com.spotify.docker.client.messages.Network;
 import com.spotify.docker.client.messages.NetworkConfig;
+import com.spotify.docker.client.messages.NetworkConnection;
 import com.spotify.docker.client.messages.NetworkCreation;
 import com.spotify.docker.client.messages.RegistryAuth;
 import com.spotify.docker.client.messages.RemovedImage;
@@ -871,8 +872,8 @@ public interface DockerClient extends Closeable {
    */
   void renameContainer(String containerId, String name)
       throws DockerException, InterruptedException;
-  
-  
+
+
   /**
    * Update an existing container. Only available in Docker API &gt;= 1.22.
    *
@@ -1262,7 +1263,7 @@ public interface DockerClient extends Closeable {
    */
   ServiceCreateResponse createService(ServiceSpec spec)
           throws DockerException, InterruptedException;
-  
+
   /**
    * Create a new service. Only available in Docker API &gt;= 1.24.
    *
@@ -1497,6 +1498,19 @@ public interface DockerClient extends Closeable {
   void connectToNetwork(String containerId, String networkId)
       throws DockerException, InterruptedException;
 
+  /**
+   * Connects a docker container to a network, with extended configuration.
+   * This is useful when you want to set specific details (aliases, gateway, etc...)
+   * for your container inside the network.
+   *
+   * @param networkId          The id of the network to connect.
+   * @param networkConnection  The target connection parameters.
+   * @throws NotFoundException          if either container or network is not found (404)
+   * @throws DockerException            if a server error occurred (500)
+   * @throws InterruptedException       if the thread is interrupted
+   */
+  void connectToNetwork(String networkId, NetworkConnection networkConnection)
+      throws DockerException, InterruptedException;
 
   /**
    * Disconnects a docker container to a network.

--- a/src/main/java/com/spotify/docker/client/messages/EndpointConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/EndpointConfig.java
@@ -24,65 +24,70 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-import java.util.List;
 import javax.annotation.Nullable;
 
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
-public abstract class AttachedNetwork {
+public abstract class EndpointConfig {
 
   @Nullable
   @JsonProperty("Aliases")
   public abstract ImmutableList<String> aliases();
 
   @Nullable
-  @JsonProperty("NetworkID")
-  public abstract String networkId();
-
-  @JsonProperty("EndpointID")
-  public abstract String endpointId();
-
   @JsonProperty("Gateway")
   public abstract String gateway();
 
+  @Nullable
   @JsonProperty("IPAddress")
   public abstract String ipAddress();
 
+  @Nullable
   @JsonProperty("IPPrefixLen")
   public abstract Integer ipPrefixLen();
 
+  @Nullable
   @JsonProperty("IPv6Gateway")
   public abstract String ipv6Gateway();
 
+  @Nullable
   @JsonProperty("GlobalIPv6Address")
   public abstract String globalIPv6Address();
 
+  @Nullable
   @JsonProperty("GlobalIPv6PrefixLen")
   public abstract Integer globalIPv6PrefixLen();
 
+  @Nullable
   @JsonProperty("MacAddress")
   public abstract String macAddress();
 
-  @JsonCreator
-  static AttachedNetwork create(
-      @JsonProperty("Aliases") final List<String> aliases,
-      @JsonProperty("NetworkID") final String networkId,
-      @JsonProperty("EndpointID") final String endpointId,
-      @JsonProperty("Gateway") final String gateway,
-      @JsonProperty("IPAddress") final String ipAddress,
-      @JsonProperty("IPPrefixLen") final Integer ipPrefixLen,
-      @JsonProperty("IPv6Gateway") final String ipv6Gateway,
-      @JsonProperty("GlobalIPv6Address") final String globalIpv6Address,
-      @JsonProperty("GlobalIPv6PrefixLen") final Integer globalIpv6PrefixLen,
-      @JsonProperty("MacAddress") final String macAddress) {
-    return new AutoValue_AttachedNetwork(
-            aliases == null ? null : ImmutableList.copyOf(aliases),
-            networkId, endpointId, gateway, ipAddress, ipPrefixLen,
-            ipv6Gateway, globalIpv6Address, globalIpv6PrefixLen, macAddress);
+  public static Builder builder() {
+    return new AutoValue_EndpointConfig.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder aliases(ImmutableList<String> aliases);
+
+    public abstract Builder gateway(String gateway);
+
+    public abstract Builder ipAddress(String ipAddress);
+
+    public abstract Builder ipPrefixLen(Integer ipPrefixLen);
+
+    public abstract Builder ipv6Gateway(String ipv6Gateway);
+
+    public abstract Builder globalIPv6Address(String globalIPv6Address);
+
+    public abstract Builder globalIPv6PrefixLen(Integer globalIPv6PrefixLen);
+
+    public abstract Builder macAddress(String macAddress);
+
+    public abstract EndpointConfig build();
   }
 }

--- a/src/main/java/com/spotify/docker/client/messages/NetworkConnection.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkConnection.java
@@ -1,0 +1,55 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public abstract class NetworkConnection {
+
+  @JsonProperty("Container")
+  public abstract String containerId();
+
+  @Nullable
+  @JsonProperty("EndpointConfig")
+  public abstract EndpointConfig endpointConfig();
+
+  public static Builder builder() {
+    return new AutoValue_NetworkConnection.Builder();
+  }
+
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder containerId(String containerId);
+
+    public abstract Builder endpointConfig(EndpointConfig endpointConfig);
+
+    public abstract NetworkConnection build();
+  }
+}

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -8,9 +8,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -8,9 +8,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -144,6 +144,7 @@ import com.spotify.docker.client.messages.ContainerInfo;
 import com.spotify.docker.client.messages.ContainerMount;
 import com.spotify.docker.client.messages.ContainerStats;
 import com.spotify.docker.client.messages.ContainerUpdate;
+import com.spotify.docker.client.messages.EndpointConfig;
 import com.spotify.docker.client.messages.Event;
 import com.spotify.docker.client.messages.ExecCreation;
 import com.spotify.docker.client.messages.ExecState;
@@ -160,6 +161,7 @@ import com.spotify.docker.client.messages.IpamConfig;
 import com.spotify.docker.client.messages.LogConfig;
 import com.spotify.docker.client.messages.Network;
 import com.spotify.docker.client.messages.NetworkConfig;
+import com.spotify.docker.client.messages.NetworkConnection;
 import com.spotify.docker.client.messages.NetworkCreation;
 import com.spotify.docker.client.messages.PortBinding;
 import com.spotify.docker.client.messages.ProcessConfig;
@@ -239,7 +241,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 public class DefaultDockerClientTest {
 
@@ -3454,7 +3455,67 @@ public class DefaultDockerClientTest {
     assertThat(attachedNetwork.ipv6Gateway(), is(notNullValue()));
     assertThat(attachedNetwork.globalIPv6Address(), is(notNullValue()));
     assertThat(attachedNetwork.globalIPv6PrefixLen(), greaterThanOrEqualTo(0));
+    sut.disconnectFromNetwork(containerCreation.id(), networkCreation.id());
+    network = sut.inspectNetwork(networkCreation.id());
+    assertThat(network.containers().size(), equalTo(0));
 
+    sut.stopContainer(containerCreation.id(), 1);
+    sut.removeContainer(containerCreation.id());
+    sut.removeNetwork(networkCreation.id());
+
+  }
+
+  @Test
+  public void testNetworksConnectContainerWithEndpointConfig() throws Exception {
+    requireDockerApiVersionAtLeast("1.22", "createNetwork and listNetworks");
+
+    assumeFalse(CIRCLECI);
+    final String networkName = randomName();
+    final String containerName = randomName();
+    final String dummyAlias = "badass-alias";
+    final NetworkCreation networkCreation =
+            sut.createNetwork(NetworkConfig.builder().name(networkName).build());
+    assertThat(networkCreation.id(), is(notNullValue()));
+    final ContainerConfig containerConfig =
+            ContainerConfig.builder()
+                .image(BUSYBOX_LATEST)
+                .cmd("sh", "-c", "while :; do sleep 1; done")
+                .build();
+    final ContainerCreation containerCreation = sut.createContainer(containerConfig, containerName);
+    assertThat(containerCreation.id(), is(notNullValue()));
+    sut.startContainer(containerCreation.id());
+
+    // Those are some of the extra parameters that can be set along with the network connection
+    EndpointConfig endpointConfig = EndpointConfig.builder()
+            .aliases(ImmutableList.<String>of(dummyAlias))
+            .build();
+
+    NetworkConnection networkConnection = NetworkConnection.builder()
+            .containerId(containerCreation.id())
+            .endpointConfig(endpointConfig)
+            .build();
+
+    sut.connectToNetwork(networkCreation.id(), networkConnection);
+
+    Network network = sut.inspectNetwork(networkCreation.id());
+    Network.Container networkContainer = network.containers().get(containerCreation.id());
+    assertThat(network.containers().size(), equalTo(1));
+    assertThat(networkContainer, notNullValue());
+    final ContainerInfo containerInfo = sut.inspectContainer(containerCreation.id());
+    assertThat(containerInfo.networkSettings().networks().size(), is(2));
+    final AttachedNetwork attachedNetwork =
+            containerInfo.networkSettings().networks().get(networkName);
+    assertThat(attachedNetwork, is(notNullValue()));
+    assertThat(attachedNetwork.networkId(), is(notNullValue()));
+    assertThat(attachedNetwork.endpointId(), is(notNullValue()));
+    assertThat(attachedNetwork.gateway(), is(notNullValue()));
+    assertThat(attachedNetwork.ipAddress(), is(notNullValue()));
+    assertThat(attachedNetwork.ipPrefixLen(), is(notNullValue()));
+    assertThat(attachedNetwork.macAddress(), is(notNullValue()));
+    assertThat(attachedNetwork.ipv6Gateway(), is(notNullValue()));
+    assertThat(attachedNetwork.globalIPv6Address(), is(notNullValue()));
+    assertThat(attachedNetwork.globalIPv6PrefixLen(), greaterThanOrEqualTo(0));
+    assertTrue(attachedNetwork.aliases().contains(dummyAlias));
     sut.disconnectFromNetwork(containerCreation.id(), networkCreation.id());
     network = sut.inspectNetwork(networkCreation.id());
     assertThat(network.containers().size(), equalTo(0));


### PR DESCRIPTION
To this day, only **connectToNetwork(String containerId, String networkId)** was supported to add a network.
This did not allow to add additional configuration (specifically in my case, provide **aliases** when connecting a container to a network).

This use-case could not be solved unless [EndpointConfig (see API Docs)](https://docs.docker.com/engine/api/v1.25/) support was added.

This pull request adds support for EndpointConfig while keeping existing APIs.

NB: An additional method was added to the DockerClient interface with the following signature:
```java
  /**
   * Connects a docker container to a network, with extended configuration.
   * This is useful when you want to set specific details (aliases, gateway, etc...)
   * for your container inside the network.
   *
   * @param networkId          The id of the network to connect.
   * @param networkConnection  The target connection parameters.
   * @throws NotFoundException          if either container or network is not found (404)
   * @throws DockerException            if a server error occurred (500)
   * @throws InterruptedException       if the thread is interrupted
   */
  void connectToNetwork(String networkId, NetworkConnection networkConnection)
    throws DockerException, InterruptedException;
```

The DefaultDockerClient has been implemented, one test was added in  **src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java** to make sure the use-case works out well.

Would you be able to merge this PR?

Thanks everyone for the awesome work behind this API. It's evolved to become the best java API for docker with great improvements from what it was two years ago ;)

Best wishes!