### PR TITLE
Only copy volumes if non-null

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/VolumeList.java
+++ b/src/main/java/com/spotify/docker/client/messages/VolumeList.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 public abstract class VolumeList {
 
+  @Nullable
   @JsonProperty("Volumes")
   public abstract ImmutableList<Volume> volumes();
 

--- a/src/main/java/com/spotify/docker/client/messages/VolumeList.java
+++ b/src/main/java/com/spotify/docker/client/messages/VolumeList.java
@@ -47,8 +47,10 @@ public abstract class VolumeList {
   static VolumeList create(
       @JsonProperty("Volumes") final List<Volume> volumes,
       @JsonProperty("Warnings") final List<String> warnings) {
+    final ImmutableList<Volume> volumesCopy = volumes == null
+                                               ? null : ImmutableList.copyOf(volumes);
     final ImmutableList<String> warningsCopy = warnings == null
                                                ? null : ImmutableList.copyOf(warnings);
-    return new AutoValue_VolumeList(ImmutableList.copyOf(volumes), warningsCopy);
+    return new AutoValue_VolumeList(volumesCopy, warningsCopy);
   }
 }


### PR DESCRIPTION
Fixes #603.

I didn't see a way to add a test for this issue. The issue only occurs if there are no volumes; it would be hard to guarantee that no other volume tests have already run and created volumes, and I didn't think it would be safe to just delete all of the existing volumes in my test.