### PR TITLE
Testing 1s sleep to clean out event stream

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -2090,6 +2090,7 @@ public class DefaultDockerClientTest {
 
     requireDockerApiVersionNot("1.19", "Docker 1.7.x has a bug that breaks DockerClient.events(). "
                                        + "So we skip this test.");
+    Thread.sleep(1000); // Waiting to ensure event stream has no events from prior tests
     try (final EventStream eventStream = getImageAndContainerEventStream()) {
 
       final String containerName = randomName();


### PR DESCRIPTION
Attempt to fix flaky test pointed out in #749.