### PR TITLE
Add support for network filters

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -498,10 +498,25 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       throws DockerException, InterruptedException {
     WebTarget resource = resource()
         .path("containers").path("json");
+    resource = addParameters(resource, params);
 
+    try {
+      return request(GET, CONTAINER_LIST, resource, resource.request(APPLICATION_JSON_TYPE));
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
+        case 400:
+          throw new BadParamException(getQueryParamMap(resource), e);
+        default:
+          throw e;
+      }
+    }
+  }
+
+  private WebTarget addParameters(WebTarget resource, final Param... params)
+      throws DockerException {
     final Map<String, List<String>> filters = newHashMap();
-    for (final ListContainersParam param : params) {
-      if (param instanceof ListContainersFilterParam) {
+    for (final Param param : params) {
+      if (param instanceof FilterParam) {
         List<String> filterValueList;
         if (filters.containsKey(param.name())) {
           filterValueList = filters.get(param.name());
@@ -521,17 +536,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       // urlEncodeFilters will return null and queryParam() will remove that query parameter.
       resource = resource.queryParam("filters", urlEncodeFilters(filters));
     }
-
-    try {
-      return request(GET, CONTAINER_LIST, resource, resource.request(APPLICATION_JSON_TYPE));
-    } catch (DockerRequestException e) {
-      switch (e.status()) {
-        case 400:
-          throw new BadParamException(getQueryParamMap(resource), e);
-        default:
-          throw e;
-      }
-    }
+    return resource;
   }
 
   private Map<String, String> getQueryParamMap(final WebTarget resource) {
@@ -585,30 +590,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       throws DockerException, InterruptedException {
     WebTarget resource = resource()
         .path("images").path("json");
-
-    final Map<String, List<String>> filters = newHashMap();
-    for (final ListImagesParam param : params) {
-      if (param instanceof ListImagesFilterParam) {
-        final List<String> filterValueList;
-        if (filters.containsKey(param.name())) {
-          filterValueList = filters.get(param.name());
-        } else {
-          filterValueList = Lists.newArrayList();
-        }
-        filterValueList.add(param.value());
-        filters.put(param.name(), filterValueList);
-      } else {
-        resource = resource.queryParam(urlEncode(param.name()), urlEncode(param.value()));
-      }
-    }
-
-    if (!filters.isEmpty()) {
-      // If filters were specified, we must put them in a JSON object and pass them using the
-      // 'filters' query param like this: filters={"dangling":["true"]}. If filters is an empty map,
-      // urlEncodeFilters will return null and queryParam() will remove that query parameter.
-      resource = resource.queryParam("filters", urlEncodeFilters(filters));
-    }
-
+    resource = addParameters(resource, params);
     return request(GET, IMAGE_LIST, resource, resource.request(APPLICATION_JSON_TYPE));
   }
 
@@ -1944,32 +1926,10 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   public List<Network> listNetworks(final ListNetworksParam... params)
       throws DockerException, InterruptedException {
     WebTarget resource = resource().path("networks");
-
-    final Map<String, List<String>> filters = newHashMap();
-    for (final ListNetworksParam param : params) {
-      if (param instanceof ListNetworksFilterParam) {
-        List<String> filterValueList;
-        if (filters.containsKey(param.name())) {
-          filterValueList = filters.get(param.name());
-        } else {
-          filterValueList = Lists.newArrayList();
-        }
-        filterValueList.add(param.value());
-        filters.put(param.name(), filterValueList);
-      } else {
-        resource = resource.queryParam(urlEncode(param.name()), urlEncode(param.value()));
-      }
-    }
-
-    if (!filters.isEmpty()) {
-      // If filters were specified, we must put them in a JSON object and pass them using the
-      // 'filters' query param like this: filters={"dangling":["true"]}. If filters is an empty map,
-      // urlEncodeFilters will return null and queryParam() will remove that query parameter.
-      resource = resource.queryParam("filters", urlEncodeFilters(filters));
-    }
+    resource = addParameters(resource, params);
     return request(GET, NETWORK_LIST, resource, resource.request(APPLICATION_JSON_TYPE));
   }
-
+  
   @Override
   public Network inspectNetwork(String networkId) throws DockerException, InterruptedException {
     final WebTarget resource = resource().path("networks").path(networkId);
@@ -2130,30 +2090,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   public VolumeList listVolumes(ListVolumesParam... params)
       throws DockerException, InterruptedException {
     WebTarget resource = resource().path("volumes");
-
-    final Map<String, List<String>> filters = newHashMap();
-    for (final ListVolumesParam param : params) {
-      if (param instanceof ListVolumesFilterParam) {
-        List<String> filterValueList;
-        if (filters.containsKey(param.name())) {
-          filterValueList = filters.get(param.name());
-        } else {
-          filterValueList = Lists.newArrayList();
-        }
-        filterValueList.add(param.value());
-        filters.put(param.name(), filterValueList);
-      } else {
-        resource = resource.queryParam(urlEncode(param.name()), urlEncode(param.value()));
-      }
-    }
-
-    if (!filters.isEmpty()) {
-      // If filters were specified, we must put them in a JSON object and pass them using the
-      // 'filters' query param like this: filters={"dangling":["true"]}. If filters is an empty map,
-      // urlEncodeFilters will return null and queryParam() will remove that query parameter.
-      resource = resource.queryParam("filters", urlEncodeFilters(filters));
-    }
-
+    resource = addParameters(resource, params);
     return request(GET, VolumeList.class, resource, resource.request(APPLICATION_JSON_TYPE));
   }
 

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -1486,29 +1486,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   public EventStream events(EventsParam... params)
       throws DockerException, InterruptedException {
     WebTarget resource = noTimeoutResource().path("events");
-
-    final Map<String, List<String>> filters = newHashMap();
-    for (final EventsParam param : params) {
-      if (param instanceof EventsFilterParam) {
-        final List<String> filterValueList;
-        if (filters.containsKey(param.name())) {
-          filterValueList = filters.get(param.name());
-        } else {
-          filterValueList = Lists.newArrayList();
-        }
-        filterValueList.add(param.value());
-        filters.put(param.name(), filterValueList);
-      } else {
-        resource = resource.queryParam(urlEncode(param.name()), urlEncode(param.value()));
-      }
-    }
-
-    if (!filters.isEmpty()) {
-      // If filters were specified, we must put them in a JSON object and pass them using the
-      // 'filters' query param like this: filters={"dangling":["true"]}. If filters is an empty map,
-      // urlEncodeFilters will return null and queryParam() will remove that query parameter.
-      resource = resource.queryParam("filters", urlEncodeFilters(filters));
-    }
+    resource = addParameters(resource, params);
 
     try {
       final CloseableHttpClient client = (CloseableHttpClient) ApacheConnectorProvider

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -689,6 +689,14 @@ public interface DockerClient extends Closeable {
       return Objects.hash(name, value);
     }
   }
+  
+  /**
+   * Marker interface to designate a parameter as a filter parameter.
+   * Filter parameters receive special treatment during serialization:
+   * They are all rendered into the special 'filter' query parameter.
+   */
+  interface FilterParam {
+  }
 
   /**
    * Flags which can be passed to the <code>build</code> method.
@@ -1587,7 +1595,7 @@ public interface DockerClient extends Closeable {
    * This should be used by ListNetworksParam only.
    * @since Docker 1.10, API version 1.22
    */
-  class ListNetworksFilterParam extends ListNetworksParam {
+  class ListNetworksFilterParam extends ListNetworksParam implements FilterParam {
     
     private ListNetworksFilterParam(String name, String value) {
       super(name, value);
@@ -2148,7 +2156,7 @@ public interface DockerClient extends Closeable {
     }
   }
 
-  class ListContainersFilterParam extends ListContainersParam {
+  class ListContainersFilterParam extends ListContainersParam implements FilterParam {
 
     public ListContainersFilterParam(String name, String value) {
       super(name, value);
@@ -2270,7 +2278,7 @@ public interface DockerClient extends Closeable {
    * Filter parameter for {@link #listImages(ListImagesParam...)}. This should be used by
    * ListImagesParam only.
    */
-  class ListImagesFilterParam extends ListImagesParam {
+  class ListImagesFilterParam extends ListImagesParam implements FilterParam {
 
     public ListImagesFilterParam(String name, String value) {
       super(name, value);
@@ -2579,7 +2587,7 @@ public interface DockerClient extends Closeable {
    * ListVolumesParam only.
    * @since Docker 1.9, API version 1.21
    */
-  class ListVolumesFilterParam extends ListVolumesParam {
+  class ListVolumesFilterParam extends ListVolumesParam implements FilterParam {
     public ListVolumesFilterParam(String name, String value) {
       super(name, value);
     }

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -1528,7 +1528,7 @@ public interface DockerClient extends Closeable {
      * @return The ListNetworksParam for the given driver.
      * @since Docker 1.12, API version 1.24
      */
-    public static ListNetworksParam withNetworkDriver(final String driver) {
+    public static ListNetworksParam withDriver(final String driver) {
       return filter("driver", driver);
     }
 
@@ -1542,30 +1542,30 @@ public interface DockerClient extends Closeable {
      * @see #customNetworks()
      * @since Docker 1.10, API version 1.22
      */
-    public static ListNetworksParam withNetworkType(final Network.Type type) {
-      return filter("type", type.toString());
+    public static ListNetworksParam withType(final Network.Type type) {
+      return filter("type", type.getName());
     }
 
     /**
      * Return built-in networks only.
      * @return The ListNetworksParam for built-in networks.
-     * @see #withNetworkType(com.spotify.docker.client.messages.Network.Type)
+     * @see #withType(com.spotify.docker.client.messages.Network.Type)
      * @see #customNetworks()
      * @since Docker 1.10, API version 1.22
      */
     public static ListNetworksParam builtInNetworks() {
-      return withNetworkType(BUILTIN);
+      return withType(BUILTIN);
     }
 
     /**
      * Return user-defined (custom) networks only.
      * @return The ListNetworksParam for user-defined networks.
-     * @see #withNetworkType(com.spotify.docker.client.messages.Network.Type)
+     * @see #withType(com.spotify.docker.client.messages.Network.Type)
      * @see #builtInNetworks()
      * @since Docker 1.10, API version 1.22
      */
     public static ListNetworksParam customNetworks() {
-      return withNetworkType(CUSTOM);
+      return withType(CUSTOM);
     }
 
     /**
@@ -1575,7 +1575,7 @@ public interface DockerClient extends Closeable {
      * @return ListNetworksParam
      * @since Docker 1.12, API version 1.24
      */
-    public static ListNetworksParam withNetworkLabel(String label, String value) {
+    public static ListNetworksParam withLabel(String label, String value) {
       return isNullOrEmpty(value) ? filter("label", label) : filter("label", label + "=" + value);
     }
 
@@ -1585,8 +1585,8 @@ public interface DockerClient extends Closeable {
      * @return ListNetworksParam
      * @since Docker 1.12, API version 1.24
      */
-    public static ListNetworksParam withNetworkLabel(String label) {
-      return withNetworkLabel(label, null);
+    public static ListNetworksParam withLabel(String label) {
+      return withLabel(label, null);
     }
   }
   

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -2288,32 +2288,10 @@ public interface DockerClient extends Closeable {
   /**
    * Parameters for {@link #events(EventsParam...)}
    */
-  class EventsParam {
-
-    private final String name;
-    private final String value;
+  class EventsParam extends Param {
 
     private EventsParam(final String name, final String value) {
-      this.name = name;
-      this.value = value;
-    }
-
-    /**
-     * Parameter name.
-     *
-     * @return The name
-     */
-    public String name() {
-      return name;
-    }
-
-    /**
-     * Parameter value.
-     *
-     * @return The value
-     */
-    public String value() {
-      return value;
+      super(name, value);
     }
 
     /**
@@ -2459,7 +2437,7 @@ public interface DockerClient extends Closeable {
   /**
    * Filter parameter for {@link #events(EventsParam...)}. This should be used by EventsParam only.
    */
-  class EventsFilterParam extends EventsParam {
+  class EventsFilterParam extends EventsParam implements FilterParam {
 
     public EventsFilterParam(String name, String value) {
       super(name, value);

--- a/src/main/java/com/spotify/docker/client/messages/Network.java
+++ b/src/main/java/com/spotify/docker/client/messages/Network.java
@@ -26,11 +26,11 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.auto.value.AutoValue;
 
 import com.google.common.collect.ImmutableMap;
 
-import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -125,13 +125,20 @@ public abstract class Network {
    */
   public enum Type {
     /** Predefined networks that are built-in into Docker. */
-    BUILTIN,
-    /** Custom networks created by users. */
-    CUSTOM;
+    BUILTIN("builtin"),
+    /** Custom networks that were created by users. */
+    CUSTOM("custom");
     
-    @Override
-    public String toString() {
-      return name().toLowerCase(Locale.ENGLISH);
+    private final String name;
+
+    @JsonCreator
+    Type(final String name) {
+      this.name = name;
+    }
+
+    @JsonValue
+    public String getName() {
+      return name;
     }
   }
 }

--- a/src/main/java/com/spotify/docker/client/messages/Network.java
+++ b/src/main/java/com/spotify/docker/client/messages/Network.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
 import com.google.common.collect.ImmutableMap;
+
+import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -115,6 +117,21 @@ public abstract class Network {
         @JsonProperty("IPv4Address") final String ipv4Address,
         @JsonProperty("IPv6Address") final String ipv6Address) {
       return new AutoValue_Network_Container(endpointId, macAddress, ipv4Address, ipv6Address);
+    }
+  }
+  
+  /**
+   * Docker networks come in two kinds: built-in or custom. 
+   */
+  public enum Type {
+    /** Predefined networks that are built-in into Docker. */
+    BUILTIN,
+    /** Custom networks created by users. */
+    CUSTOM;
+    
+    @Override
+    public String toString() {
+      return name().toLowerCase(Locale.ENGLISH);
     }
   }
 }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -3643,7 +3643,7 @@ public class DefaultDockerClientTest {
     assertThat(networks, not(hasItem(network2)));
     
     // filter by type
-    networks = sut.listNetworks(ListNetworksParam.withNetworkType(BUILTIN));
+    networks = sut.listNetworks(ListNetworksParam.withType(BUILTIN));
     assertThat(networks, hasItem(hostNetwork));
     assertThat(networks, not(hasItems(network1, network2)));
     
@@ -3657,26 +3657,26 @@ public class DefaultDockerClientTest {
     
     // filter by driver
     if (dockerApiVersionAtLeast("1.24")) {
-      networks = sut.listNetworks(ListNetworksParam.withNetworkDriver("bridge"));
+      networks = sut.listNetworks(ListNetworksParam.withDriver("bridge"));
       assertThat(networks, not(hasItem(hostNetwork)));
       assertThat(networks, hasItems(network1, network2));
       
-      networks = sut.listNetworks(ListNetworksParam.withNetworkDriver("host"));
+      networks = sut.listNetworks(ListNetworksParam.withDriver("host"));
       assertThat(networks, hasItem(hostNetwork));
       assertThat(networks, not(hasItems(network1, network2)));
     }
     
     // filter by label
     if (dockerApiVersionAtLeast("1.24")) {
-      networks = sut.listNetworks(ListNetworksParam.withNetworkLabel("is-test"));
+      networks = sut.listNetworks(ListNetworksParam.withLabel("is-test"));
       assertThat(networks, not(hasItem(hostNetwork)));
       assertThat(networks, hasItems(network1, network2));
       
-      networks = sut.listNetworks(ListNetworksParam.withNetworkLabel("is-test", "true"));
+      networks = sut.listNetworks(ListNetworksParam.withLabel("is-test", "true"));
       assertThat(networks, hasItem(network1));
       assertThat(networks, not(hasItem(network2)));
       
-      networks = sut.listNetworks(ListNetworksParam.withNetworkLabel("is-test", "false"));
+      networks = sut.listNetworks(ListNetworksParam.withLabel("is-test", "false"));
       assertThat(networks, not(hasItems(network1, network2)));
     }
     


### PR DESCRIPTION
This PR adds support for filters to `DockerClient.listNetworks()` as suggested in #694.
Closes #694. Needs discussion.

### Naming Issues
I was very unsure how to name the factory methods for the filter params because there are some inconsistencies in the existing list methods:

    ListContainersParam
      withExitStatus(int exitStatus)
      withStatusXXX()
      withLabel(String label, String value)
    ListImagesParam
      danglingImages()
      withLabel(String label, String value)
    EventsParam
      event(String event)
      image(String image)
      container(String container)
      volume(String volume)
      network(String network)
      type(Event.Type type)
      label(String label, String value)
    ListVolumesParam
      name(String name)
      dangling()
      driver(String driver)

So I could have named the methods `withDriver` or `driver` , `withLabel` or `label` etc.

I'd like to suggest a third variant: Given that the factory methods are syntactical sugar, they offer most value if they can be used with static imports, i.e.

    client.listNetworks(withLabel("stage", "production"), custom())

instead of

    client.listNetworks(ListNetworkParam.withLabel("stage", "production"), ListNetworkParam.custom())

This does not work well if the various `XXXListParam` types have name collisions, e.g. `.withLabels()` and you want to use several of them in one class. One solution would be to name the methods like `withNetworkLabel`, `withImageLabel`, `withContainerLabel` and so on.

In this PR, I used such names. I'm OK with other naming schemes, just let me know and I'll update the PR.

### Consistency

IMHO consistency in the names of the existing factory methods should be improved. New methods should be added and ill-named ones should be deprecated.

If you agree, just give me a ping and I'll create a follow-up PR.

### Refactoring

I stepped into some repetitions in the filter methods that I resolved in additional commits. The third commit deserves special attention because it changes the type hierarchy.