### PR TITLE
added the interface to allow for a different DockerCertificates imple…

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -310,10 +310,10 @@ public class DefaultDockerClient implements DockerClient, Closeable {
    * Create a new client with default configuration.
    *
    * @param uri                The docker rest api uri.
-   * @param dockerCertificates The certificates to use for HTTPS.
+   * @param dockerCertificatesStore The certificates to use for HTTPS.
    */
-  public DefaultDockerClient(final URI uri, final DockerCertificates dockerCertificates) {
-    this(new Builder().uri(uri).dockerCertificates(dockerCertificates));
+  public DefaultDockerClient(final URI uri, final DockerCertificatesStore dockerCertificatesStore) {
+    this(new Builder().uri(uri).dockerCertificates(dockerCertificatesStore));
   }
 
   /**
@@ -330,7 +330,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     final URI originalUri = checkNotNull(builder.uri, "uri");
     this.apiVersion = builder.apiVersion();
 
-    if ((builder.dockerCertificates != null) && !originalUri.getScheme().equals("https")) {
+    if ((builder.dockerCertificatesStore != null) && !originalUri.getScheme().equals("https")) {
       throw new IllegalArgumentException(
           "An HTTPS URI for DOCKER_HOST must be provided to use Docker client certificates");
     }
@@ -391,11 +391,11 @@ public class DefaultDockerClient implements DockerClient, Closeable {
 
   private Registry<ConnectionSocketFactory> getSchemeRegistry(final Builder builder) {
     final SSLConnectionSocketFactory https;
-    if (builder.dockerCertificates == null) {
+    if (builder.dockerCertificatesStore == null) {
       https = SSLConnectionSocketFactory.getSocketFactory();
     } else {
-      https = new SSLConnectionSocketFactory(builder.dockerCertificates.sslContext(),
-                                             builder.dockerCertificates.hostnameVerifier());
+      https = new SSLConnectionSocketFactory(builder.dockerCertificatesStore.sslContext(),
+                                             builder.dockerCertificatesStore.hostnameVerifier());
     }
 
     final RegistryBuilder<ConnectionSocketFactory> registryBuilder = RegistryBuilder
@@ -2260,7 +2260,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
 
     final Builder builder = new Builder();
 
-    final Optional<DockerCertificates> certs = DockerCertificates.builder()
+    final Optional<DockerCertificatesStore> certs = DockerCertificates.builder()
         .dockerCertPath(dockerCertPath).build();
 
     if (endpoint.startsWith(UNIX_SCHEME + "://")) {
@@ -2291,7 +2291,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     private long connectTimeoutMillis = DEFAULT_CONNECT_TIMEOUT_MILLIS;
     private long readTimeoutMillis = DEFAULT_READ_TIMEOUT_MILLIS;
     private int connectionPoolSize = DEFAULT_CONNECTION_POOL_SIZE;
-    private DockerCertificates dockerCertificates;
+    private DockerCertificatesStore dockerCertificatesStore;
     private boolean dockerAuth;
     private RegistryAuth registryAuth;
     private Map<String, Object> headers = new HashMap<>();
@@ -2362,18 +2362,18 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       return this;
     }
 
-    public DockerCertificates dockerCertificates() {
-      return dockerCertificates;
+    public DockerCertificatesStore dockerCertificates() {
+      return dockerCertificatesStore;
     }
 
     /**
      * Provide certificates to secure the connection to Docker.
      *
-     * @param dockerCertificates DockerCertificates object
+     * @param dockerCertificatesStore DockerCertificatesStore object
      * @return Builder
      */
-    public Builder dockerCertificates(final DockerCertificates dockerCertificates) {
-      this.dockerCertificates = dockerCertificates;
+    public Builder dockerCertificates(final DockerCertificatesStore dockerCertificatesStore) {
+      this.dockerCertificatesStore = dockerCertificatesStore;
       return this;
     }
 

--- a/src/main/java/com/spotify/docker/client/DockerCertificates.java
+++ b/src/main/java/com/spotify/docker/client/DockerCertificates.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
  * DockerCertificates holds certificates for connecting to an HTTPS-secured Docker instance with
  * client/server authentication.
  */
-public class DockerCertificates {
+public class DockerCertificates implements DockerCertificatesStore {
 
   public static final String DEFAULT_CA_CERT_NAME = "ca.pem";
   public static final String DEFAULT_CLIENT_CERT_NAME = "cert.pem";
@@ -162,13 +162,13 @@ public class DockerCertificates {
       return this;
     }
 
-    public Optional<DockerCertificates> build() throws DockerCertificateException {
+    public Optional<DockerCertificatesStore> build() throws DockerCertificateException {
       if (this.caCertPath == null || this.clientKeyPath == null || this.clientCertPath == null) {
         log.debug("caCertPath, clientKeyPath or clientCertPath not specified, not using SSL");
         return Optional.absent();
       } else if (Files.exists(this.caCertPath) && Files.exists(this.clientKeyPath)
                  && Files.exists(this.clientCertPath)) {
-        return Optional.of(new DockerCertificates(this));
+        return Optional.of((DockerCertificatesStore) new DockerCertificates(this));
       } else {
         log.debug("{}, {} or {} does not exist, not using SSL", this.caCertPath, this.clientKeyPath,
                   this.clientCertPath);

--- a/src/main/java/com/spotify/docker/client/DockerCertificatesStore.java
+++ b/src/main/java/com/spotify/docker/client/DockerCertificatesStore.java
@@ -1,0 +1,34 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+/**
+ * DockerCertificatesStore holds certificates for connecting to an HTTPS-secured Docker
+ * instance with client/server authentication.
+ */
+public interface DockerCertificatesStore {
+  SSLContext sslContext();
+
+  HostnameVerifier hostnameVerifier();
+}

--- a/src/main/java/com/spotify/docker/client/messages/Container.java
+++ b/src/main/java/com/spotify/docker/client/messages/Container.java
@@ -41,6 +41,7 @@ public abstract class Container {
   @JsonProperty("Id")
   public abstract String id();
 
+  @Nullable
   @JsonProperty("Names")
   public abstract ImmutableList<String> names();
 
@@ -64,6 +65,7 @@ public abstract class Container {
   @JsonProperty("Status")
   public abstract String status();
 
+  @Nullable
   @JsonProperty("Ports")
   public abstract ImmutableList<PortMapping> ports();
 
@@ -144,8 +146,8 @@ public abstract class Container {
     final ImmutableList<PortMapping> portsT = ports == null
             ? null : ImmutableList.copyOf(ports);
 
-    return new AutoValue_Container(id, ImmutableList.copyOf(names), image, imageId, command,
-        created, state, status, ImmutableList.copyOf(ports), labelsT, sizeRw,
+    return new AutoValue_Container(id, namesT, image, imageId, command,
+        created, state, status, portsT, labelsT, sizeRw,
         sizeRootFs, networkSettings, mountsT);
   }
 

--- a/src/main/java/com/spotify/docker/client/messages/Container.java
+++ b/src/main/java/com/spotify/docker/client/messages/Container.java
@@ -139,6 +139,11 @@ public abstract class Container {
                                                  ? null : ImmutableMap.copyOf(labels);
     final ImmutableList<ContainerMount> mountsT = mounts == null
                                                   ? null : ImmutableList.copyOf(mounts);
+    final ImmutableList<String> namesT = names == null
+            ? null : ImmutableList.copyOf(names);
+    final ImmutableList<PortMapping> portsT = ports == null
+            ? null : ImmutableList.copyOf(ports);
+
     return new AutoValue_Container(id, ImmutableList.copyOf(names), image, imageId, command,
         created, state, status, ImmutableList.copyOf(ports), labelsT, sizeRw,
         sizeRootFs, networkSettings, mountsT);

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -2302,7 +2302,7 @@ public class DefaultDockerClientTest {
   @Test
   public void testNoDockerCertificatesInDir() throws Exception {
     final Path certDir = Paths.get(System.getProperty("java.io.tmpdir"));
-    final Optional<DockerCertificates> result = DockerCertificates.builder()
+    final Optional<DockerCertificatesStore> result = DockerCertificates.builder()
         .dockerCertPath(certDir).build();
     assertThat(result.isPresent(), is(false));
   }

--- a/src/test/java/com/spotify/docker/client/messages/ContainerTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/ContainerTest.java
@@ -54,4 +54,13 @@ public class ContainerTest {
         .readValue(fixture("fixtures/container-ports-as-string.json"), Container.class);
     assertThat(container.portsAsString(), is("0.0.0.0:80->88/tcp"));
   }
+
+
+  @Test
+  public void testLoadFromFixtureMissingPorts() throws Exception {
+    final Container container = objectMapper
+            .readValue(fixture("fixtures/container-no-ports-or-names.json"), Container.class);
+    assertThat(container.id(), is("1009"));
+  }
+
 }

--- a/src/test/resources/fixtures/container-no-ports-or-names.json
+++ b/src/test/resources/fixtures/container-no-ports-or-names.json
@@ -1,0 +1,10 @@
+{
+  "Id": "1009",
+  "Names": [],
+  "Image": "ports as string test",
+  "Command": "test",
+  "Created": 1,
+  "Status": "testing",
+  "Ports": []
+
+}


### PR DESCRIPTION
I am currently working on a project that uses VMWare Docker implementation. This is one of some minor changes that allow me to use this api with the Open Source Docker engine implementation and also the VMWare Docker implementation. I have other small changes that allow for this api to be used in VMWare and also Docker. Example is the mandatory fields and some fields with assumptions that they will not be null but with VMWare Docker they are null giving Nullpointer exception.
If i get these changes submitted also then you can say this api works also with VMWare Docker