### PR TITLE
Handle empty sub-directories when compressing contents.

### DIFF
--- a/src/main/java/com/spotify/docker/client/CompressedDirectory.java
+++ b/src/main/java/com/spotify/docker/client/CompressedDirectory.java
@@ -265,6 +265,27 @@ class CompressedDirectory implements Closeable {
     }
 
     @Override
+    public FileVisitResult preVisitDirectory(Path dir,
+                                             BasicFileAttributes attrs) throws IOException {
+      if (Files.isSameFile(dir, root)) {
+        return FileVisitResult.CONTINUE;
+      }
+
+      final Path relativePath = root.relativize(dir);
+
+      if (exclude(ignoreMatchers, relativePath)) {
+        return FileVisitResult.CONTINUE;
+      }
+
+      final TarArchiveEntry entry = new TarArchiveEntry(dir.toFile());
+      entry.setName(relativePath.toString());
+      entry.setMode(getFileMode(dir));
+      tarStream.putArchiveEntry(entry);
+      tarStream.closeArchiveEntry();
+      return FileVisitResult.CONTINUE;
+    }
+
+    @Override
     public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 
       final Path relativePath = root.relativize(file);

--- a/src/test/java/com/spotify/docker/client/CompressedDirectoryTest.java
+++ b/src/test/java/com/spotify/docker/client/CompressedDirectoryTest.java
@@ -20,6 +20,7 @@
 
 package com.spotify.docker.client;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -101,8 +102,7 @@ public class CompressedDirectoryTest {
         final String name = entry.getName();
         names.add(name);
       }
-      assertThat(names,
-          containsInAnyOrder("emptySubDir/"));
+      assertThat(names, contains("emptySubDir/"));
     }
   }
 


### PR DESCRIPTION
This fixes an issue where empty subdirectories were being ignored (as they didn’t have their `visitor.visitFile` method called). This better aligns with the default unix tar implementation, whereby all directories are created as archive entries, regardless if they have contents or not.