### PR TITLE
Fix container name regex

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -226,7 +226,8 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       LogsResponseReader.class,
       ProgressResponseReader.class);
 
-  private static final Pattern CONTAINER_NAME_PATTERN = Pattern.compile("/?[a-zA-Z0-9_-]+");
+  private static final Pattern CONTAINER_NAME_PATTERN =
+          Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9_.-]+$");
 
   private static final GenericType<List<Container>> CONTAINER_LIST =
       new GenericType<List<Container>>() {

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -2964,6 +2964,42 @@ public class DefaultDockerClientTest {
     sut.createContainer(config, name);
   }
 
+  @Test
+  public void testCreateContainerNameMatcher() throws Exception {
+    final ContainerConfig config = ContainerConfig.builder()
+        .image(BUSYBOX_LATEST)
+        .cmd("sh", "-c", "echo hello world")
+        .build();
+
+    final String goodName = "aBc1.2-3_";
+    sut.createContainer(config, goodName);
+
+    // Bad names
+    final String oneCharacter = "a";
+    exception.expect(invalidContainerNameException(oneCharacter));
+    sut.createContainer(config, oneCharacter);
+
+    final String invalidCharacter = "abc~";
+    exception.expect(invalidContainerNameException(invalidCharacter));
+    sut.createContainer(config, invalidCharacter);
+
+    final String invalidFirstCharacter = ".a";
+    exception.expect(invalidContainerNameException(invalidFirstCharacter));
+    sut.createContainer(config, invalidFirstCharacter);
+  }
+
+  private static Matcher<IllegalArgumentException>
+        invalidContainerNameException(final String containerName) {
+    final String exceptionMessage = String.format("Invalid container name: \"%s\"", containerName);
+    final String description = "for container name " + containerName;
+    return new CustomTypeSafeMatcher<IllegalArgumentException>(description) {
+      @Override
+      protected boolean matchesSafely(final IllegalArgumentException ex) {
+        return ex.getMessage().equals(exceptionMessage);
+      }
+    };
+  }
+
   @Test(expected = ContainerNotFoundException.class)
   public void testKillBadContainer() throws Exception {
     sut.killContainer(randomName());


### PR DESCRIPTION
Bring our container name regex into alignment with docker's, as read from their code [here](https://github.com/docker/docker/blob/dba271a42ab4841dbcf2e953491e9ee728cd8e16/api/names.go#L6). Fixes #658.

Changes:

* Change name matcher from "one or more characters in the set `[a-zA-Z0-9_-]`" to "one character in the set `[a-zA-Z0-9]` followed by one or more characters in the set `[a-zA-Z0-9_.-]`". 
* Remove the optional `/` at the start of the name. I think this may have been added for testing purposes, as the name returned by docker when you inspect the container does have a leading `/`. However, it doesn't make sense to include it here. We have better ways to check that condition in tests, and `/` is not a valid character when naming a container.
* Enforce that these characters are the whole name by adding the anchors `^...$`. I am pretty sure this will not actually change anything about the match—i.e. if something would have matched or not without these anchors, it still will match or not—since the `java.util.regex.Matcher#match` method we use is already anchored by default. But, still, I feel that it's good to make the anchors obvious in case anyone checks. And it is consistent with docker's regex linked above, which is explicitly anchored on both ends.