### PR TITLE
Improve consistency in ListXXXParameters classes

### DIFF
--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -2510,6 +2510,18 @@ public interface DockerClient extends Closeable {
      * Show events with a label value.
      *
      * @param label The label to filter on
+     * @return EventsParam
+     * @see #withLabel(String)
+     * @since API 1.21
+     */
+    public static EventsParam label(final String label) {
+      return label(label, null);
+    }
+    
+    /**
+     * Show events with a label value.
+     *
+     * @param label The label to filter on
      * @param value The value of the label
      * @return EventsParam
      * @see #label(String, String)
@@ -2517,18 +2529,6 @@ public interface DockerClient extends Closeable {
      */
     public static EventsParam withLabel(final String label, final String value) {
       return label(label, value);
-    }
-
-    /**
-     * Show events with a label value.
-     *
-     * @param label The label to filter on
-     * @return EventsParam
-     * @see #withLabel(String)
-     * @since API 1.21
-     */
-    public static EventsParam label(final String label) {
-      return label(label, null);
     }
 
     /**

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -1509,7 +1509,7 @@ public interface DockerClient extends Closeable {
      * @return The ListNetworksParam for the given ID.
      * @since Docker 1.10, API version 1.22
      */
-    public static ListNetworksParam byNetworkId(final String id) {
+    public static ListNetworksParam withId(final String id) {
       return filter("id", id);
     }
 
@@ -1519,7 +1519,7 @@ public interface DockerClient extends Closeable {
      * @return The ListNetworksParam for the given name.
      * @since Docker 1.10, API version 1.22
      */
-    public static ListNetworksParam byNetworkName(final String name) {
+    public static ListNetworksParam withName(final String name) {
       return filter("name", name);
     }
 

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -2333,6 +2333,7 @@ public interface DockerClient extends Closeable {
      * Show only certain events. For example, "event=pull" for image pull events.
      * @param event Type of event to show
      * @return EventsParam
+     * @see #forEvent(String)
      * @since API 1.18
      */
     public static EventsParam event(final String event) {
@@ -2340,13 +2341,47 @@ public interface DockerClient extends Closeable {
     }
 
     /**
+     * Show only certain events. For example, "event=pull" for image pull events.
+     * @param event Type of event to show
+     * @return EventsParam
+     * @see #event(String)
+     * @since API 1.18
+     */
+    public static EventsParam forEvent(final String event) {
+      return event(event);
+    }
+
+    /**
      * Show events for an image.
      * @param image An image tag or id
      * @return EventsParam
+     * @see #forImage(String)
      * @since API 1.18
      */
     public static EventsParam image(final String image) {
       return filter("image", image);
+    }
+
+    /**
+     * Show events for an image.
+     * @param image An image tag or id
+     * @return EventsParam
+     * @see #image(String)
+     * @since API 1.18
+     */
+    public static EventsParam forImage(final String image) {
+      return image(image);
+    }
+
+    /**
+     * Show events for a container.
+     * @param container A container name or id
+     * @return EventsParam
+     * @see #forContainer(String)
+     * @since API 1.18
+     */
+    public static EventsParam container(final String container) {
+      return filter("container", container);
     }
 
     /**
@@ -2355,14 +2390,15 @@ public interface DockerClient extends Closeable {
      * @return EventsParam
      * @since API 1.18
      */
-    public static EventsParam container(final String container) {
-      return filter("container", container);
+    public static EventsParam forContainer(final String container) {
+      return container(container);
     }
 
     /**
      * Show events for a volume.
      * @param volume A volume name or id
      * @return EventsParam
+     * @see #forVolume(String)
      * @since API 1.22
      */
     public static EventsParam volume(final String volume) {
@@ -2370,9 +2406,21 @@ public interface DockerClient extends Closeable {
     }
 
     /**
+     * Show events for a volume.
+     * @param volume A volume name or id
+     * @return EventsParam
+     * @see #volume(String)
+     * @since API 1.22
+     */
+    public static EventsParam forVolume(final String volume) {
+      return volume(volume);
+    }
+
+    /**
      * Show events for a network.
      * @param network A network name or id
      * @return EventsParam
+     * @see #forNetwork(String)
      * @since API 1.22
      */
     public static EventsParam network(final String network) {
@@ -2380,13 +2428,36 @@ public interface DockerClient extends Closeable {
     }
 
     /**
+     * Show events for a network.
+     * @param network A network name or id
+     * @return EventsParam
+     * @see #network(String)
+     * @since API 1.22
+     */
+    public static EventsParam forNetwork(final String network) {
+      return network(network);
+    }
+
+    /**
      * Show events for a daemon.
      * @param daemon A daemon name or id
      * @return EventsParam
+     * @see #forDaemon(String)
      * @since API 1.24
      */
     public static EventsParam daemon(final String daemon) {
       return filter("daemon", daemon);
+    }
+
+    /**
+     * Show events for a daemon.
+     * @param daemon A daemon name or id
+     * @return EventsParam
+     * @see #daemon(String)
+     * @since API 1.24
+     */
+    public static EventsParam forDaemon(final String daemon) {
+      return daemon(daemon);
     }
 
     /**
@@ -2412,11 +2483,23 @@ public interface DockerClient extends Closeable {
     }
 
     /**
+     * Show events of a given type. For instance, "type=image" for all image events.
+     * @param type A type of event. Possible values: container, image, volume, network, or daemon
+     * @return EventsParam
+     * @see #type(Event.Type)
+     * @since API 1.22
+     */
+    public static EventsParam withType(final Event.Type type) {
+      return type(type);
+    }
+
+    /**
      * Show events with a label value.
      *
      * @param label The label to filter on
      * @param value The value of the label
      * @return EventsParam
+     * @see #withLabel(String, String)
      * @since API 1.21
      */
     public static EventsParam label(final String label, final String value) {
@@ -2427,11 +2510,37 @@ public interface DockerClient extends Closeable {
      * Show events with a label value.
      *
      * @param label The label to filter on
+     * @param value The value of the label
      * @return EventsParam
+     * @see #label(String, String)
+     * @since API 1.21
+     */
+    public static EventsParam withLabel(final String label, final String value) {
+      return label(label, value);
+    }
+
+    /**
+     * Show events with a label value.
+     *
+     * @param label The label to filter on
+     * @return EventsParam
+     * @see #withLabel(String)
      * @since API 1.21
      */
     public static EventsParam label(final String label) {
       return label(label, null);
+    }
+
+    /**
+     * Show events with a label value.
+     *
+     * @param label The label to filter on
+     * @return EventsParam
+     * @see #label(String)
+     * @since API 1.21
+     */
+    public static EventsParam withLabel(final String label) {
+      return label(label);
     }
   }
 
@@ -2508,10 +2617,22 @@ public interface DockerClient extends Closeable {
      * Filter volumes by name.
      * @param name Matches all or part of a volume name.
      * @return ListVolumesParam
+     * @see #withName(String)
      * @since Docker 1.12, API version 1.24
      */
     public static ListVolumesParam name(final String name) {
       return filter("name", name);
+    }
+
+    /**
+     * Filter volumes by name.
+     * @param name Matches all or part of a volume name.
+     * @return ListVolumesParam
+     * @see #name(String)
+     * @since Docker 1.12, API version 1.24
+     */
+    public static ListVolumesParam withName(final String name) {
+      return name(name);
     }
 
     /**
@@ -2553,10 +2674,22 @@ public interface DockerClient extends Closeable {
      * Filter volumes by volume driver.
      * @param driver Matches all or part of a volume driver name.
      * @return ListVolumesParam
+     * @see #withDriver(String)
      * @since Docker 1.12, API version 1.24
      */
     public static ListVolumesParam driver(final String driver) {
       return filter("driver", driver);
+    }
+
+    /**
+     * Filter volumes by volume driver.
+     * @param driver Matches all or part of a volume driver name.
+     * @return ListVolumesParam
+     * @see #driver(String)
+     * @since Docker 1.12, API version 1.24
+     */
+    public static ListVolumesParam withDriver(final String driver) {
+      return driver(driver);
     }
 
   }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -3638,12 +3638,12 @@ public class DefaultDockerClientTest {
     List<Network> networks;
     
     // filter by id
-    networks = sut.listNetworks(ListNetworksParam.byNetworkId(network1.id()));
+    networks = sut.listNetworks(ListNetworksParam.withId(network1.id()));
     assertThat(networks, hasItem(network1));
     assertThat(networks, not(hasItem(network2)));
     
     // filter by name
-    networks = sut.listNetworks(ListNetworksParam.byNetworkName(network1.name()));
+    networks = sut.listNetworks(ListNetworksParam.withName(network1.name()));
     assertThat(networks, hasItem(network1));
     assertThat(networks, not(hasItem(network2)));
     


### PR DESCRIPTION
See the discussion in #707 for naming issues in the static factory methods of several `ListXXXParameters` classes.

In this PR, for several short-named methods (e.g. `driver`) aliases with more consistent names (e.g. `withDriver`) are **added**.
I leave it to discussion whether the old methods should get deprecated or not. Currently they are not. 

In cases where you want to do imports for a bunch of static methods from several `ListXXXParameters` classes, it might be helpful to be able to choose from several names for the same function. So it might be a good idea not to deprecate the methods.

Following this argument further on, we could even create more aliases like `withNetworkLabel`, `withImageLabel`, `withContainerLabel` as suggested but dropped in #707.

On the other hand, the choice between several names for the same thing might be confusing to the user. I tried to mitigate this by adding some `@see` javadoc references between the related methods.

WDYT?

Notes:
* For filter parameters that target exactly one instance as event source, I chose the prefix `for` instead of `with` (e.g. `forContainer`).
* This PR also **changes** two **unreleased** method names in `ListNetworksParam`