### PR TITLE
Fix potential race condition in test

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -4191,6 +4191,7 @@ public class DefaultDockerClientTest {
 
     sut.startContainer(container.id());
     sut.stopContainer(container.id(), 5);
+    await().until(containerIsRunning(sut, container.id()), is(false));
 
     // A ContainerNotFoundException should be thrown since the container is removed when it stops
     exception.expect(ContainerNotFoundException.class);


### PR DESCRIPTION
Container might not be stopped yet so wait for it to be stopped in
`DefaultDockerClientTest.testAutoRemoveWhenSetToTrue()`.