### PR TITLE
[travis] Fix a frequent test failure

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -44,6 +44,26 @@ case "$1" in
     # installing the package
     sudo restart docker
 
+    # Check if docker is ready up to a certain number of times
+    retries=0
+    max_retries=10
+    while true ; do
+      let "retries++"
+      if [ "$retries" -gt "$max_retries" ]; then
+        echo 'Exceeded number of retries.'
+        exit 1
+      fi
+
+      echo 'Checking docker is ready.'
+      if docker ps; then
+          echo 'Docker is ready.'
+          break
+      else
+        echo 'Docker is not ready yet. Sleeping and checking again.'
+        sleep 2
+      fi
+    done
+
     if [[ "$ENABLE_SWARM" = "1"  ]]; then
         # initialize docker swarm to be able to run docker tests
         sudo docker swarm init --advertise-addr 127.0.0.1

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 if [[ -z $1 ]]; then
   "I need a command!"
@@ -48,7 +48,7 @@ case "$1" in
     retries=0
     max_retries=10
     while true ; do
-      let "retries++"
+      retries=$((retries+1))
       if [ "$retries" -gt "$max_retries" ]; then
         echo 'Exceeded number of retries.'
         exit 1


### PR DESCRIPTION
caused by docker not being ready yet.

Travis builds often fail because the docker daemon
isn't running after we restart it. Sleep to give it some
time to restart.