### PR TITLE
Swarm info

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/Info.java
+++ b/src/main/java/com/spotify/docker/client/messages/Info.java
@@ -190,7 +190,7 @@ public abstract class Info {
   
   @Nullable
   @JsonProperty("Swarm")
-  public abstract SwarmInfo swarn();
+  public abstract SwarmInfo swarm();
 
   @Nullable
   @JsonProperty("SystemStatus")

--- a/src/main/java/com/spotify/docker/client/messages/Info.java
+++ b/src/main/java/com/spotify/docker/client/messages/Info.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.spotify.docker.client.messages.swarm.SwarmInfo;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -186,6 +187,10 @@ public abstract class Info {
 
   @JsonProperty("SwapLimit")
   public abstract Boolean swapLimit();
+  
+  @Nullable
+  @JsonProperty("Swarm")
+  public abstract SwarmInfo swarn();
 
   @Nullable
   @JsonProperty("SystemStatus")
@@ -237,6 +242,7 @@ public abstract class Info {
       @JsonProperty("RegistryConfig") final RegistryConfig registryConfig,
       @JsonProperty("ServerVersion") final String serverVersion,
       @JsonProperty("SwapLimit") final Boolean swapLimit,
+      @JsonProperty("Swarm") final SwarmInfo swarm,
       @JsonProperty("SystemStatus") final List<List<String>> systemStatus,
       @JsonProperty("SystemTime") final Date systemTime) {
     final ImmutableList.Builder<ImmutableList<String>> driverStatusB = ImmutableList.builder();
@@ -259,7 +265,7 @@ public abstract class Info {
         httpProxy, httpsProxy, id, ipv4Forwarding, images, indexServerAddress, initPath, initSha1,
         kernelMemory, kernelVersion, labelsT, memTotal, memoryLimit, cpus, eventsListener,
         fileDescriptors, goroutines, name, noProxy, oomKillDisable, operatingSystem, osType,
-        plugins, registryConfig, serverVersion, swapLimit, systemStatusB.build(), systemTime);
+        plugins, registryConfig, serverVersion, swapLimit, swarm, systemStatusB.build(), systemTime);
   }
 
   @AutoValue

--- a/src/main/java/com/spotify/docker/client/messages/swarm/RemoteManager.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/RemoteManager.java
@@ -1,0 +1,47 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages.swarm;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public abstract class RemoteManager {
+
+  @JsonProperty("Addr")
+  public abstract String addr();
+
+  @JsonProperty("NodeID")
+  public abstract String nodeId();
+
+  @JsonCreator
+  static RemoteManager create(
+      @JsonProperty("Addr") final String addr,
+      @JsonProperty("NodeID") final String nodeId) {
+    return new AutoValue_RemoteManager(addr, nodeId);
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/SwarmCluster.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/SwarmCluster.java
@@ -1,0 +1,65 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages.swarm;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Date;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public abstract class SwarmCluster {
+
+  @JsonProperty("ID")
+  public abstract String id();
+
+  @JsonProperty("Version")
+  public abstract Version version();
+
+  @JsonProperty("CreatedAt")
+  public abstract Date createdAt();
+
+  @JsonProperty("UpdatedAt")
+  public abstract Date updatedAt();
+
+  @JsonProperty("Spec")
+  public abstract SwarmSpec swarmSpec();
+
+  @JsonCreator
+  static SwarmCluster create(
+      @JsonProperty("ID") final String id,
+      @JsonProperty("Version") final Version version,
+      @JsonProperty("CreatedAt") final Date createdAt,
+      @JsonProperty("UpdatedAt") final Date updatedAt,
+      @JsonProperty("Spec") final SwarmSpec swarmSpec) {
+    
+    return new AutoValue_SwarmCluster(id, version, createdAt, updatedAt, swarmSpec);
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/SwarmInfo.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/SwarmInfo.java
@@ -1,0 +1,73 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages.swarm;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import java.util.Date;
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public abstract class SwarmInfo {
+
+  @JsonProperty("Cluster")
+  public abstract SwarmCluster cluster();
+  
+  @JsonProperty("ControlAvailable")
+  public abstract boolean controlAvailable();
+
+  @JsonProperty("Error")
+  public abstract String error();
+
+  @JsonProperty("LocalNodeState")
+  public abstract String localNodeState();
+
+  @JsonProperty("NodeAddr")
+  public abstract String nodeAddr();
+
+  @JsonProperty("NodeID")
+  public abstract String nodeId();
+
+  @JsonProperty("Nodes")
+  public abstract int nodes();
+  
+  @JsonProperty("RemoteManagers")
+  public abstract ImmutableList<RemoteManager> remoteManagers();
+
+  @JsonCreator
+  static SwarmInfo create(
+      @JsonProperty("Cluster") final SwarmCluster cluster,
+      @JsonProperty("ControlAvailable") final boolean controlAvailable,
+      @JsonProperty("Error") final String error,
+      @JsonProperty("LocalNodeState") final String localNodeState,
+      @JsonProperty("NodeAddr") final String nodeAddr,
+      @JsonProperty("NodeID") final String nodeId,
+      @JsonProperty("Nodes") final int nodes,
+      @JsonProperty("RemoteManagers") final ImmutableList<RemoteManager> remoteManagers) {
+    return new AutoValue_SwarmInfo(cluster, controlAvailable, error, localNodeState, nodeAddr, nodeId, nodes, remoteManagers);
+  }
+}


### PR DESCRIPTION
When "docker info" is triggered from an Swarm Member, we get additional Swarm Info:
```
"Swarm": {
  "Cluster": {
    "CreatedAt": "2017-04-26T00:42:45.129252892Z",
    "ID": "sio7xsch1lxmk7sqctyb8v6ez",
    "Spec": {
      "CAConfig": {
        "NodeCertExpiry": 7776000000000000
      },
      "Dispatcher": {
        "HeartbeatPeriod": 5000000000
      },
      "EncryptionConfig": {
        "AutoLockManagers": false
      },
      "Name": "default",
      "Orchestration": {
        "TaskHistoryRetentionLimit": 5
      },
      "Raft": {
        "ElectionTick": 3,
        "HeartbeatTick": 1,
        "KeepOldSnapshots": 0,
        "LogEntriesForSlowFollowers": 500,
        "SnapshotInterval": 10000
      },
      "TaskDefaults": {}
    },
    "UpdatedAt": "2017-05-02T03:43:59.806823885Z",
    "Version": {
      "Index": 8662
    }
  },
  "ControlAvailable": true,
  "Error": "",
  "LocalNodeState": "active",
  "Managers": 1,
  "NodeAddr": "192.168.99.100",
  "NodeID": "pax308nh6wnw02q4st7c1kpnc",
  "Nodes": 2,
  "RemoteManagers": [
    {
      "Addr": "192.168.99.100:2377",
      "NodeID": "pax308nh6wnw02q4st7c1kpnc"
    }
  ]
}
}
```

Quick and dirty test:
```
DockerClient client = DefaultDockerClient.builder()
        .uri("https://192.168.99.100:2376")
        .dockerCertificates(new DockerCertificates(Paths.get("/Users/tiago/.docker/machine/certs/")))
        .build();
    
    Info info = client.info();
    System.out.println(info.swarm());



