### PR TITLE
Upgrade to jnr-unixsocket 0.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.8</version>
+      <version>0.18</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>

--- a/src/main/java/com/spotify/docker/client/ApacheUnixSocket.java
+++ b/src/main/java/com/spotify/docker/client/ApacheUnixSocket.java
@@ -36,6 +36,7 @@ import java.util.Queue;
 
 import jnr.unixsocket.UnixSocketAddress;
 import jnr.unixsocket.UnixSocketChannel;
+import jnr.unixsocket.UnixSocketOptions;
 
 /**
  * Provides a socket that wraps an jnr.unixsocket.UnixSocketChannel and delays setting options until
@@ -196,14 +197,22 @@ public class ApacheUnixSocket extends Socket {
     setSocketOption(new SocketOptionSetter() {
       @Override
       public void run() throws SocketException {
-        inner.setSoTimeout(timeout);
+        try {
+          inner.setOption(UnixSocketOptions.SO_RCVTIMEO, timeout);
+        } catch (IOException e) {
+          throw (SocketException)new SocketException().initCause(e);
+        }
       }
     });
   }
 
   @Override
   public synchronized int getSoTimeout() throws SocketException {
-    return inner.getSoTimeout();
+    try {
+      return inner.getOption(UnixSocketOptions.SO_RCVTIMEO);
+    } catch (IOException e) {
+      throw (SocketException)new SocketException().initCause(e);
+    }
   }
 
   @Override
@@ -231,14 +240,22 @@ public class ApacheUnixSocket extends Socket {
     setSocketOption(new SocketOptionSetter() {
       @Override
       public void run() throws SocketException {
-        inner.setKeepAlive(on);
+        try {
+          inner.setOption(UnixSocketOptions.SO_KEEPALIVE, on);
+        } catch (IOException e) {
+          throw (SocketException)new SocketException().initCause(e);
+        }
       }
     });
   }
 
   @Override
   public boolean getKeepAlive() throws SocketException {
-    return inner.getKeepAlive();
+    try {
+      return inner.getOption(UnixSocketOptions.SO_KEEPALIVE).booleanValue();
+    } catch (IOException e) {
+      throw (SocketException)new SocketException().initCause(e);
+    }
   }
 
   @Override


### PR DESCRIPTION
Upgrade to jnr-unixsocket-0.18.

Mapped socket timeout to receive socket timeout and follow same pattern is converting the checked IOException to SocketException
https://github.com/jnr/jnr-unixsocket/pull/35

Exception thrown when using dependency management to manage jnr-unixsocket to 0.18
```
Caused by: java.lang.NoSuchMethodError: jnr.unixsocket.UnixSocketChannel.setSoTimeout(I)V
	at com.spotify.docker.client.ApacheUnixSocket$1.run(ApacheUnixSocket.java:199)
	at com.spotify.docker.client.ApacheUnixSocket.setSocketOption(ApacheUnixSocket.java:144)
	at com.spotify.docker.client.ApacheUnixSocket.setSoTimeout(ApacheUnixSocket.java:196)
```