### PR TITLE
Swarm Mode Operations (init, join, leave, update, unlockkey, unlock)

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -113,7 +113,11 @@ import com.spotify.docker.client.messages.swarm.SecretSpec;
 import com.spotify.docker.client.messages.swarm.Service;
 import com.spotify.docker.client.messages.swarm.ServiceSpec;
 import com.spotify.docker.client.messages.swarm.Swarm;
+import com.spotify.docker.client.messages.swarm.SwarmInit;
+import com.spotify.docker.client.messages.swarm.SwarmJoin;
+import com.spotify.docker.client.messages.swarm.SwarmSpec;
 import com.spotify.docker.client.messages.swarm.Task;
+import com.spotify.docker.client.messages.swarm.UnlockKey;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Closeable;
 import java.io.IOException;
@@ -1650,6 +1654,168 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     final WebTarget resource = resource().path("swarm");
     return request(GET, Swarm.class, resource, resource.request(APPLICATION_JSON_TYPE));
   }
+  
+  @Override
+  public String initSwarm(SwarmInit swarmInit) throws DockerException, InterruptedException {
+    assertApiVersionIsAbove("1.24");
+
+    try {
+      final WebTarget resource = resource().path("swarm").path("init");
+      return request(POST, String.class, resource, resource.request(APPLICATION_JSON_TYPE),
+          Entity.json(swarmInit));
+
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
+      case 400:
+        throw new DockerException("bad parameter", e);
+      case 500:
+        throw new DockerException("server error", e);
+      case 503:
+        throw new DockerException("node is already part of a swarm", e);
+      default:
+        throw e;
+      }
+    }
+  }
+
+  @Override
+  public void joinSwarm(SwarmJoin swarmJoin) throws DockerException, InterruptedException {
+    assertApiVersionIsAbove("1.24");
+
+    try {
+      final WebTarget resource = resource().path("swarm").path("join");
+      request(POST, String.class, resource, resource.request(APPLICATION_JSON_TYPE),
+          Entity.json(swarmJoin));
+
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
+      case 400:
+        throw new DockerException("bad parameter", e);
+      case 500:
+        throw new DockerException("server error", e);
+      case 503:
+        throw new DockerException("node is already part of a swarm", e);
+      default:
+        throw e;
+      }
+    }
+  }
+
+  @Override
+  public void leaveSwarm() throws DockerException, InterruptedException {
+    leaveSwarm(false);
+  }
+
+  @Override
+  public void leaveSwarm(boolean force) throws DockerException, InterruptedException {
+    assertApiVersionIsAbove("1.24");
+
+    try {
+      final WebTarget resource = resource().path("swarm").path("leave").queryParam("force", force);
+      request(POST, String.class, resource, resource.request(APPLICATION_JSON_TYPE));
+
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
+        case 500:
+          throw new DockerException("server error", e);
+        case 503:
+          throw new DockerException("node is not part of a swarm", e);
+        default:
+          throw e;
+      }
+    }
+  }
+
+  @Override
+  public void updateSwarm(Long version, 
+                          boolean rotateWorkerToken, 
+                          boolean rotateManagerToken,
+                          boolean rotateManagerUnlockKey, 
+                          SwarmSpec spec)
+      throws DockerException, InterruptedException {
+    assertApiVersionIsAbove("1.24");
+
+    try {
+      final WebTarget resource = resource().path("swarm").path("update")
+          .queryParam("version", version)
+          .queryParam("rotateWorkerToken", rotateWorkerToken)
+          .queryParam("rotateManagerToken", rotateManagerToken)
+          .queryParam("rotateManagerUnlockKey", rotateManagerUnlockKey);
+          
+      request(POST, String.class, resource, resource.request(APPLICATION_JSON_TYPE), Entity.json(spec));
+
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
+        case 400:
+          throw new DockerException("bad parameter", e);
+        default:
+          throw e;
+      }
+    }
+  }
+
+  @Override
+  public void updateSwarm(Long version, 
+                          boolean rotateWorkerToken, 
+                          boolean rotateManagerToken, 
+                          SwarmSpec spec)
+      throws DockerException, InterruptedException {
+    updateSwarm(version, rotateWorkerToken, rotateWorkerToken, false, spec);
+  }
+
+  @Override
+  public void updateSwarm(Long version, 
+                          boolean rotateWorkerToken, 
+                          SwarmSpec spec)
+      throws DockerException, InterruptedException {
+    updateSwarm(version, rotateWorkerToken, false, false, spec);
+    
+  }
+
+  @Override
+  public void updateSwarm(Long version, SwarmSpec spec) 
+      throws DockerException, InterruptedException {
+    updateSwarm(version, false, false, false, spec);
+  }
+
+  @Override
+  public UnlockKey unlockkey() throws DockerException, InterruptedException {
+    assertApiVersionIsAbove("1.24");
+    try {
+      final WebTarget resource = resource().path("swarm").path("unlockkey");
+      
+      return request(GET, UnlockKey.class, resource, resource.request(APPLICATION_JSON_TYPE));
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
+        case 500:
+          throw new DockerException("server error", e);
+        case 503:
+          throw new DockerException("node is not part of a swarm", e);
+        default:
+          throw e;
+      }
+    }
+  }
+
+  @Override
+  public void unlock(UnlockKey unlockKey) throws DockerException, InterruptedException {
+    assertApiVersionIsAbove("1.24");
+    try {
+      final WebTarget resource = resource().path("swarm").path("unlock");
+      
+      request(POST, String.class, resource, resource.request(APPLICATION_JSON_TYPE),
+          Entity.json(unlockKey));
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
+        case 500:
+          throw new DockerException("server error", e);
+        case 503:
+          throw new DockerException("node is not part of a swarm", e);
+        default:
+          throw e;
+      }
+    }
+  }
 
   @Override
   public ServiceCreateResponse createService(ServiceSpec spec)
