### PR TITLE
Fix testListTaskWithCriteria

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -5290,7 +5290,9 @@ public class DefaultDockerClientTest {
     sut.createService(spec);
     await().until(numberOfTasks(sut), is(greaterThan(0)));
 
-    final Task task = sut.listTasks().get(1);
+    final Task transientTask = sut.listTasks().get(1);
+    await().until(taskState(transientTask.id(), sut), is(transientTask.desiredState()));
+    final Task task = sut.inspectTask(transientTask.id());
 
     final List<Task> tasksWithId = sut.listTasks(Task.find().taskId(task.id()).build());
     assertThat(tasksWithId.size(), is(1));
@@ -5510,6 +5512,15 @@ public class DefaultDockerClientTest {
     return new Callable<Integer>() {
       public Integer call() throws Exception {
         return client.listTasks().size();
+      }
+    };
+  }
+
+  private Callable<String> taskState(final String taskId,
+                                     final DockerClient client) {
+    return new Callable<String>() {
+      public String call() throws Exception {
+        return client.inspectTask(taskId).status().state();
       }
     };
   }


### PR DESCRIPTION
#### BACKGROUND
I saw #734 had failed, and checked out the build. Here is the failure from Travis [Job #1345.4](https://travis-ci.org/spotify/docker-client/jobs/228296329):
```
testListTaskWithCriteria(com.spotify.docker.client.DefaultDockerClientTest)  Time elapsed: 0.295 sec  <<< FAILURE!
java.lang.AssertionError: 
Expected: <Task{id=1xyk6beukidfs4lm3tc6bzf66, version=Version{index=58}, createdAt=Wed May 03 11:35:35 UTC 2017, updatedAt=Wed May 03 11:35:35 UTC 2017, name=null, labels=null, spec=TaskSpec{containerSpec=ContainerSpec{image=alpine, hostname=null, labels={}, command=[ping, -c1000, localhost], args=null, env=null, dir=null, user=null, groups=null, tty=null, mounts=null, stopGracePeriod=null, healthcheck=null, hosts=null, secrets=null, dnsConfig=null}, resources=null, restartPolicy=null, placement=null, networks=null, logDriver=null}, serviceId=4j96onqaill1rcoz20wkyvpy5, slot=1, nodeId=9srg7nkwlb7w2wmjyehr6neni, status=TaskStatus{timestamp=2017-05-03T11:35:35.568067532Z, state=assigned, message=scheduler assigned task to node, err=null, containerStatus=ContainerStatus{containerId=null, pid=null, exitCode=null}}, desiredState=running, networkAttachments=null}>
     but: was <Task{id=1xyk6beukidfs4lm3tc6bzf66, version=Version{index=59}, createdAt=Wed May 03 11:35:35 UTC 2017, updatedAt=Wed May 03 11:35:35 UTC 2017, name=null, labels=null, spec=TaskSpec{containerSpec=ContainerSpec{image=alpine, hostname=null, labels={}, command=[ping, -c1000, localhost], args=null, env=null, dir=null, user=null, groups=null, tty=null, mounts=null, stopGracePeriod=null, healthcheck=null, hosts=null, secrets=null, dnsConfig=null}, resources=null, restartPolicy=null, placement=null, networks=null, logDriver=null}, serviceId=4j96onqaill1rcoz20wkyvpy5, slot=1, nodeId=9srg7nkwlb7w2wmjyehr6neni, status=TaskStatus{timestamp=2017-05-03T11:35:35.638503647Z, state=preparing, message=preparing, err=null, containerStatus=ContainerStatus{containerId=null, pid=null, exitCode=null}}, desiredState=running, networkAttachments=null}>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:956)
	at org.junit.Assert.assertThat(Assert.java:923)
	at com.spotify.docker.client.DefaultDockerClientTest.testListTaskWithCriteria(DefaultDockerClientTest.java:5297)
        ...
```

We have seen many failures like this with `Task` tests, and I wanted to figure out the cause of this one and fix it.

#### INVESTIGATION
Of particular note are the `status`es of the two `Task`s, which are different. In addition to the timestamps being different, the `Task` that we had grabbed at the beginning of the test had `status.state=assigned`, and the `Task` that we got from the criteria had `status.state=preparing`. But both `Task`s have `desiredState=running`.

#### FIX
What we want to test here is that we can take any old `Task` that is lying around and use `listTasks(Criteria)` to get back the same `Task`. It is important, though, that the `Task` be stable and not change between when we first pick out our example and when we go ask for `Task`s that match the `Criteria`. 

When we first get any old `Task`, it may be in a transient state. The test should wait until that `Task` is in its desired state, in this case `running`. That way we can be assured that it will remain in that state for the duration of the test. Then once the `Task` is in the right state, we can get the example `Task` object to compare with the results of the various `listTask(Criteria)` calls.