### PR TITLE
Fix missing or incomplete Network objects

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
+++ b/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.List;
 import javax.annotation.Nullable;
@@ -62,13 +61,9 @@ public abstract class AttachedNetwork {
   public abstract String ipv6Gateway();
 
   @JsonProperty("GlobalIPv6Address")
-  @SuppressFBWarnings(value = {"NM_CONFUSING"},
-          justification = "Conforming to docker API")
   public abstract String globalIPv6Address();
 
   @JsonProperty("GlobalIPv6PrefixLen")
-  @SuppressFBWarnings(value = {"NM_CONFUSING"},
-          justification = "Conforming to docker API")
   public abstract Integer globalIPv6PrefixLen();
 
   @JsonProperty("MacAddress")

--- a/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
+++ b/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -60,9 +62,13 @@ public abstract class AttachedNetwork {
   public abstract String ipv6Gateway();
 
   @JsonProperty("GlobalIPv6Address")
+  @SuppressFBWarnings(value = {"NM_CONFUSING"},
+          justification = "Conforming to docker API")
   public abstract String globalIPv6Address();
 
   @JsonProperty("GlobalIPv6PrefixLen")
+  @SuppressFBWarnings(value = {"NM_CONFUSING"},
+          justification = "Conforming to docker API")
   public abstract Integer globalIPv6PrefixLen();
 
   @JsonProperty("MacAddress")

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -418,7 +418,9 @@ public abstract class ContainerConfig {
     @JsonProperty("EndpointsConfig")
     public abstract ImmutableMap<String, EndpointConfig> endpointsConfig();
 
-    public static NetworkingConfig create(final Map<String, EndpointConfig> endpointsConfig) {
+    @JsonCreator
+    public static NetworkingConfig create(
+            @JsonProperty("EndpointsConfig") final Map<String, EndpointConfig> endpointsConfig) {
       final ImmutableMap<String, EndpointConfig> endpointsConfigCopy =
               endpointsConfig == null
                       ? ImmutableMap.<String, EndpointConfig>of()

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -154,6 +154,10 @@ public abstract class ContainerConfig {
     return stopSignal();
   }
 
+  @Nullable
+  @JsonProperty("NetworkingConfig")
+  public abstract NetworkingConfig networkingConfig();
+
   @JsonCreator
   static ContainerConfig create(
       @JsonProperty("Hostname") final String hostname,
@@ -179,7 +183,8 @@ public abstract class ContainerConfig {
       @JsonProperty("MacAddress") final String macAddress,
       @JsonProperty("HostConfig") final HostConfig hostConfig,
       @JsonProperty("StopSignal") final String stopSignal,
-      @JsonProperty("Healthcheck") final Healthcheck healthcheck) {
+      @JsonProperty("Healthcheck") final Healthcheck healthcheck,
+      @JsonProperty("NetworkingConfig") final NetworkingConfig networkingConfig) {
     final Builder builder = builder()
         .hostname(hostname)
         .domainname(domainname)
@@ -195,7 +200,8 @@ public abstract class ContainerConfig {
         .networkDisabled(networkDisabled)
         .macAddress(macAddress)
         .hostConfig(hostConfig)
-        .stopSignal(stopSignal);
+        .stopSignal(stopSignal)
+        .networkingConfig(networkingConfig);
 
     if (portSpecs != null) {
       builder.portSpecs(portSpecs);
@@ -337,6 +343,8 @@ public abstract class ContainerConfig {
 
     public abstract Builder healthcheck(final Healthcheck healthcheck);
 
+    public abstract Builder networkingConfig(final NetworkingConfig networkingConfig);
+
     public abstract ContainerConfig build();
   }
 
@@ -402,6 +410,20 @@ public abstract class ContainerConfig {
       public abstract Builder retries(final Integer retries);
 
       public abstract Healthcheck build();
+    }
+  }
+
+  @AutoValue
+  public abstract static class NetworkingConfig {
+    @JsonProperty("EndpointsConfig")
+    public abstract ImmutableMap<String, EndpointConfig> endpointsConfig();
+
+    public static NetworkingConfig create(final Map<String, EndpointConfig> endpointsConfig) {
+      final ImmutableMap<String, EndpointConfig> endpointsConfigCopy =
+              endpointsConfig == null
+                      ? ImmutableMap.<String, EndpointConfig>of()
+                      : ImmutableMap.copyOf(endpointsConfig);
+      return new AutoValue_ContainerConfig_NetworkingConfig(endpointsConfigCopy);
     }
   }
 }

--- a/src/main/java/com/spotify/docker/client/messages/EndpointConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/EndpointConfig.java
@@ -27,12 +27,21 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-import javax.annotation.Nullable;
 
+import java.util.List;
+import javax.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 public abstract class EndpointConfig {
+
+  @Nullable
+  @JsonProperty("IPAMConfig")
+  public abstract EndpointIpamConfig ipamConfig();
+
+  @Nullable
+  @JsonProperty("Links")
+  public abstract ImmutableList<String> links();
 
   @Nullable
   @JsonProperty("Aliases")
@@ -72,6 +81,11 @@ public abstract class EndpointConfig {
 
   @AutoValue.Builder
   public abstract static class Builder {
+
+    public abstract Builder ipamConfig(EndpointIpamConfig ipamConfig);
+
+    public abstract Builder links(List<String> links);
+
     public abstract Builder aliases(ImmutableList<String> aliases);
 
     public abstract Builder gateway(String gateway);
@@ -89,5 +103,37 @@ public abstract class EndpointConfig {
     public abstract Builder macAddress(String macAddress);
 
     public abstract EndpointConfig build();
+  }
+
+  @AutoValue
+  public abstract static class EndpointIpamConfig {
+
+    @Nullable
+    @JsonProperty("IPv4Address")
+    public abstract String ipv4Address();
+
+    @Nullable
+    @JsonProperty("IPv6Address")
+    public abstract String ipv6Address();
+
+    @Nullable
+    @JsonProperty("LinkLocalIPs")
+    public abstract ImmutableList<String> linkLocalIps();
+
+    public static Builder builder() {
+      return new AutoValue_EndpointConfig_EndpointIpamConfig.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+      public abstract Builder ipv4Address(String ipv4Address);
+
+      public abstract Builder ipv6Address(String ipv6Address);
+
+      public abstract Builder linkLocalIps(List<String> linkLocalIps);
+
+      public abstract EndpointIpamConfig build();
+    }
   }
 }

--- a/src/main/java/com/spotify/docker/client/messages/EndpointConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/EndpointConfig.java
@@ -118,7 +118,7 @@ public abstract class EndpointConfig {
 
     @Nullable
     @JsonProperty("LinkLocalIPs")
-    public abstract ImmutableList<String> linkLocalIps();
+    public abstract ImmutableList<String> linkLocalIPs();
 
     public static Builder builder() {
       return new AutoValue_EndpointConfig_EndpointIpamConfig.Builder();
@@ -131,7 +131,7 @@ public abstract class EndpointConfig {
 
       public abstract Builder ipv6Address(String ipv6Address);
 
-      public abstract Builder linkLocalIps(List<String> linkLocalIps);
+      public abstract Builder linkLocalIPs(List<String> linkLocalIPs);
 
       public abstract EndpointIpamConfig build();
     }

--- a/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
 import com.google.common.collect.ImmutableMap;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Collections;
 import java.util.List;
@@ -98,15 +97,11 @@ public abstract class NetworkSettings {
 
   @Nullable
   @JsonProperty("GlobalIPv6Address")
-  @SuppressFBWarnings(value = {"NM_CONFUSING"},
-          justification = "Conforming to docker API")
-  public abstract String globalIpv6Address();
+  public abstract String globalIPv6Address();
 
   @Nullable
   @JsonProperty("GlobalIPv6PrefixLen")
-  @SuppressFBWarnings(value = {"NM_CONFUSING"},
-          justification = "Conforming to docker API")
-  public abstract Integer globalIpv6PrefixLen();
+  public abstract Integer globalIPv6PrefixLen();
 
   @Nullable
   @JsonProperty("IPv6Gateway")
@@ -128,8 +123,8 @@ public abstract class NetworkSettings {
       @JsonProperty("HairpinMode") final Boolean hairpinMode,
       @JsonProperty("LinkLocalIPv6Address") final String linkLocalIpv6Address,
       @JsonProperty("LinkLocalIPv6PrefixLen") final Integer linkLocalIpv6PrefixLen,
-      @JsonProperty("GlobalIPv6Address") final String globalIpv6Address,
-      @JsonProperty("GlobalIPv6PrefixLen") final Integer globalIpv6PrefixLen,
+      @JsonProperty("GlobalIPv6Address") final String globalIPv6Address,
+      @JsonProperty("GlobalIPv6PrefixLen") final Integer globalIPv6PrefixLen,
       @JsonProperty("IPv6Gateway") final String ipv6Gateway) {
 
     final ImmutableMap.Builder<String, List<PortBinding>> portsCopy = ImmutableMap.builder();
@@ -155,8 +150,8 @@ public abstract class NetworkSettings {
         .hairpinMode(hairpinMode)
         .linkLocalIpv6Address(linkLocalIpv6Address)
         .linkLocalIpv6PrefixLen(linkLocalIpv6PrefixLen)
-        .globalIpv6Address(globalIpv6Address)
-        .globalIpv6PrefixLen(globalIpv6PrefixLen)
+        .globalIPv6Address(globalIPv6Address)
+        .globalIPv6PrefixLen(globalIPv6PrefixLen)
         .ipv6Gateway(ipv6Gateway)
         .build();
   }
@@ -196,9 +191,9 @@ public abstract class NetworkSettings {
 
     abstract Builder linkLocalIpv6PrefixLen(final Integer linkLocalIpv6PrefixLen);
 
-    abstract Builder globalIpv6Address(final String globalIpv6Address);
+    abstract Builder globalIPv6Address(final String globalIPv6Address);
 
-    abstract Builder globalIpv6PrefixLen(final Integer globalIpv6PrefixLen);
+    abstract Builder globalIPv6PrefixLen(final Integer globalIPv6PrefixLen);
 
     abstract Builder ipv6Gateway(final String ipv6Gateway);
 

--- a/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -96,10 +98,14 @@ public abstract class NetworkSettings {
 
   @Nullable
   @JsonProperty("GlobalIPv6Address")
+  @SuppressFBWarnings(value = {"NM_CONFUSING"},
+          justification = "Conforming to docker API")
   public abstract String globalIpv6Address();
 
   @Nullable
   @JsonProperty("GlobalIPv6PrefixLen")
+  @SuppressFBWarnings(value = {"NM_CONFUSING"},
+          justification = "Conforming to docker API")
   public abstract Integer globalIpv6PrefixLen();
 
   @Nullable

--- a/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
@@ -70,6 +70,42 @@ public abstract class NetworkSettings {
   @JsonProperty("Networks")
   public abstract ImmutableMap<String, AttachedNetwork> networks();
 
+  @Nullable
+  @JsonProperty("EndpointID")
+  public abstract String endpointId();
+
+  @Nullable
+  @JsonProperty("SandboxID")
+  public abstract String sandboxId();
+
+  @Nullable
+  @JsonProperty("SandboxKey")
+  public abstract String sandboxKey();
+
+  @Nullable
+  @JsonProperty("HairpinMode")
+  public abstract Boolean hairpinMode();
+
+  @Nullable
+  @JsonProperty("LinkLocalIPv6Address")
+  public abstract String linkLocalIpv6Address();
+
+  @Nullable
+  @JsonProperty("LinkLocalIPv6PrefixLen")
+  public abstract Integer linkLocalIpv6PrefixLen();
+
+  @Nullable
+  @JsonProperty("GlobalIPv6Address")
+  public abstract String globalIpv6Address();
+
+  @Nullable
+  @JsonProperty("GlobalIPv6PrefixLen")
+  public abstract Integer globalIpv6PrefixLen();
+
+  @Nullable
+  @JsonProperty("IPv6Gateway")
+  public abstract String ipv6Gateway();
+
   @JsonCreator
   static NetworkSettings create(
       @JsonProperty("IPAddress") final String ipAddress,
@@ -79,7 +115,16 @@ public abstract class NetworkSettings {
       @JsonProperty("PortMapping") final Map<String, Map<String, String>> portMapping,
       @JsonProperty("Ports") final Map<String, List<PortBinding>> ports,
       @JsonProperty("MacAddress") final String macAddress,
-      @JsonProperty("Networks") final Map<String, AttachedNetwork> networks) {
+      @JsonProperty("Networks") final Map<String, AttachedNetwork> networks,
+      @JsonProperty("EndpointID") final String endpointId,
+      @JsonProperty("SandboxID") final String sandboxId,
+      @JsonProperty("SandboxKey") final String sandboxKey,
+      @JsonProperty("HairpinMode") final Boolean hairpinMode,
+      @JsonProperty("LinkLocalIPv6Address") final String linkLocalIpv6Address,
+      @JsonProperty("LinkLocalIPv6PrefixLen") final Integer linkLocalIpv6PrefixLen,
+      @JsonProperty("GlobalIPv6Address") final String globalIpv6Address,
+      @JsonProperty("GlobalIPv6PrefixLen") final Integer globalIpv6PrefixLen,
+      @JsonProperty("IPv6Gateway") final String ipv6Gateway) {
 
     final ImmutableMap.Builder<String, List<PortBinding>> portsCopy = ImmutableMap.builder();
     if (ports != null) {
@@ -98,32 +143,59 @@ public abstract class NetworkSettings {
         .ports(portsCopy.build())
         .macAddress(macAddress)
         .networks(networks)
+        .endpointId(endpointId)
+        .sandboxId(sandboxId)
+        .sandboxKey(sandboxKey)
+        .hairpinMode(hairpinMode)
+        .linkLocalIpv6Address(linkLocalIpv6Address)
+        .linkLocalIpv6PrefixLen(linkLocalIpv6PrefixLen)
+        .globalIpv6Address(globalIpv6Address)
+        .globalIpv6PrefixLen(globalIpv6PrefixLen)
+        .ipv6Gateway(ipv6Gateway)
         .build();
   }
 
-  public static Builder builder() {
+  private static Builder builder() {
     return new AutoValue_NetworkSettings.Builder();
   }
 
   @AutoValue.Builder
-  public abstract static class Builder {
+  abstract static class Builder {
 
-    public abstract Builder ipAddress(String ipAddress);
+    abstract Builder ipAddress(String ipAddress);
 
-    public abstract Builder ipPrefixLen(Integer ipPrefixLen);
+    abstract Builder ipPrefixLen(Integer ipPrefixLen);
 
-    public abstract Builder gateway(String gateway);
+    abstract Builder gateway(String gateway);
 
-    public abstract Builder bridge(String bridge);
+    abstract Builder bridge(String bridge);
 
-    public abstract Builder portMapping(Map<String, Map<String, String>> portMapping);
+    abstract Builder portMapping(Map<String, Map<String, String>> portMapping);
 
-    public abstract Builder ports(Map<String, List<PortBinding>> ports);
+    abstract Builder ports(Map<String, List<PortBinding>> ports);
 
-    public abstract Builder macAddress(String macAddress);
+    abstract Builder macAddress(String macAddress);
 
-    public abstract Builder networks(Map<String, AttachedNetwork> networks);
+    abstract Builder networks(Map<String, AttachedNetwork> networks);
 
-    public abstract NetworkSettings build();
+    abstract Builder endpointId(final String endpointId);
+
+    abstract Builder sandboxId(final String sandboxId);
+
+    abstract Builder sandboxKey(final String sandboxKey);
+
+    abstract Builder hairpinMode(final Boolean hairpinMode);
+
+    abstract Builder linkLocalIpv6Address(final String linkLocalIpv6Address);
+
+    abstract Builder linkLocalIpv6PrefixLen(final Integer linkLocalIpv6PrefixLen);
+
+    abstract Builder globalIpv6Address(final String globalIpv6Address);
+
+    abstract Builder globalIpv6PrefixLen(final Integer globalIpv6PrefixLen);
+
+    abstract Builder ipv6Gateway(final String ipv6Gateway);
+
+    abstract NetworkSettings build();
   }
 }

--- a/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
@@ -89,11 +89,11 @@ public abstract class NetworkSettings {
 
   @Nullable
   @JsonProperty("LinkLocalIPv6Address")
-  public abstract String linkLocalIpv6Address();
+  public abstract String linkLocalIPv6Address();
 
   @Nullable
   @JsonProperty("LinkLocalIPv6PrefixLen")
-  public abstract Integer linkLocalIpv6PrefixLen();
+  public abstract Integer linkLocalIPv6PrefixLen();
 
   @Nullable
   @JsonProperty("GlobalIPv6Address")
@@ -121,8 +121,8 @@ public abstract class NetworkSettings {
       @JsonProperty("SandboxID") final String sandboxId,
       @JsonProperty("SandboxKey") final String sandboxKey,
       @JsonProperty("HairpinMode") final Boolean hairpinMode,
-      @JsonProperty("LinkLocalIPv6Address") final String linkLocalIpv6Address,
-      @JsonProperty("LinkLocalIPv6PrefixLen") final Integer linkLocalIpv6PrefixLen,
+      @JsonProperty("LinkLocalIPv6Address") final String linkLocalIPv6Address,
+      @JsonProperty("LinkLocalIPv6PrefixLen") final Integer linkLocalIPv6PrefixLen,
       @JsonProperty("GlobalIPv6Address") final String globalIPv6Address,
       @JsonProperty("GlobalIPv6PrefixLen") final Integer globalIPv6PrefixLen,
       @JsonProperty("IPv6Gateway") final String ipv6Gateway) {
@@ -148,8 +148,8 @@ public abstract class NetworkSettings {
         .sandboxId(sandboxId)
         .sandboxKey(sandboxKey)
         .hairpinMode(hairpinMode)
-        .linkLocalIpv6Address(linkLocalIpv6Address)
-        .linkLocalIpv6PrefixLen(linkLocalIpv6PrefixLen)
+        .linkLocalIPv6Address(linkLocalIPv6Address)
+        .linkLocalIPv6PrefixLen(linkLocalIPv6PrefixLen)
         .globalIPv6Address(globalIPv6Address)
         .globalIPv6PrefixLen(globalIPv6PrefixLen)
         .ipv6Gateway(ipv6Gateway)
@@ -187,9 +187,9 @@ public abstract class NetworkSettings {
 
     abstract Builder hairpinMode(final Boolean hairpinMode);
 
-    abstract Builder linkLocalIpv6Address(final String linkLocalIpv6Address);
+    abstract Builder linkLocalIPv6Address(final String linkLocalIPv6Address);
 
-    abstract Builder linkLocalIpv6PrefixLen(final Integer linkLocalIpv6PrefixLen);
+    abstract Builder linkLocalIPv6PrefixLen(final Integer linkLocalIPv6PrefixLen);
 
     abstract Builder globalIPv6Address(final String globalIPv6Address);
 

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -3559,14 +3559,6 @@ public class DefaultDockerClientTest {
               Ipam.create("default", Collections.<IpamConfig>emptyList()));
     }
 
-    // final NetworkConfig defaultDriverConfig = networkConfigBuilder.name(randomName())
-    //         .driver("default").build();
-    // final NetworkCreation defaultDriverCreation = sut.createNetwork(defaultDriverConfig);
-    // assertThat(defaultDriverCreation, notNullValue());
-    // assertThat(defaultDriverCreation.id(), notNullValue());
-    // assertTrue(defaultDriverCreation.warnings().isEmpty());
-    // sut.removeNetwork(defaultDriverCreation.id());
-
     final NetworkConfig bridgeDriverConfig = networkConfigBuilder.name(randomName())
             .driver("bridge").build();
     final NetworkCreation bridgeDriverCreation = sut.createNetwork(bridgeDriverConfig);
@@ -3575,14 +3567,6 @@ public class DefaultDockerClientTest {
     assertThat(bridgeDriverCreation.warnings(), anyOf(nullValue(String.class), equalTo("")));
     sut.removeNetwork(bridgeDriverCreation.id());
 
-    final NetworkConfig overlayDriverConfig = networkConfigBuilder.name(randomName())
-            .driver("overlay").build();
-    final NetworkCreation overlayDriverCreation = sut.createNetwork(overlayDriverConfig);
-    assertThat(overlayDriverCreation, notNullValue());
-    assertThat(overlayDriverCreation.id(), notNullValue());
-    assertThat(overlayDriverCreation.warnings(), anyOf(nullValue(String.class), equalTo("")));
-    sut.removeNetwork(overlayDriverCreation.id());
-
     final NetworkConfig macvlanDriverConfig = networkConfigBuilder.name(randomName())
             .driver("macvlan").build();
     final NetworkCreation macvlanDriverCreation = sut.createNetwork(macvlanDriverConfig);
@@ -3590,6 +3574,17 @@ public class DefaultDockerClientTest {
     assertThat(macvlanDriverCreation.id(), notNullValue());
     assertThat(macvlanDriverCreation.warnings(), anyOf(nullValue(String.class), equalTo("")));
     sut.removeNetwork(macvlanDriverCreation.id());
+
+    if (dockerApiVersionAtLeast("1.24")) {
+        // We are operating a swarm, so we can create an overlay network
+        final NetworkConfig overlayDriverConfig = networkConfigBuilder.name(randomName())
+                .driver("overlay").build();
+        final NetworkCreation overlayDriverCreation = sut.createNetwork(overlayDriverConfig);
+        assertThat(overlayDriverCreation, notNullValue());
+        assertThat(overlayDriverCreation.id(), notNullValue());
+        assertThat(overlayDriverCreation.warnings(), anyOf(nullValue(String.class), equalTo("")));
+        sut.removeNetwork(overlayDriverCreation.id());
+    }
   }
 
   @Test

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -3504,6 +3504,7 @@ public class DefaultDockerClientTest {
     final IpamConfig ipamConfig =
         IpamConfig.create("192.168.0.0/24", "192.168.0.0/24", "192.168.0.1");
     final Ipam ipam = Ipam.builder()
+        .driver("default")
         .config(singletonList(ipamConfig))
         .build();
     final NetworkConfig networkConfig =

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -3687,22 +3687,22 @@ public class DefaultDockerClientTest {
     assertThat(network.containers().size(), equalTo(1));
     assertThat(networkContainer, notNullValue());
     final ContainerInfo containerInfo = sut.inspectContainer(containerCreation.id());
-    assertNotNull(containerInfo.networkSettings().networks());
+    assertThat(containerInfo.networkSettings().networks(), is(notNullValue()));
     assertThat(containerInfo.networkSettings().networks().size(), is(2));
     assertThat(containerInfo.networkSettings().networks(), hasKey(networkName));
     final AttachedNetwork attachedNetwork =
             containerInfo.networkSettings().networks().get(networkName);
-    assertNotNull(attachedNetwork);
-    assertEquals(networkCreation.id(), attachedNetwork.networkId());
-    assertNotNull(attachedNetwork.endpointId());
-    assertEquals(gateway, attachedNetwork.gateway());
-    assertEquals(ip, attachedNetwork.ipAddress());
-    assertNotNull(attachedNetwork.ipPrefixLen());
-    assertNotNull(attachedNetwork.macAddress());
-    assertNotNull(attachedNetwork.ipv6Gateway());
-    assertNotNull(attachedNetwork.globalIPv6Address());
+    assertThat(attachedNetwork, is(notNullValue()));
+    assertThat(attachedNetwork.networkId(), is(equalTo(networkCreation.id())));
+    assertThat(attachedNetwork.endpointId(), is(notNullValue()));
+    assertThat(attachedNetwork.gateway(), is(equalTo(gateway)));
+    assertThat(attachedNetwork.ipAddress(), is(equalTo(ip)));
+    assertThat(attachedNetwork.ipPrefixLen(), is(notNullValue()));
+    assertThat(attachedNetwork.macAddress(), is(notNullValue()));
+    assertThat(attachedNetwork.ipv6Gateway(), is(notNullValue()));
+    assertThat(attachedNetwork.globalIPv6Address(), is(notNullValue()));
     assertThat(attachedNetwork.globalIPv6PrefixLen(), greaterThanOrEqualTo(0));
-    assertNotNull(attachedNetwork.aliases());
+    assertThat(attachedNetwork.aliases(), is(notNullValue()));
     assertThat(dummyAlias, isIn(attachedNetwork.aliases()));
 
     sut.disconnectFromNetwork(containerCreation.id(), networkCreation.id());

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -3548,6 +3548,51 @@ public class DefaultDockerClientTest {
   }
 
   @Test
+  public void testNetworkDrivers() throws Exception {
+    requireDockerApiVersionAtLeast("1.21", "networks");
+
+    NetworkConfig.Builder networkConfigBuilder = NetworkConfig.builder();
+
+    if (dockerApiVersionEquals("1.24")) {
+      // workaround for https://github.com/docker/docker/issues/25735
+      networkConfigBuilder = networkConfigBuilder.ipam(
+              Ipam.create("default", Collections.<IpamConfig>emptyList()));
+    }
+
+    // final NetworkConfig defaultDriverConfig = networkConfigBuilder.name(randomName())
+    //         .driver("default").build();
+    // final NetworkCreation defaultDriverCreation = sut.createNetwork(defaultDriverConfig);
+    // assertThat(defaultDriverCreation, notNullValue());
+    // assertThat(defaultDriverCreation.id(), notNullValue());
+    // assertTrue(defaultDriverCreation.warnings().isEmpty());
+    // sut.removeNetwork(defaultDriverCreation.id());
+
+    final NetworkConfig bridgeDriverConfig = networkConfigBuilder.name(randomName())
+            .driver("bridge").build();
+    final NetworkCreation bridgeDriverCreation = sut.createNetwork(bridgeDriverConfig);
+    assertThat(bridgeDriverCreation, notNullValue());
+    assertThat(bridgeDriverCreation.id(), notNullValue());
+    assertThat(bridgeDriverCreation.warnings(), anyOf(nullValue(String.class), equalTo("")));
+    sut.removeNetwork(bridgeDriverCreation.id());
+
+    final NetworkConfig overlayDriverConfig = networkConfigBuilder.name(randomName())
+            .driver("overlay").build();
+    final NetworkCreation overlayDriverCreation = sut.createNetwork(overlayDriverConfig);
+    assertThat(overlayDriverCreation, notNullValue());
+    assertThat(overlayDriverCreation.id(), notNullValue());
+    assertThat(overlayDriverCreation.warnings(), anyOf(nullValue(String.class), equalTo("")));
+    sut.removeNetwork(overlayDriverCreation.id());
+
+    final NetworkConfig macvlanDriverConfig = networkConfigBuilder.name(randomName())
+            .driver("macvlan").build();
+    final NetworkCreation macvlanDriverCreation = sut.createNetwork(macvlanDriverConfig);
+    assertThat(macvlanDriverCreation, notNullValue());
+    assertThat(macvlanDriverCreation.id(), notNullValue());
+    assertThat(macvlanDriverCreation.warnings(), anyOf(nullValue(String.class), equalTo("")));
+    sut.removeNetwork(macvlanDriverCreation.id());
+  }
+
+  @Test
   public void testNetworksConnectContainer() throws Exception {
     requireDockerApiVersionAtLeast("1.21", "createNetwork and listNetworks");
 

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -4239,8 +4239,6 @@ public class DefaultDockerClientTest {
 
     final NetworkCreation networkCreation = sut
             .createNetwork(NetworkConfig.builder().driver("overlay")
-                    // TODO: workaround for https://github.com/docker/docker/issues/25735
-                    .ipam(Ipam.create("default", Collections.<IpamConfig>emptyList()))
                     .name(networkName).build());
 
     final String networkId = networkCreation.id();

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -3576,14 +3576,14 @@ public class DefaultDockerClientTest {
     sut.removeNetwork(macvlanDriverCreation.id());
 
     if (dockerApiVersionAtLeast("1.24")) {
-        // We are operating a swarm, so we can create an overlay network
-        final NetworkConfig overlayDriverConfig = networkConfigBuilder.name(randomName())
-                .driver("overlay").build();
-        final NetworkCreation overlayDriverCreation = sut.createNetwork(overlayDriverConfig);
-        assertThat(overlayDriverCreation, notNullValue());
-        assertThat(overlayDriverCreation.id(), notNullValue());
-        assertThat(overlayDriverCreation.warnings(), anyOf(nullValue(String.class), equalTo("")));
-        sut.removeNetwork(overlayDriverCreation.id());
+      // We are operating a swarm, so we can create an overlay network
+      final NetworkConfig overlayDriverConfig = networkConfigBuilder.name(randomName())
+              .driver("overlay").build();
+      final NetworkCreation overlayDriverCreation = sut.createNetwork(overlayDriverConfig);
+      assertThat(overlayDriverCreation, notNullValue());
+      assertThat(overlayDriverCreation.id(), notNullValue());
+      assertThat(overlayDriverCreation.warnings(), anyOf(nullValue(String.class), equalTo("")));
+      sut.removeNetwork(overlayDriverCreation.id());
     }
   }
 

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -3567,16 +3567,16 @@ public class DefaultDockerClientTest {
     assertThat(bridgeDriverCreation.warnings(), anyOf(nullValue(String.class), equalTo("")));
     sut.removeNetwork(bridgeDriverCreation.id());
 
-    final NetworkConfig macvlanDriverConfig = networkConfigBuilder.name(randomName())
-            .driver("macvlan").build();
-    final NetworkCreation macvlanDriverCreation = sut.createNetwork(macvlanDriverConfig);
-    assertThat(macvlanDriverCreation, notNullValue());
-    assertThat(macvlanDriverCreation.id(), notNullValue());
-    assertThat(macvlanDriverCreation.warnings(), anyOf(nullValue(String.class), equalTo("")));
-    sut.removeNetwork(macvlanDriverCreation.id());
-
     if (dockerApiVersionAtLeast("1.24")) {
-      // We are operating a swarm, so we can create an overlay network
+      // These network drivers only exist in later versions
+      final NetworkConfig macvlanDriverConfig = networkConfigBuilder.name(randomName())
+              .driver("macvlan").build();
+      final NetworkCreation macvlanDriverCreation = sut.createNetwork(macvlanDriverConfig);
+      assertThat(macvlanDriverCreation, notNullValue());
+      assertThat(macvlanDriverCreation.id(), notNullValue());
+      assertThat(macvlanDriverCreation.warnings(), anyOf(nullValue(String.class), equalTo("")));
+      sut.removeNetwork(macvlanDriverCreation.id());
+
       final NetworkConfig overlayDriverConfig = networkConfigBuilder.name(randomName())
               .driver("overlay").build();
       final NetworkCreation overlayDriverCreation = sut.createNetwork(overlayDriverConfig);


### PR DESCRIPTION
* Add `"NetworkingConfig": {"EndpointsConfig": {"name": EndpointConfig, ...}}` to `ContainerConfig`
* Add `"IPAMConfig"` and `"Links"` to `EndpointConfig`. This fixes #675.
* Add lots of missing fields to `NetworkSettings`
* Set `NetworkSettings#builder` to `private`. This class isn't intended to be created by users, just received as a message from Docker. I left the `Builder` in place rather than remove it because it does make creating the object look a little nicer. 
* Modified an existing test, `DefaultDockerClientTest#testNetworksConnectContainerWithEndpointConfig`, to verify that #675 is fixed.