### PR TITLE
Implement "hosts", "healthcheck" and "secrets" in service createapi

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/swarm/ContainerSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ContainerSpec.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.mount.Mount;
 
 import java.util.List;
@@ -89,13 +88,6 @@ public abstract class ContainerSpec {
   @Nullable
   @JsonProperty("StopGracePeriod")
   public abstract Long stopGracePeriod();
-
-  /**
-   * @since API 1.26
-   */
-  @Nullable
-  @JsonProperty("HealthCheck")
-  public abstract ContainerConfig.Healthcheck healthCheck();
 
   /**
    * @since API 1.26
@@ -326,8 +318,6 @@ public abstract class ContainerSpec {
       return this;
     }
 
-    public abstract Builder healthCheck(ContainerConfig.Healthcheck healthCheck);
-
     public abstract Builder hosts(List<String> hosts);
 
     public abstract Builder secrets(List<SecretBind> secrets);
@@ -353,7 +343,6 @@ public abstract class ContainerSpec {
       @JsonProperty("TTY") final Boolean tty,
       @JsonProperty("Mounts") final List<Mount> mounts,
       @JsonProperty("StopGracePeriod") final Long stopGracePeriod,
-      @JsonProperty("HealthCheck") final ContainerConfig.Healthcheck healthCheck,
       @JsonProperty("Hosts") final List<String> hosts,
       @JsonProperty("Secrets") final List<SecretBind> secrets) {
     final Builder builder = builder()
@@ -367,7 +356,6 @@ public abstract class ContainerSpec {
         .tty(tty)
         .mounts(mounts)
         .stopGracePeriod(stopGracePeriod)
-        .healthCheck(healthCheck)
         .hosts(hosts);
 
     if (labels != null) {

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ContainerSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ContainerSpec.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.mount.Mount;
 
 import java.util.List;
@@ -88,6 +89,27 @@ public abstract class ContainerSpec {
   @Nullable
   @JsonProperty("StopGracePeriod")
   public abstract Long stopGracePeriod();
+
+  /**
+   * @since API 1.26
+   */
+  @Nullable
+  @JsonProperty("HealthCheck")
+  public abstract ContainerConfig.Healthcheck healthCheck();
+
+  /**
+   * @since API 1.26
+   */
+  @Nullable
+  @JsonProperty("Hosts")
+  public abstract ImmutableList<String> hosts();
+
+  /**
+   * @since API 1.26
+   */
+  @Nullable
+  @JsonProperty("Secrets")
+  public abstract ImmutableList<SecretBind> secrets();
 
   @AutoValue.Builder
   public abstract static class Builder {
@@ -304,6 +326,12 @@ public abstract class ContainerSpec {
       return this;
     }
 
+    public abstract Builder healthCheck(ContainerConfig.Healthcheck healthCheck);
+
+    public abstract Builder hosts(List<String> hosts);
+
+    public abstract Builder secrets(List<SecretBind> secrets);
+
     public abstract ContainerSpec build();
   }
 
@@ -324,7 +352,10 @@ public abstract class ContainerSpec {
       @JsonProperty("Groups") final List<String> groups,
       @JsonProperty("TTY") final Boolean tty,
       @JsonProperty("Mounts") final List<Mount> mounts,
-      @JsonProperty("StopGracePeriod") final Long stopGracePeriod) {
+      @JsonProperty("StopGracePeriod") final Long stopGracePeriod,
+      @JsonProperty("HealthCheck") final ContainerConfig.Healthcheck healthCheck,
+      @JsonProperty("Hosts") final List<String> hosts,
+      @JsonProperty("Secrets") final List<SecretBind> secrets) {
     final Builder builder = builder()
         .image(image)
         .hostname(hostname)
@@ -335,7 +366,9 @@ public abstract class ContainerSpec {
         .groups(groups)
         .tty(tty)
         .mounts(mounts)
-        .stopGracePeriod(stopGracePeriod);
+        .stopGracePeriod(stopGracePeriod)
+        .healthCheck(healthCheck)
+        .hosts(hosts);
 
     if (labels != null) {
       builder.labels(labels);
@@ -343,6 +376,10 @@ public abstract class ContainerSpec {
 
     if (command != null) {
       builder.command(command);
+    }
+
+    if (secrets != null) {
+      builder.secrets(secrets);
     }
 
     return builder.build();

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ContainerSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ContainerSpec.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.mount.Mount;
 
 import java.util.List;
@@ -88,6 +89,13 @@ public abstract class ContainerSpec {
   @Nullable
   @JsonProperty("StopGracePeriod")
   public abstract Long stopGracePeriod();
+
+  /**
+   * @since API 1.26
+   */
+  @Nullable
+  @JsonProperty("Healthcheck")
+  public abstract ContainerConfig.Healthcheck healthcheck();
 
   /**
    * @since API 1.26
@@ -318,6 +326,8 @@ public abstract class ContainerSpec {
       return this;
     }
 
+    public abstract Builder healthcheck(ContainerConfig.Healthcheck healthcheck);
+
     public abstract Builder hosts(List<String> hosts);
 
     public abstract Builder secrets(List<SecretBind> secrets);
@@ -343,6 +353,7 @@ public abstract class ContainerSpec {
       @JsonProperty("TTY") final Boolean tty,
       @JsonProperty("Mounts") final List<Mount> mounts,
       @JsonProperty("StopGracePeriod") final Long stopGracePeriod,
+      @JsonProperty("Healthcheck") final ContainerConfig.Healthcheck healthcheck,
       @JsonProperty("Hosts") final List<String> hosts,
       @JsonProperty("Secrets") final List<SecretBind> secrets) {
     final Builder builder = builder()
@@ -356,6 +367,7 @@ public abstract class ContainerSpec {
         .tty(tty)
         .mounts(mounts)
         .stopGracePeriod(stopGracePeriod)
+        .healthcheck(healthcheck)
         .hosts(hosts);
 
     if (labels != null) {

--- a/src/main/java/com/spotify/docker/client/messages/swarm/SecretBind.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/SecretBind.java
@@ -1,0 +1,70 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages.swarm;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public abstract class SecretBind {
+  @JsonProperty("File")
+  public abstract SecretFile file();
+
+  @JsonProperty("SecretID")
+  public abstract String secretId();
+
+  @JsonProperty("SecretName")
+  public abstract String secretName();
+
+  public static Builder builder() {
+    return new AutoValue_SecretBind.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder file(SecretFile file);
+
+    public abstract Builder secretId(String secretId);
+
+    public abstract Builder secretName(String secretName);
+
+    public abstract SecretBind build();
+  }
+
+  @JsonCreator
+  static SecretBind create(
+         @JsonProperty("File") SecretFile file,
+         @JsonProperty("SecretID") String secretId,
+         @JsonProperty("SecretName") String secretName) {
+    return builder()
+        .file(file)
+        .secretId(secretId)
+        .secretName(secretName)
+        .build();
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/SecretFile.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/SecretFile.java
@@ -1,0 +1,82 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages.swarm;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import javax.annotation.Nullable;
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public abstract class SecretFile {
+  @JsonProperty("Name")
+  public abstract String name();
+
+  @Nullable
+  @JsonProperty("UID")
+  public abstract String uid();
+
+  @Nullable
+  @JsonProperty("GID")
+  public abstract String gid();
+
+  @Nullable
+  @JsonProperty("Mode")
+  public abstract Long mode();
+
+  public static Builder builder() {
+    return new AutoValue_SecretFile.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder name(String name);
+
+    public abstract Builder uid(String uid);
+
+    public abstract Builder gid(String gid);
+
+    public abstract Builder mode(Long mode);
+
+    public abstract SecretFile build();
+  }
+
+  @JsonCreator
+  static SecretFile create(
+         @JsonProperty("Name") String name,
+         @JsonProperty("UID") String uid,
+         @JsonProperty("GID") String gid,
+         @JsonProperty("Mode") Long mode) {
+    return builder()
+        .name(name)
+        .uid(uid)
+        .gid(gid)
+        .mode(mode)
+        .build();
+  }
+}

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -4519,7 +4519,7 @@ public class DefaultDockerClientTest {
   }
 
   @Test
-  public void testCreateWithSecret() throws Exception {
+  public void testCreateServiceWithSecret() throws Exception {
     requireDockerApiVersionAtLeast("1.26", "swarm support");
 
     final String hostname = "tshost-{{.Task.Slot}}";

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -4524,6 +4524,7 @@ public class DefaultDockerClientTest {
 
     final String hostname = "tshost-{{.Task.Slot}}";
     final String[] hosts = {"127.0.0.1 test.local", "127.0.0.1 test"};
+    final String[] healthcheckCmd = {"ping", "-c", "1", "127.0.0.1"};
 
     for (final Secret secret : sut.listSecrets()) {
       sut.deleteSecret(secret.id());
@@ -4560,6 +4561,7 @@ public class DefaultDockerClientTest {
                     .secrets(Arrays.asList(secretBind))
                     .hostname(hostname)
                     .hosts(Arrays.asList(hosts))
+                    .healthcheck(Healthcheck.create(Arrays.asList(healthcheckCmd), 30L, 3L, 3))
                     .command(commandLine).build())
             .build();
     final String serviceName = randomName();
@@ -4584,6 +4586,14 @@ public class DefaultDockerClientTest {
             equalTo(secretId));
     assertThat(service.spec().taskTemplate().containerSpec().secrets().get(0).file().name(),
             equalTo("bsecret"));
+    assertThat(service.spec().taskTemplate().containerSpec().healthcheck().test(),
+            equalTo(Arrays.asList(healthcheckCmd)));
+    assertThat(service.spec().taskTemplate().containerSpec().healthcheck().interval(),
+            equalTo(30L));
+    assertThat(service.spec().taskTemplate().containerSpec().healthcheck().timeout(),
+            equalTo(3L));
+    assertThat(service.spec().taskTemplate().containerSpec().healthcheck().retries(),
+            equalTo(3));
   }
 
   @Test


### PR DESCRIPTION
This PR implement "hosts", "healthcheck" and "secrets" features that introduced in API version 1.26
Also moved "hostname" test into "testCreatWithSecret" since "hostname" is also a new feature in 1.26