### PR TITLE
ContainerStats working for Docker API > 1.25

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/MemoryStats.java
+++ b/src/main/java/com/spotify/docker/client/messages/MemoryStats.java
@@ -150,6 +150,7 @@ public abstract class MemoryStats {
     @JsonProperty("total_writeback")
     public abstract Long totalWriteback();
 
+    @Nullable
     @JsonProperty("writeback")
     public abstract Long writeback();
 

--- a/src/test/java/com/spotify/docker/client/messages/ContainerStatsTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/ContainerStatsTest.java
@@ -1,0 +1,50 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages;
+
+import static com.spotify.docker.FixtureUtil.fixture;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.docker.client.ObjectMapperProvider;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ContainerStatsTest {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private ObjectMapper objectMapper;
+
+  @Before
+  public void setUp() throws Exception {
+    objectMapper = new ObjectMapperProvider().getContext(ContainerStats.class);
+  }
+
+  @Test
+  public void test1_26() throws Exception {
+    objectMapper.readValue(fixture("fixtures/1.26/containerStats.json"), ContainerStats.class);
+  }
+
+}

--- a/src/test/resources/fixtures/1.26/containerStats.json
+++ b/src/test/resources/fixtures/1.26/containerStats.json
@@ -1,0 +1,116 @@
+{
+  "read": "2017-03-07T07:50:29.288919121Z",
+  "preread": "2017-03-07T07:50:28.339273872Z",
+  "pids_stats": {
+    "current": 17
+  },
+  "blkio_stats": {
+    "io_service_bytes_recursive": [],
+    "io_serviced_recursive": [],
+    "io_queue_recursive": [],
+    "io_service_time_recursive": [],
+    "io_wait_time_recursive": [],
+    "io_merged_recursive": [],
+    "io_time_recursive": [],
+    "sectors_recursive": []
+  },
+  "num_procs": 0,
+  "storage_stats": {},
+  "cpu_stats": {
+    "cpu_usage": {
+      "total_usage": 323252212744,
+      "percpu_usage": [
+        51360101157,
+        50697712943,
+        53431297910,
+        48201200622,
+        30886647454,
+        30320876952,
+        29063619655,
+        29290756051
+      ],
+      "usage_in_kernelmode": 112140000000,
+      "usage_in_usermode": 161580000000
+    },
+    "system_cpu_usage": 3214393990000000,
+    "throttling_data": {
+      "periods": 0,
+      "throttled_periods": 0,
+      "throttled_time": 0
+    }
+  },
+  "precpu_stats": {
+    "cpu_usage": {
+      "total_usage": 323252212744,
+      "percpu_usage": [
+        51360101157,
+        50697712943,
+        53431297910,
+        48201200622,
+        30886647454,
+        30320876952,
+        29063619655,
+        29290756051
+      ],
+      "usage_in_kernelmode": 112140000000,
+      "usage_in_usermode": 161580000000
+    },
+    "system_cpu_usage": 3214386040000000,
+    "throttling_data": {
+      "periods": 0,
+      "throttled_periods": 0,
+      "throttled_time": 0
+    }
+  },
+  "memory_stats": {
+    "usage": 7921664,
+    "max_usage": 8450048,
+    "stats": {
+      "active_anon": 7921664,
+      "active_file": 0,
+      "cache": 0,
+      "hierarchical_memory_limit": 67108864,
+      "hierarchical_memsw_limit": 67108864,
+      "inactive_anon": 0,
+      "inactive_file": 0,
+      "mapped_file": 0,
+      "pgfault": 262476,
+      "pgmajfault": 0,
+      "pgpgin": 20765,
+      "pgpgout": 19342,
+      "rss": 7921664,
+      "rss_huge": 2097152,
+      "swap": 0,
+      "total_active_anon": 7921664,
+      "total_active_file": 0,
+      "total_cache": 0,
+      "total_inactive_anon": 0,
+      "total_inactive_file": 0,
+      "total_mapped_file": 0,
+      "total_pgfault": 262476,
+      "total_pgmajfault": 0,
+      "total_pgpgin": 20765,
+      "total_pgpgout": 19342,
+      "total_rss": 7921664,
+      "total_rss_huge": 2097152,
+      "total_swap": 0,
+      "total_unevictable": 0,
+      "unevictable": 0
+    },
+    "limit": 67108864
+  },
+  "name": "/container_stats_test",
+  "id": "7fb49f670384954de6eaa77073d5fe0facf276f33af9d20af88626b5baf05422",
+  "networks": {
+    "eth0": {
+      "rx_bytes": 675463458,
+      "rx_packets": 2136581,
+      "rx_errors": 0,
+      "rx_dropped": 0,
+      "tx_bytes": 439221284,
+      "tx_packets": 2348228,
+      "tx_errors": 0,
+      "tx_dropped": 0
+    }
+  }
+}


### PR DESCRIPTION
Fix ContainerStats to work with 1.13.x. Add tests

More info: https://github.com/spotify/docker-client/issues/647