### PR TITLE
remove DockerClient methods with unused RegistryAuth parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 8.5.0
+
+### Removal of deprecated methods
+Previously deprecated DockerClient methods that have a RegistryAuth parameter
+but never used the value were removed. These methods are:
+
+- `load(String, InputStream, RegistryAuth)`
+- `load(String, InputStream, RegistryAuth, ProgressHandler)`
+- `save(String, RegistryAuth)`
+
 ## 7.0.0
 
 ### Breaking changes

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>docker-client</artifactId>
-  <version>8.4.1-SNAPSHOT</version>
+  <version>8.5.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>docker-client</name>
   <description>A docker client</description>

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -128,7 +128,6 @@ import java.net.URLEncoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1081,27 +1080,11 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   @Override
   @Deprecated
   public void load(final String image, final InputStream imagePayload,
-                   final RegistryAuth registryAuth)
-      throws DockerException, InterruptedException {
-    create(image, imagePayload);
-  }
-
-  @Override
-  @Deprecated
-  public void load(final String image, final InputStream imagePayload,
                    final ProgressHandler handler)
       throws DockerException, InterruptedException {
     create(image, imagePayload, handler);
   }
 
-  @Override
-  @Deprecated
-  public void load(final String image, final InputStream imagePayload,
-                   final RegistryAuth registryAuth, final ProgressHandler handler)
-      throws DockerException, InterruptedException {
-    create(image, imagePayload, handler);
-  }
-  
   @Override
   public Set<String> load(final InputStream imagePayload)
       throws DockerException, InterruptedException {
@@ -1184,13 +1167,6 @@ public class DefaultDockerClient implements DockerClient, Closeable {
         InputStream.class,
         resource,
         resource.request(APPLICATION_JSON_TYPE));
-  }
-
-  @Override
-  @Deprecated
-  public InputStream save(final String image, final RegistryAuth registryAuth)
-      throws DockerException, IOException, InterruptedException {
-    return save(image);
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -283,47 +283,6 @@ public interface DockerClient extends Closeable {
   void load(String image, InputStream imagePayload, ProgressHandler handler)
       throws DockerException, InterruptedException;
 
-
-  /**
-   * Creates a single image from a tarball. This method also tags the image
-   * with the given image name upon loading completion.
-   *
-   * @param image        the name to assign to the image.
-   * @param imagePayload the image's payload (i.e.: the stream corresponding to the image's .tar
-   *                     file).
-   * @param registryAuth the {@link RegistryAuth} needed to pull the image.
-   * @throws DockerException      if a server error occurred (500).
-   * @throws InterruptedException if the thread is interrupted.
-   *
-   * @deprecated Use {@link #load(InputStream)} to load a set of image layers from a tarball. Use
-   * {@link #create(String, InputStream)} to create a single image from the contents of a tarball.
-   */
-  @Deprecated
-  void load(String image, InputStream imagePayload, RegistryAuth registryAuth)
-      throws DockerException, InterruptedException;
-
-
-  /**
-   * Creates a single image from a tarball. This method also tags the image
-   * with the given image name upon loading completion.
-   *
-   * @param image        the name to assign to the image.
-   * @param imagePayload the image's payload (i.e.: the stream corresponding to the image's .tar
-   *                     file).
-   * @param registryAuth the {@link RegistryAuth} needed to pull the image.
-   * @param handler      The handler to use for processing each progress message received from
-   *                     Docker.
-   * @throws DockerException      if a server error occurred (500).
-   * @throws InterruptedException if the thread is interrupted.
-   *
-   * @deprecated Use {@link #load(InputStream)} to load a set of image layers from a tarball. Use
-   *             {@link #create(String, InputStream, ProgressHandler)} to create a single image from
-   *             the contents of a tarball.
-   */
-  @Deprecated
-  void load(String image, InputStream imagePayload, RegistryAuth registryAuth,
-            ProgressHandler handler) throws DockerException, InterruptedException;
-
   /**
    * Load a set of images and tags from a tarball.
    *
@@ -391,26 +350,6 @@ public interface DockerClient extends Closeable {
    * @throws InterruptedException if the thread is interrupted.
    */
   InputStream save(String... images) throws DockerException, IOException, InterruptedException;
-
-  /**
-   * Get a tarball containing all images and metadata for the repository specified.
-   * @param image the name or id of the image to save. If a specific name and tag
-   *              (e.g. ubuntu:latest), then only that image (and its parents) are returned.
-   *              If an image ID, similarly only that image (and its parents) are returned,
-   *              but with the exclusion of the 'repositories' file in the tarball,
-   *              as there were no image names referenced.
-   * @param registryAuth the {@link RegistryAuth} needed to pull the image.
-   * @return the image's .tar stream.
-   * @throws DockerException      if a server error occurred (500).
-   * @throws IOException          if the server started returning, but an I/O error occurred in the
-   *                              context of processing it on the client-side.
-   * @throws InterruptedException if the thread is interrupted.
-   *
-   * @deprecated RegistryAuth is not required. Use {@link #save(String...)}.
-   */
-  @Deprecated
-  InputStream save(String image, RegistryAuth registryAuth)
-      throws DockerException, IOException, InterruptedException;
 
   /**
    * Get a tarball containing all images and metadata for one or more repositories.


### PR DESCRIPTION
There are several overloads of the `load()` and `save()` methods in the
`DockerClient` interface that has a `RegistryAuth` parameter that is
never used in the DefaultDockerClient implementation.

This change removes those methods as they don't serve any purpose (and
have been marked as deprecated for a while).