### PR TITLE
Fix testContainerWithBlkioOptions

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -1719,8 +1719,7 @@ public class DefaultDockerClientTest {
       //     HostConfig.BlkioWeightDevice.builder().path("/dev/urandom").weight(200).build()
       // ));
       final List<HostConfig.BlkioDeviceRate> deviceRates = ImmutableList.of(
-          HostConfig.BlkioDeviceRate.builder().path("/dev/random").rate(1024).build(),
-          HostConfig.BlkioDeviceRate.builder().path("/dev/urandom").rate(2048).build()
+          HostConfig.BlkioDeviceRate.builder().path("/dev/loop0").rate(1024).build()
       );
       hostConfigBuilder.blkioDeviceReadBps(deviceRates);
       hostConfigBuilder.blkioDeviceWriteBps(deviceRates);


### PR DESCRIPTION
I have been seeing failures from `DefaultDockerClientTest#testContainerWithBlkioOptions` on my Mac recently. The test is not failing on the Travis CI tests, so I thought there was some issue with docker. I investigated and opened docker/docker#31826. However, in the discussion of that issue, I learned that our test was doing something wrong. 

This test is currently throttling `/dev/random` and `/dev/urandom`. However, those are character devices. From [a comment on the above-linked ticket](https://github.com/docker/docker/issues/31826#issuecomment-286718988):

> You can't throttle `/dev/random` with the blkio controller, it only applies to block devices (like disks), and `/dev/random` is a character device. I don't think there is currently an equivalent for character devices.

What's more, just because the tests were passing on our CI environment doesn't mean they actually worked. It is possible that there is an error being produced by the kernel about the invalid device, but that docker handles it in a different, non-fatal way.

I asked for advice on a block device to use that would be present on many different OSes. [I received the answer](https://github.com/docker/docker/issues/31826#issuecomment-286885592) that `/dev/loop0` would be a good device to use. I modified this test to throttle `/dev/loop0`, and now it passes on my Mac. 

I still don't know how to address the broader problem that, just because we can make a container with device throttling options, we are not testing that the specified device is actually throttled and to the correct rate. But perhaps that level of testing is out of scope for this project.