### PR TITLE
Fix autoremove test

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -4170,7 +4170,7 @@ public class DefaultDockerClientTest {
     assertThat(info.hostConfig().storageOpt().get("size"), is("20G"));
   }
 
-  @Test(expected = ContainerNotFoundException.class)
+  @Test
   public void testAutoRemoveWhenSetToTrue() throws Exception {
     requireDockerApiVersionAtLeast("1.25", "AutoRemove");
 
@@ -4186,16 +4186,14 @@ public class DefaultDockerClientTest {
         .build();
 
     final ContainerCreation container = sut.createContainer(config, randomName());
-
-    sut.startContainer(container.id());
-
     final ContainerInfo info = sut.inspectContainer(container.id());
     assertThat(info.hostConfig().autoRemove(), is(true));
-    assertThat(info.state().running(), equalTo(true));
 
+    sut.startContainer(container.id());
     sut.stopContainer(container.id(), 5);
 
     // A ContainerNotFoundException should be thrown since the container is removed when it stops
+    exception.expect(ContainerNotFoundException.class);
     sut.inspectContainer(container.id());
   }
 


### PR DESCRIPTION
I have seen a lot of failed tests on 1.13 from `testAutoRemoveWhenSetToTrue`. I fixed that test.