@@ -2543,5 +2709,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       return headers;
     }
   }
+
+ 
 
 }

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -1711,7 +1711,8 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     assertApiVersionIsAbove("1.24");
 
     try {
-      final WebTarget resource = resource().path("swarm").path("leave").queryParam("force", force);
+      final WebTarget resource = resource().path("swarm")
+          .path("leave").queryParam("force", force);
       request(POST, String.class, resource, resource.request(APPLICATION_JSON_TYPE));
 
     } catch (DockerRequestException e) {
@@ -1742,7 +1743,8 @@ public class DefaultDockerClient implements DockerClient, Closeable {
           .queryParam("rotateManagerToken", rotateManagerToken)
           .queryParam("rotateManagerUnlockKey", rotateManagerUnlockKey);
           
-      request(POST, String.class, resource, resource.request(APPLICATION_JSON_TYPE), Entity.json(spec));
+      request(POST, String.class, resource, resource.request(APPLICATION_JSON_TYPE), 
+          Entity.json(spec));
 
     } catch (DockerRequestException e) {
       switch (e.status()) {

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -71,7 +71,11 @@ import com.spotify.docker.client.messages.swarm.SecretSpec;
 import com.spotify.docker.client.messages.swarm.Service;
 import com.spotify.docker.client.messages.swarm.ServiceSpec;
 import com.spotify.docker.client.messages.swarm.Swarm;
+import com.spotify.docker.client.messages.swarm.SwarmInit;
+import com.spotify.docker.client.messages.swarm.SwarmJoin;
+import com.spotify.docker.client.messages.swarm.SwarmSpec;
 import com.spotify.docker.client.messages.swarm.Task;
+import com.spotify.docker.client.messages.swarm.UnlockKey;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -86,7 +90,6 @@ import java.util.Set;
  *
  * <p>Note: All methods throw DockerException on unexpected docker response status codes.
  */
-@SuppressWarnings("JavadocMethod")
 public interface DockerClient extends Closeable {
 
   /**
@@ -1489,6 +1492,47 @@ public interface DockerClient extends Closeable {
    * @throws InterruptedException If the thread is interrupted
    */
   Swarm inspectSwarm() throws DockerException, InterruptedException;
+  
+  /**
+   * Init a Swarm cluster. Only available in Docker API &gt;= 1.24.
+   *
+   * @return Node ID
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  String initSwarm(SwarmInit swarmInit) throws DockerException, InterruptedException;
+  
+  /**
+   * Join to a Swarm cluster. Only available in Docker API &gt;= 1.24.
+   *
+   * 
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  void joinSwarm(SwarmJoin swarmJoin) throws DockerException, InterruptedException;
+  
+  void leaveSwarm() throws DockerException, InterruptedException;
+  
+  void leaveSwarm(boolean force) throws DockerException, InterruptedException;
+
+  void updateSwarm(final Long version, 
+      boolean rotateWorkerToken, boolean rotateManagerToken, boolean rotateManagerUnlockKey, 
+      SwarmSpec spec) throws DockerException, InterruptedException;
+  
+  void updateSwarm(final Long version, 
+      boolean rotateWorkerToken, boolean rotateManagerToken,  
+      SwarmSpec spec) throws DockerException, InterruptedException;
+  
+  void updateSwarm(final Long version, 
+      boolean rotateWorkerToken, 
+      SwarmSpec spec) throws DockerException, InterruptedException;
+  
+  void updateSwarm(final Long version, SwarmSpec spec) 
+      throws DockerException, InterruptedException;
+  
+  UnlockKey unlockkey() throws DockerException, InterruptedException;
+  
+  void unlock(UnlockKey unlockKey) throws DockerException, InterruptedException;
 
   /**
    * Create a new service. Only available in Docker API &gt;= 1.24.

--- a/src/main/java/com/spotify/docker/client/messages/swarm/SwarmInit.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/SwarmInit.java
@@ -1,0 +1,64 @@
+package com.spotify.docker.client.messages.swarm;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
+
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public abstract class SwarmInit {
+  @JsonProperty("ListenAddr")
+  public abstract String listenAddr();
+
+  @JsonProperty("AdvertiseAddr")
+  public abstract String advertiseAddr();
+
+  @JsonProperty("ForceNewCluster")
+  public abstract boolean forceNewCluster();
+
+  @Nullable
+  @JsonProperty("Spec")
+  public abstract SwarmSpec swarmSpec();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder listenAddr(String listenAddr);
+
+    public abstract Builder advertiseAddr(String advertiseAddr);
+
+    public abstract Builder forceNewCluster(boolean forceNewCluster);
+
+    public abstract Builder swarmSpec(SwarmSpec swarmSpec);
+
+    public abstract SwarmInit build();
+  }
+
+  public static SwarmInit.Builder builder() {
+    return new AutoValue_SwarmInit.Builder();
+  }
+
+  @JsonCreator
+  static SwarmInit create(
+      @JsonProperty("ListenAddr") final String listenAddr,
+      @JsonProperty("AdvertiseAddr") final String advertiseAddr,
+      @JsonProperty("ForceNewCluster") final boolean forceNewCluster,
+      @JsonProperty("Spec") final SwarmSpec swarmSpec) {
+    final Builder builder = builder()
+        .listenAddr(listenAddr)
+        .advertiseAddr(advertiseAddr)
+        .forceNewCluster(forceNewCluster);
+
+    if (swarmSpec != null) {
+      builder.swarmSpec(swarmSpec);
+    }
+
+    return builder.build();
+
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/SwarmJoin.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/SwarmJoin.java
@@ -1,0 +1,60 @@
+package com.spotify.docker.client.messages.swarm;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import java.util.List;
+
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public abstract class SwarmJoin {
+  @JsonProperty("ListenAddr")
+  public abstract String listenAddr();
+
+  @JsonProperty("AdvertiseAddr")
+  public abstract String advertiseAddr();
+
+  @JsonProperty("RemoteAddrs")
+  public abstract List<String> remoteAddrs();
+
+  @JsonProperty("JoinToken")
+  public abstract String joinToken();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder listenAddr(String listenAddr);
+
+    public abstract Builder advertiseAddr(String advertiseAddr);
+
+    public abstract Builder remoteAddrs(List<String> remoteAddrs);
+
+    public abstract Builder joinToken(String swarmSpec);
+
+    public abstract SwarmJoin build();
+  }
+
+  public static SwarmJoin.Builder builder() {
+    return new AutoValue_SwarmJoin.Builder();
+  }
+
+  @JsonCreator
+  static SwarmJoin create(
+      @JsonProperty("ListenAddr") final String listenAddr,
+      @JsonProperty("AdvertiseAddr") final String advertiseAddr,
+      @JsonProperty("RemoteAddrs") final List<String> remoteAddrs,
+      @JsonProperty("JoinToken") final String joinToken) {
+    final Builder builder = builder()
+        .listenAddr(listenAddr)
+        .advertiseAddr(advertiseAddr)
+        .remoteAddrs(remoteAddrs)
+        .joinToken(joinToken);
+
+    return builder.build();
+
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/UnlockKey.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/UnlockKey.java
@@ -1,0 +1,43 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages.swarm;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public abstract class UnlockKey {
+
+  @JsonProperty("UnlockKey")
+  public abstract String unlockKey();
+
+  @JsonCreator
+  static UnlockKey create(@JsonProperty("UnlockKey") final String unlockKey) {
+    return new AutoValue_UnlockKey(unlockKey);
+  }
+}


### PR DESCRIPTION
For testing purpose:
```
// Creating Docker Vm's
docker-machine create -d virtualbox t1
docker-machine create -d virtualbox t2
```

```
// Disabling TLS for t1 and t2
docker-machine ssh t1 | t2 
# sudo su -
# vi /var/lib/boot2docker/profile
DOCKER_HOST='-H tcp://0.0.0.0:2375'
DOCKER_TLS=no
# source /var/lib/boot2docker/profile
# /etc/init.d/docker stop
# /etc/init.d/docker start
# exit
$ exit
```

I have tested "init", "join", "leave" and "inspect" with the following java code:
```
private static final Logger LOGGER = Logger.getAnonymousLogger();

public static void main(String[] args) throws Exception {

    DockerClient client1 = DefaultDockerClient.builder()
        .uri("http://192.168.99.100:2375")
        .build();
    LOGGER.info("Client 1: OK");

    SwarmInit swarmInit = SwarmInit.builder()
        .forceNewCluster(false)
        .advertiseAddr("192.168.99.100:2377")
        .listenAddr("0.0.0.0:2377")
        .build();

    client1.initSwarm(swarmInit);
    LOGGER.info("initSwarm(): OK");

    Swarm swarm = client1.inspectSwarm();
    LOGGER.info("inspectSwarm(): OK");

    String token = swarm.joinTokens().worker();
    
    DockerClient client2 = DefaultDockerClient.builder()
        .uri("http://192.168.99.101:2375")
        .build();
    LOGGER.info("Client 2: OK");
    
    List<String> remoteAddrs = new ArrayList<>();
    remoteAddrs.add("192.168.99.100:2377");
    
    SwarmJoin swarmJoin = SwarmJoin.builder()
        .advertiseAddr("192.168.99.101:2377")
        .listenAddr("0.0.0.0:2377")
        .joinToken(token)
        .remoteAddrs(remoteAddrs)
        .build();
    
    client2.joinSwarm(swarmJoin);
    LOGGER.info("joinSwarm() OK");
    
    client2.leaveSwarm();
    LOGGER.info("leaveSwarm() OK");
    
    client1.leaveSwarm(true);
    LOGGER.info("leaveSwarm(true) OK");
    
    client1.close();
    client2.close();
    LOGGER.info("Finished!");
  }
```

And everything works fine.