### PR TITLE
Fix containerIsRunning

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -4762,8 +4762,13 @@ public class DefaultDockerClientTest {
                                                final String containerId) {
     return new Callable<Boolean>() {
       public Boolean call() throws Exception {
-        final ContainerInfo containerInfo = client.inspectContainer(containerId);
-        return containerInfo.state().running();
+        try {
+          final ContainerInfo containerInfo = client.inspectContainer(containerId);
+          return containerInfo.state().running();
+        } catch (ContainerNotFoundException ignored) {
+          // Ignore exception. If container is not found, it is not running.
+          return false;
+        }
       }
     };
   }


### PR DESCRIPTION
In #666, we added a check to `testAutoRemoveWhenSetToFalse` to verify that the container is not running before we try to `inspect` it, at which time we expect a `ContainerNotFoundException`. And how to we verify that it is running? By `inspect`ing it, of course! Which, we should have known, would throw its own `ContainerNotFoundException` before we get to the part of the test that expects to see that.

So this is a modification to the convenience method `isContainerRunning`. If the container is not found when you `inspect` it, then no, it is certainly not running. So return `false`.