### PR TITLE
Rerun failing tests up to two times on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - docker version
   - docker info
 
-script: mvn clean test
+script: mvn clean -Dsurefire.rerunFailingTestsCount=1 test
 
 after_success:
   # test coverage reporting


### PR DESCRIPTION
Travis builds often fail due to errors pulling images needed
for tests. Retry up to two times before failing a test.