### PR TITLE
Make Task.Slot nullable

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/swarm/GlobalService.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/GlobalService.java
@@ -24,6 +24,7 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
@@ -39,6 +40,11 @@ public abstract class GlobalService {
 
     public abstract GlobalService build();
 
+  }
+
+  @JsonCreator
+  static GlobalService create() {
+    return builder().build();
   }
 
 }

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Task.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Task.java
@@ -65,6 +65,7 @@ public abstract class Task {
   @JsonProperty("ServiceID")
   public abstract String serviceId();
 
+  @Nullable
   @JsonProperty("Slot")
   public abstract Integer slot();
 


### PR DESCRIPTION
for global swarm services. Global mode services do not have
task slots - there is one task per host.

fixes #654