### PR TITLE
add RegistryAuthSupplier interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 8.6.0 (not yet released)
+
+### Revamped support for authentication
+This version introduces a new way to configure DefaultDockerClient to use
+authentication - the RegistryAuthSupplier interface.
+
+Historically, a single RegistryAuth instance was configured in
+DefaultDockerClient at construction-time and the instance would be used
+throughout the lifetime of the DefaultDockerClient instance. Many of the static
+factory methods in the RegistryAuth class would use the first auth element
+found in the docker client config file, and a DefaultDockerClient configured
+with `dockerAuth(true)` would have this behavior enabled by default.
+
+Inspired by a desire to be able to integrate with pushing and pulling images to
+Google Container Registry (where the docker client config file contains
+short-lived access tokens), the previous behavior has been removed and is
+replaced by RegistryAuthSupplier. DefaultDockerClient will now invoke the
+appropriate method on the configured RegistryAuthSupplier instance before each
+API operation that requires authentication. This allows for use of
+authentication info that is dynamic and changes during the lifetime of the
+DefaultDockerClient instance.
+
+The docker-client library contains an implementation of this interface that
+returns static RegistryAuth instances (NoOpRegistryAuthSupplier, which is
+configured for you if you use the old method `registryAuth(RegistryAuth)` in
+DefaultDockerClient.Builder) and an implementation for refreshing GCR access
+tokens with `gcloud docker -a`. We suggest that users implement this interface
+themselves if there is a need to customize the behavior.
+
+The new class DockerConfigReader replaces the static factory methods from
+RegistryAuth.
+
+The following methods are deprecated and will be removed in a future release:
+- DefaultDockerClient.Builder.registryAuth(RegistryAuth)
+- all overloads of RegistryAuth.fromDockerConfig(...)
+
+[740](https://github.com/spotify/docker-client/issues/740), [759](https://github.com/spotify/docker-client/pull/759)
+
 ## 8.5.0 (released May 18 2017)
 
 ### Removal of deprecated methods

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,11 @@
       <version>1.9</version>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>docker-client</artifactId>
-  <version>8.5.1-SNAPSHOT</version>
+  <version>8.6.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>docker-client</name>
   <description>A docker client</description>

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -97,6 +97,7 @@ import com.spotify.docker.client.messages.NetworkConnection;
 import com.spotify.docker.client.messages.NetworkCreation;
 import com.spotify.docker.client.messages.ProgressMessage;
 import com.spotify.docker.client.messages.RegistryAuth;
+import com.spotify.docker.client.messages.RegistryAuthSupplier;
 import com.spotify.docker.client.messages.RegistryConfigs;
 import com.spotify.docker.client.messages.RemovedImage;
 import com.spotify.docker.client.messages.ServiceCreateResponse;
@@ -324,7 +325,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
 
   private final URI uri;
   private final String apiVersion;
-  private final RegistryAuth registryAuth;
+  private final RegistryAuthSupplier registryAuthSupplier;
 
   private final Map<String, Object> headers;
 
@@ -398,7 +399,12 @@ public class DefaultDockerClient implements DockerClient, Closeable {
         .property(ApacheClientProperties.CONNECTION_MANAGER, cm)
         .property(ApacheClientProperties.REQUEST_CONFIG, requestConfig);
 
-    this.registryAuth = builder.registryAuth;
+
+    if (builder.registryAuthSupplier == null) {
+      this.registryAuthSupplier = new NoOpRegistryAuthSupplier(null);
+    } else {
+      this.registryAuthSupplier = builder.registryAuthSupplier;
+    }
 
     this.client = ClientBuilder.newBuilder()
         .withConfig(config)
@@ -1165,17 +1171,16 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       throws DockerException, IOException, InterruptedException {
 
     final WebTarget resource = resource().path("images").path("get");
-    if (images != null) {
-      for (final String image : images) {
-        resource.queryParam("names", urlEncode(image));
-      }
+    for (final String image : images) {
+      resource.queryParam("names", urlEncode(image));
     }
 
     return request(
         GET,
         InputStream.class,
         resource,
-        resource.request(APPLICATION_JSON_TYPE).header("X-Registry-Auth", authHeader(registryAuth))
+        resource.request(APPLICATION_JSON_TYPE).header("X-Registry-Auth", authHeader(
+            registryAuthSupplier.authFor(images[0])))
     );
   }
 
@@ -1187,7 +1192,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   @Override
   public void pull(final String image, final ProgressHandler handler)
       throws DockerException, InterruptedException {
-    pull(image, registryAuth, handler);
+    pull(image, registryAuthSupplier.authFor(image), handler);
   }
 
   @Override
@@ -1241,7 +1246,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   @Override
   public void push(final String image, final ProgressHandler handler)
       throws DockerException, InterruptedException {
-    push(image, handler, registryAuth);
+    push(image, handler, registryAuthSupplier.authFor(image));
   }
 
   @Override
@@ -1349,6 +1354,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
 
     WebTarget resource = noTimeoutResource().path("build");
 
+    final RegistryAuth registryAuth = registryAuthSupplier.authFor(name);
     for (final BuildParam param : params) {
       resource = resource.queryParam(param.name(), param.value());
     }
@@ -1784,8 +1790,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   @Override
   public ServiceCreateResponse createService(ServiceSpec spec)
       throws DockerException, InterruptedException {
-
-    return createService(spec, registryAuth);
+    return createService(spec, registryAuthSupplier.authForSwarm());
   }
 
   @Override
@@ -2514,6 +2519,10 @@ public class DefaultDockerClient implements DockerClient, Closeable {
 
   public static class Builder {
 
+    public static final String ERROR_MESSAGE =
+        "LOGIC ERROR: DefaultDockerClient does not support being built "
+        + "with both `registryAuth` and `registryAuthSupplier`. "
+        + "Please build with at most one of these options.";
     private URI uri;
     private String apiVersion;
     private long connectTimeoutMillis = DEFAULT_CONNECT_TIMEOUT_MILLIS;
@@ -2522,6 +2531,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     private DockerCertificatesStore dockerCertificatesStore;
     private boolean dockerAuth;
     private RegistryAuth registryAuth;
+    private RegistryAuthSupplier registryAuthSupplier;
     private Map<String, Object> headers = new HashMap<>();
 
     public URI uri() {
@@ -2647,9 +2657,24 @@ public class DefaultDockerClient implements DockerClient, Closeable {
      *
      * @param registryAuth RegistryAuth object
      * @return Builder
+     *
+     * @deprecated in favor of registryAuthSupplier
      */
+    @Deprecated
     public Builder registryAuth(final RegistryAuth registryAuth) {
+      if (this.registryAuthSupplier != null) {
+        throw new IllegalStateException(ERROR_MESSAGE);
+      }
       this.registryAuth = registryAuth;
+      this.registryAuthSupplier = new NoOpRegistryAuthSupplier(registryAuth);
+      return this;
+    }
+
+    public Builder registryAuthSupplier(final RegistryAuthSupplier registryAuthSupplier) {
+      if (this.registryAuthSupplier != null) {
+        throw new IllegalStateException(ERROR_MESSAGE);
+      }
+      this.registryAuthSupplier = registryAuthSupplier;
       return this;
     }
 

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -2631,7 +2631,9 @@ public class DefaultDockerClient implements DockerClient, Closeable {
      *
      * @param dockerAuth tells if Docker auth info should be used
      * @return Builder
+     * @deprecated in favor of {@link #registryAuthSupplier(RegistryAuthSupplier)}
      */
+    @Deprecated
     public Builder dockerAuth(final boolean dockerAuth) {
       this.dockerAuth = dockerAuth;
       return this;
@@ -2647,7 +2649,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
      * @param registryAuth RegistryAuth object
      * @return Builder
      *
-     * @deprecated in favor of registryAuthSupplier
+     * @deprecated in favor of {@link #registryAuthSupplier(RegistryAuthSupplier)}
      */
     @Deprecated
     public Builder registryAuth(final RegistryAuth registryAuth) {
@@ -2677,9 +2679,9 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     }
 
     public DefaultDockerClient build() {
-      if (dockerAuth) {
+      if (dockerAuth && registryAuthSupplier == null && registryAuth == null) {
         try {
-          this.registryAuth = RegistryAuth.fromDockerConfig().build();
+          registryAuth(RegistryAuth.fromDockerConfig().build());
         } catch (IOException e) {
           log.warn("Unable to use Docker auth info", e);
         }

--- a/src/main/java/com/spotify/docker/client/DockerConfigReader.java
+++ b/src/main/java/com/spotify/docker/client/DockerConfigReader.java
@@ -1,0 +1,117 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.docker.client.messages.RegistryAuth;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import org.glassfish.jersey.internal.util.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DockerConfigReader {
+  private static final Logger LOG = LoggerFactory.getLogger(DockerConfigReader.class);
+
+  private static final ObjectMapper MAPPER = ObjectMapperProvider.objectMapper();
+
+
+  public RegistryAuth fromComfig(Path configPath, String serverAddress) throws IOException {
+    return parseDockerConfig(configPath, serverAddress).build();
+  }
+
+  public RegistryAuth.Builder parseDockerConfig(final Path configPath, String serverAddress)
+      throws IOException {
+    checkNotNull(configPath);
+    final RegistryAuth.Builder authBuilder = RegistryAuth.builder();
+    final JsonNode authJson = this.extractAuthJson(configPath);
+
+    if (isNullOrEmpty(serverAddress)) {
+      final Iterator<String> servers = authJson.fieldNames();
+      if (servers.hasNext()) {
+        serverAddress = servers.next();
+      }
+    } else {
+      if (!authJson.has(serverAddress)) {
+        LOG.error("Could not find auth config for {}. Returning empty builder", serverAddress);
+        return RegistryAuth.builder().serverAddress(serverAddress);
+      }
+    }
+
+    final JsonNode serverAuth = authJson.get(serverAddress);
+    if (serverAuth != null && serverAuth.has("auth")) {
+      authBuilder.serverAddress(serverAddress);
+      final String authString = serverAuth.get("auth").asText();
+      final String[] authParams = Base64.decodeAsString(authString).split(":");
+
+      if (authParams.length == 2) {
+        authBuilder.username(authParams[0].trim());
+        authBuilder.password(authParams[1].trim());
+      } else if (serverAuth.has("identityToken")) {
+        authBuilder.identityToken(serverAuth.get("identityToken").asText());
+        return authBuilder;
+      } else {
+        LOG.warn("Failed to parse auth string for {}", serverAddress);
+        return authBuilder;
+      }
+    } else {
+      LOG.warn("Could not find auth field for {}", serverAddress);
+      return authBuilder;
+    }
+
+    if (serverAuth.has("email")) {
+      authBuilder.email(serverAuth.get("email").asText());
+    }
+
+    return authBuilder;
+  }
+
+  public Path defaultConfigPath() {
+    final String home = System.getProperty("user.home");
+    final Path dockerConfig = Paths.get(home, ".docker", "config.json");
+    final Path dockerCfg = Paths.get(home, ".dockercfg");
+
+    if (Files.exists(dockerConfig)) {
+      LOG.debug("Using configfile: {}", dockerConfig);
+      return dockerConfig;
+    } else {
+      LOG.debug("Using configfile: {} ", dockerCfg);
+      return dockerCfg;
+    }
+  }
+
+  public JsonNode extractAuthJson(final Path configPath) throws IOException {
+    final JsonNode config = MAPPER.readTree(configPath.toFile());
+
+    if (config.has("auths")) {
+      return config.get("auths");
+    }
+
+    return config;
+  }
+}

--- a/src/main/java/com/spotify/docker/client/NoOpRegistryAuthSupplier.java
+++ b/src/main/java/com/spotify/docker/client/NoOpRegistryAuthSupplier.java
@@ -23,6 +23,7 @@ package com.spotify.docker.client;
 import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.messages.RegistryAuth;
 import com.spotify.docker.client.messages.RegistryAuthSupplier;
+import com.spotify.docker.client.messages.RegistryConfigs;
 
 /**
  * Wraps a RegistryAuth with the RegistryAuthSupplier interface.
@@ -30,14 +31,17 @@ import com.spotify.docker.client.messages.RegistryAuthSupplier;
 public class NoOpRegistryAuthSupplier implements RegistryAuthSupplier {
 
   private final RegistryAuth registryAuth;
+  private final RegistryConfigs configsForBuild;
 
-  public NoOpRegistryAuthSupplier(RegistryAuth registryAuth) {
+  public NoOpRegistryAuthSupplier(final RegistryAuth registryAuth,
+                                  final RegistryConfigs configsForBuild) {
     this.registryAuth = registryAuth;
+    this.configsForBuild = configsForBuild;
   }
 
   public NoOpRegistryAuthSupplier() {
     registryAuth = null;
-
+    configsForBuild = null;
   }
 
   @Override
@@ -50,4 +54,8 @@ public class NoOpRegistryAuthSupplier implements RegistryAuthSupplier {
     return registryAuth;
   }
 
+  @Override
+  public RegistryConfigs authForBuild() {
+    return configsForBuild;
+  }
 }

--- a/src/main/java/com/spotify/docker/client/NoOpRegistryAuthSupplier.java
+++ b/src/main/java/com/spotify/docker/client/NoOpRegistryAuthSupplier.java
@@ -1,0 +1,53 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client;
+
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.RegistryAuth;
+import com.spotify.docker.client.messages.RegistryAuthSupplier;
+
+/**
+ * Wraps a RegistryAuth with the RegistryAuthSupplier interface.
+ */
+public class NoOpRegistryAuthSupplier implements RegistryAuthSupplier {
+
+  private final RegistryAuth registryAuth;
+
+  public NoOpRegistryAuthSupplier(RegistryAuth registryAuth) {
+    this.registryAuth = registryAuth;
+  }
+
+  public NoOpRegistryAuthSupplier() {
+    registryAuth = null;
+
+  }
+
+  @Override
+  public RegistryAuth authFor(String imageName) throws DockerException {
+    return registryAuth;
+  }
+
+  @Override
+  public RegistryAuth authForSwarm() {
+    return registryAuth;
+  }
+
+}

--- a/src/main/java/com/spotify/docker/client/gcr/GCloudProcess.java
+++ b/src/main/java/com/spotify/docker/client/gcr/GCloudProcess.java
@@ -1,0 +1,31 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.gcr;
+
+import java.io.IOException;
+
+public class GCloudProcess {
+
+  public Process runGcloudDocker() throws IOException {
+    return Runtime.getRuntime().exec("gcloud docker -a");
+  }
+
+}

--- a/src/main/java/com/spotify/docker/client/gcr/GoogleContainerRegistryAuthSupplier.java
+++ b/src/main/java/com/spotify/docker/client/gcr/GoogleContainerRegistryAuthSupplier.java
@@ -1,0 +1,67 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.gcr;
+
+import com.spotify.docker.client.DockerConfigReader;
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.RegistryAuth;
+import com.spotify.docker.client.messages.RegistryAuthSupplier;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.apache.commons.lang.NotImplementedException;
+
+public class GoogleContainerRegistryAuthSupplier implements RegistryAuthSupplier {
+
+  private final DockerConfigReader dockerCfgReader;
+  private final GoogleContainerRegistryCredRefresher googleContainerRegistryCredRefresher;
+  private final Path configPath;
+
+  public GoogleContainerRegistryAuthSupplier() {
+    this(new DockerConfigReader(),
+        new GoogleContainerRegistryCredRefresher(new GCloudProcess()),
+        new DockerConfigReader().defaultConfigPath());
+  }
+
+  public GoogleContainerRegistryAuthSupplier(DockerConfigReader dockerCfgReader,
+                                             GoogleContainerRegistryCredRefresher
+                                                 googleContainerRegistryCredRefresher,
+                                             Path configPath) {
+    this.dockerCfgReader = dockerCfgReader;
+    this.googleContainerRegistryCredRefresher = googleContainerRegistryCredRefresher;
+    this.configPath = configPath;
+  }
+
+  @Override
+  public RegistryAuth authFor(String imageName) throws DockerException {
+    try {
+      String registryName = "https://" + imageName.split("/")[0];
+      googleContainerRegistryCredRefresher.refresh();
+      return dockerCfgReader.fromComfig(configPath, registryName);
+    } catch (IOException ex) {
+      throw new DockerException(ex);
+    }
+  }
+
+  @Override
+  public RegistryAuth authForSwarm() {
+    throw new NotImplementedException();
+  }
+}

--- a/src/main/java/com/spotify/docker/client/gcr/GoogleContainerRegistryAuthSupplier.java
+++ b/src/main/java/com/spotify/docker/client/gcr/GoogleContainerRegistryAuthSupplier.java
@@ -24,14 +24,15 @@ import com.spotify.docker.client.DockerConfigReader;
 import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.messages.RegistryAuth;
 import com.spotify.docker.client.messages.RegistryAuthSupplier;
+import com.spotify.docker.client.messages.RegistryConfigs;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.apache.commons.lang.NotImplementedException;
 
 public class GoogleContainerRegistryAuthSupplier implements RegistryAuthSupplier {
 
-  private final DockerConfigReader dockerCfgReader;
-  private final GoogleContainerRegistryCredRefresher googleContainerRegistryCredRefresher;
+  private final DockerConfigReader reader;
+  private final GoogleContainerRegistryCredRefresher refresher;
   private final Path configPath;
 
   public GoogleContainerRegistryAuthSupplier() {
@@ -40,12 +41,12 @@ public class GoogleContainerRegistryAuthSupplier implements RegistryAuthSupplier
         new DockerConfigReader().defaultConfigPath());
   }
 
-  public GoogleContainerRegistryAuthSupplier(DockerConfigReader dockerCfgReader,
-                                             GoogleContainerRegistryCredRefresher
-                                                 googleContainerRegistryCredRefresher,
-                                             Path configPath) {
-    this.dockerCfgReader = dockerCfgReader;
-    this.googleContainerRegistryCredRefresher = googleContainerRegistryCredRefresher;
+  public GoogleContainerRegistryAuthSupplier(
+      final DockerConfigReader reader,
+      final GoogleContainerRegistryCredRefresher refresher,
+      final Path configPath) {
+    this.reader = reader;
+    this.refresher = refresher;
     this.configPath = configPath;
   }
 
@@ -53,8 +54,8 @@ public class GoogleContainerRegistryAuthSupplier implements RegistryAuthSupplier
   public RegistryAuth authFor(String imageName) throws DockerException {
     try {
       String registryName = "https://" + imageName.split("/")[0];
-      googleContainerRegistryCredRefresher.refresh();
-      return dockerCfgReader.fromComfig(configPath, registryName);
+      refresher.refresh();
+      return reader.fromConfig(configPath, registryName);
     } catch (IOException ex) {
       throw new DockerException(ex);
     }
@@ -63,5 +64,15 @@ public class GoogleContainerRegistryAuthSupplier implements RegistryAuthSupplier
   @Override
   public RegistryAuth authForSwarm() {
     throw new NotImplementedException();
+  }
+
+  @Override
+  public RegistryConfigs authForBuild() throws DockerException {
+    try {
+      refresher.refresh();
+      return reader.fromConfig(reader.defaultConfigPath());
+    } catch (IOException ex) {
+      throw new DockerException(ex);
+    }
   }
 }

--- a/src/main/java/com/spotify/docker/client/gcr/GoogleContainerRegistryCredRefresher.java
+++ b/src/main/java/com/spotify/docker/client/gcr/GoogleContainerRegistryCredRefresher.java
@@ -1,0 +1,47 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.gcr;
+
+import com.spotify.docker.client.gcr.GCloudProcess;
+import java.io.IOException;
+import org.apache.commons.io.IOUtils;
+
+public class GoogleContainerRegistryCredRefresher {
+
+  private final GCloudProcess gcloudProcess;
+
+  public GoogleContainerRegistryCredRefresher(GCloudProcess gcloudProcess) {
+    this.gcloudProcess = gcloudProcess;
+  }
+
+  public void refresh() throws IOException {
+    Process process = gcloudProcess.runGcloudDocker();
+    try {
+      if (process.waitFor() != 0) {
+        throw new IOException(IOUtils.toString(process.getErrorStream(), "UTF-8"));
+      }
+    } catch (InterruptedException ex) {
+      throw new IOException(ex);
+    }
+
+  }
+
+}

--- a/src/main/java/com/spotify/docker/client/messages/RegistryAuth.java
+++ b/src/main/java/com/spotify/docker/client/messages/RegistryAuth.java
@@ -23,26 +23,21 @@ package com.spotify.docker.client.messages;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Strings.isNullOrEmpty;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
+import com.spotify.docker.client.DockerConfigReader;
 import com.spotify.docker.client.ObjectMapperProvider;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Iterator;
 
 import javax.annotation.Nullable;
 
-import org.glassfish.jersey.internal.util.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,10 +94,13 @@ public abstract class RegistryAuth {
    *
    * @return a {@link Builder}
    * @throws IOException when we can't parse the docker config file
+   * @deprecated in favor of registryAuthSupplier
    */
+  @Deprecated
   @SuppressWarnings("unused")
   public static Builder fromDockerConfig() throws IOException {
-    return parseDockerConfig(defaultConfigPath(), null);
+    DockerConfigReader dockerCfgReader = new DockerConfigReader();
+    return dockerCfgReader.fromComfig(dockerCfgReader.defaultConfigPath(), null).toBuilder();
   }
 
   /**
@@ -116,7 +114,9 @@ public abstract class RegistryAuth {
    */
   @SuppressWarnings("unused")
   public static Builder fromDockerConfig(final String serverAddress) throws IOException {
-    return parseDockerConfig(defaultConfigPath(), serverAddress);
+    DockerConfigReader dockerCfgReader = new DockerConfigReader();
+    return dockerCfgReader
+        .fromComfig(dockerCfgReader.defaultConfigPath(), serverAddress).toBuilder();
   }
 
   /**
@@ -129,7 +129,8 @@ public abstract class RegistryAuth {
    */
   @VisibleForTesting
   static Builder fromDockerConfig(final Path configPath) throws IOException {
-    return parseDockerConfig(configPath, null);
+    DockerConfigReader dockerCfgReader = new DockerConfigReader();
+    return dockerCfgReader.fromComfig(configPath, null).toBuilder();
   }
 
   /**
@@ -144,81 +145,10 @@ public abstract class RegistryAuth {
   @VisibleForTesting
   static Builder fromDockerConfig(final Path configPath, final String serverAddress)
       throws IOException {
-    return parseDockerConfig(configPath, serverAddress);
+    DockerConfigReader dockerConfigReader = new DockerConfigReader();
+    return dockerConfigReader.fromComfig(configPath, serverAddress).toBuilder();
   }
 
-  private static Path defaultConfigPath() {
-    final String home = System.getProperty("user.home");
-    final Path dockerConfig = Paths.get(home, ".docker", "config.json");
-    final Path dockerCfg = Paths.get(home, ".dockercfg");
-
-    if (Files.exists(dockerConfig)) {
-      LOG.debug("Using configfile: {}", dockerConfig);
-      return dockerConfig;
-    } else if (Files.exists(dockerCfg)) {
-      LOG.debug("Using configfile: {} ", dockerCfg);
-      return dockerCfg;
-    } else {
-      throw new RuntimeException(
-          "Could not find a docker config. Please run 'docker login' to create one");
-    }
-  }
-
-  private static RegistryAuth.Builder parseDockerConfig(final Path configPath, String serverAddress)
-      throws IOException {
-    checkNotNull(configPath);
-    final RegistryAuth.Builder authBuilder = RegistryAuth.builder();
-    final JsonNode authJson = extractAuthJson(configPath);
-
-    if (isNullOrEmpty(serverAddress)) {
-      final Iterator<String> servers = authJson.fieldNames();
-      if (servers.hasNext()) {
-        serverAddress = servers.next();
-      }
-    } else {
-      if (!authJson.has(serverAddress)) {
-        LOG.error("Could not find auth config for {}. Returning empty builder", serverAddress);
-        return RegistryAuth.builder().serverAddress(serverAddress);
-      }
-    }
-
-    final JsonNode serverAuth = authJson.get(serverAddress);
-    if (serverAuth != null && serverAuth.has("auth")) {
-      authBuilder.serverAddress(serverAddress);
-      final String authString = serverAuth.get("auth").asText();
-      final String[] authParams = Base64.decodeAsString(authString).split(":");
-
-      if (authParams.length == 2) {
-        authBuilder.username(authParams[0].trim());
-        authBuilder.password(authParams[1].trim());
-      } else if (serverAuth.has("identityToken")) {
-        authBuilder.identityToken(serverAuth.get("identityToken").asText());
-        return authBuilder;
-      } else {
-        LOG.warn("Failed to parse auth string for {}", serverAddress);
-        return authBuilder;
-      }
-    } else {
-      LOG.warn("Could not find auth field for {}", serverAddress);
-      return authBuilder;
-    }
-
-    if (serverAuth.has("email")) {
-      authBuilder.email(serverAuth.get("email").asText());
-    }
-
-    return authBuilder;
-  }
-
-  private static JsonNode extractAuthJson(final Path configPath) throws IOException {
-    final JsonNode config = MAPPER.readTree(configPath.toFile());
-
-    if (config.has("auths")) {
-      return config.get("auths");
-    }
-
-    return config;
-  }
 
   public static Builder builder() {
     return new AutoValue_RegistryAuth.Builder()

--- a/src/main/java/com/spotify/docker/client/messages/RegistryAuth.java
+++ b/src/main/java/com/spotify/docker/client/messages/RegistryAuth.java
@@ -26,12 +26,10 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.spotify.docker.client.DockerConfigReader;
-import com.spotify.docker.client.ObjectMapperProvider;
 import java.io.IOException;
 import java.nio.file.Path;
 import javax.annotation.Nullable;
@@ -40,13 +38,6 @@ import org.glassfish.jersey.internal.util.Base64;
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 public abstract class RegistryAuth {
-
-  private static final String DEFAULT_REGISTRY = "https://index.docker.io/v1/";
-  private static final String DUMMY_EMAIL = "1234@5678.com";
-
-  @SuppressWarnings("FieldCanBeLocal")
-  private static final ObjectMapper MAPPER =
-      new ObjectMapperProvider().getContext(RegistryAuth.class);
 
   @Nullable
   @JsonProperty("Username")
@@ -71,8 +62,9 @@ public abstract class RegistryAuth {
   @JsonProperty("IdentityToken")
   public abstract String identityToken();
 
+  @Override
   public final String toString() {
-    return MoreObjects.toStringHelper(this)
+    return MoreObjects.toStringHelper(RegistryAuth.class)
         .add("username", username())
         // don't log the password or email
         .add("serverAddress", serverAddress())
@@ -152,7 +144,7 @@ public abstract class RegistryAuth {
                                     @JsonProperty("identityToken") final String identityToken,
                                     @JsonProperty("auth") final String auth) {
 
-    if (auth != null && username == null && password == null) {
+    if (auth != null) {
       final String[] authParams = Base64.decodeAsString(auth).split(":");
 
       if (authParams.length == 2) {
@@ -170,10 +162,7 @@ public abstract class RegistryAuth {
   }
 
   public static Builder builder() {
-    return new AutoValue_RegistryAuth.Builder()
-        // Default to the public Docker registry.
-        .serverAddress(DEFAULT_REGISTRY)
-        .email(DUMMY_EMAIL);
+    return new AutoValue_RegistryAuth.Builder();
   }
 
   @AutoValue.Builder

--- a/src/main/java/com/spotify/docker/client/messages/RegistryAuth.java
+++ b/src/main/java/com/spotify/docker/client/messages/RegistryAuth.java
@@ -144,21 +144,31 @@ public abstract class RegistryAuth {
                                     @JsonProperty("identityToken") final String identityToken,
                                     @JsonProperty("auth") final String auth) {
 
+    final Builder builder;
     if (auth != null) {
-      final String[] authParams = Base64.decodeAsString(auth).split(":");
-
-      if (authParams.length == 2) {
-        username = authParams[0].trim();
-        password = authParams[1].trim();
-      }
+      builder = forAuthToken(auth);
+    } else {
+      builder = builder()
+          .username(username)
+          .password(password);
     }
-    return builder()
-        .username(username)
-        .password(password)
+    return builder
         .email(email)
         .serverAddress(serverAddress)
         .identityToken(identityToken)
         .build();
+  }
+
+  /** Construct a Builder based upon the "auth" field of the docker client config file. */
+  public static Builder forAuthToken(String auth) {
+    final String[] authParams = Base64.decodeAsString(auth).split(":");
+
+    if (authParams.length != 2) {
+      return builder();
+    }
+    return builder()
+        .username(authParams[0].trim())
+        .password(authParams[1].trim());
   }
 
   public static Builder builder() {

--- a/src/main/java/com/spotify/docker/client/messages/RegistryAuthSupplier.java
+++ b/src/main/java/com/spotify/docker/client/messages/RegistryAuthSupplier.java
@@ -1,0 +1,37 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages;
+
+import com.spotify.docker.client.exceptions.DockerException;
+
+public interface RegistryAuthSupplier {
+  /**
+   * Returns a RegistryAuth object that works with a given registry's API [e.g. GCR].
+   */
+  RegistryAuth authFor(String imageName) throws DockerException;
+
+  /**
+   * Returns a RegistryAuth object that is valid for a Docker Swarm context [i.e. not tied
+   * to specific image]. It's unnecessary if it's not planned to use this AuthSupplier to pull
+   * images for Swarm.
+   */
+  RegistryAuth authForSwarm();
+}

--- a/src/main/java/com/spotify/docker/client/messages/RegistryAuthSupplier.java
+++ b/src/main/java/com/spotify/docker/client/messages/RegistryAuthSupplier.java
@@ -23,6 +23,7 @@ package com.spotify.docker.client.messages;
 import com.spotify.docker.client.exceptions.DockerException;
 
 public interface RegistryAuthSupplier {
+
   /**
    * Returns a RegistryAuth object that works with a given registry's API [e.g. GCR].
    */
@@ -33,5 +34,8 @@ public interface RegistryAuthSupplier {
    * to specific image]. It's unnecessary if it's not planned to use this AuthSupplier to pull
    * images for Swarm.
    */
-  RegistryAuth authForSwarm();
+  RegistryAuth authForSwarm() throws DockerException;
+
+  /** Authentication info to pass in the X-Registry-Config header when building an image. */
+  RegistryConfigs authForBuild() throws DockerException;
 }

--- a/src/main/java/com/spotify/docker/client/messages/RegistryConfigs.java
+++ b/src/main/java/com/spotify/docker/client/messages/RegistryConfigs.java
@@ -75,6 +75,9 @@ public abstract class RegistryConfigs {
         new Maps.EntryTransformer<String, RegistryAuth, RegistryAuth>() {
           @Override
           public RegistryAuth transformEntry(final String key, final RegistryAuth value) {
+            if (value == null) {
+              return null;
+            }
             if (value.serverAddress() == null) {
               return value.toBuilder()
                   .serverAddress(key)

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -60,7 +60,6 @@ import static com.spotify.docker.client.messages.swarm.RestartPolicy.RESTART_POL
 import static java.lang.Long.toHexString;
 import static java.lang.String.format;
 import static java.lang.System.getenv;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.apache.commons.lang.StringUtils.containsIgnoreCase;
 import static org.awaitility.Awaitility.await;
@@ -214,7 +213,6 @@ import com.spotify.docker.client.messages.swarm.ServiceMode;
 import com.spotify.docker.client.messages.swarm.ServiceSpec;
 import com.spotify.docker.client.messages.swarm.Swarm;
 import com.spotify.docker.client.messages.swarm.SwarmInit;
-import com.spotify.docker.client.messages.swarm.SwarmJoin;
 import com.spotify.docker.client.messages.swarm.SwarmSpec;
 import com.spotify.docker.client.messages.swarm.Task;
 import com.spotify.docker.client.messages.swarm.TaskDefaults;

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -310,19 +310,22 @@ public class DefaultDockerClientTest {
   @Rule
   public final TestName testName = new TestName();
 
+  private final RegistryAuth registryAuth = RegistryAuth.builder()
+      .username(AUTH_USERNAME)
+      .password(AUTH_PASSWORD)
+      .email("1234@example.com")
+      .build();
+
   private final String nameTag = toHexString(ThreadLocalRandom.current().nextLong());
 
   private URI dockerEndpoint;
 
   private DefaultDockerClient sut;
 
-  private RegistryAuth registryAuth;
-
   private String dockerApiVersion;
 
   @Before
   public void setup() throws Exception {
-    registryAuth = RegistryAuth.builder().username(AUTH_USERNAME).password(AUTH_PASSWORD).build();
     final DefaultDockerClient.Builder builder = DefaultDockerClient.fromEnv();
     // Make it easier to test no read timeout occurs by using a smaller value
     // Such test methods should end in 'NoTimeout'
@@ -687,6 +690,7 @@ public class DefaultDockerClientTest {
   public void testBadAuth() throws Exception {
     final RegistryAuth badRegistryAuth = RegistryAuth.builder()
         .username(AUTH_USERNAME)
+        .email("user@example.com") // docker < 1.11 requires email to be set in RegistryAuth
         .password("foobar")
         .build();
     final int statusCode = sut.auth(badRegistryAuth);

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientUnitTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientUnitTest.java
@@ -31,8 +31,11 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.spotify.docker.client.exceptions.DockerCertificateException;
+import com.spotify.docker.client.gcr.GoogleContainerRegistryAuthSupplier;
 import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.HostConfig;
+import com.spotify.docker.client.messages.RegistryAuth;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -43,7 +46,9 @@ import okhttp3.mockwebserver.RecordedRequest;
 import okio.Buffer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /**
  * Tests DefaultDockerClient against a {@link okhttp3.mockwebserver.MockWebServer} instance, so
@@ -70,6 +75,9 @@ public class DefaultDockerClientUnitTest {
 
   private final MockWebServer server = new MockWebServer();
   private DefaultDockerClient.Builder builder;
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   @Before
   public void setup() throws Exception {
@@ -188,4 +196,15 @@ public class DefaultDockerClientUnitTest {
     return texts;
   }
 
+  @Test
+  public void buildThrowsIfRegistryAuthandRegistryAuthSupplierAreBothSpecified()
+      throws DockerCertificateException {
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("LOGIC ERROR");
+
+    DefaultDockerClient.builder()
+        .registryAuth(RegistryAuth.builder().identityToken("hello").build())
+        .registryAuthSupplier(new GoogleContainerRegistryAuthSupplier())
+        .build();
+  }
 }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientUnitTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientUnitTest.java
@@ -24,19 +24,31 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.io.BaseEncoding;
+import com.google.common.io.Resources;
 import com.spotify.docker.client.exceptions.DockerCertificateException;
 import com.spotify.docker.client.gcr.GoogleContainerRegistryAuthSupplier;
 import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.HostConfig;
 import com.spotify.docker.client.messages.RegistryAuth;
+import com.spotify.docker.client.messages.RegistryAuthSupplier;
+import com.spotify.docker.client.messages.RegistryConfigs;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -74,6 +86,7 @@ import org.junit.rules.ExpectedException;
 public class DefaultDockerClientUnitTest {
 
   private final MockWebServer server = new MockWebServer();
+
   private DefaultDockerClient.Builder builder;
 
   @Rule
@@ -150,6 +163,18 @@ public class DefaultDockerClientUnitTest {
     return ObjectMapperProvider.objectMapper().readTree(buffer.inputStream());
   }
 
+  private static JsonNode toJson(byte[] bytes) throws IOException {
+    return ObjectMapperProvider.objectMapper().readTree(bytes);
+  }
+
+  private static JsonNode toJson(Object object) throws IOException {
+    return ObjectMapperProvider.objectMapper().valueToTree(object);
+  }
+
+  private static ObjectNode createObjectNode() {
+    return ObjectMapperProvider.objectMapper().createObjectNode();
+  }
+
   @Test
   @SuppressWarnings("unchecked")
   public void testCapAddAndDrop() throws Exception {
@@ -197,6 +222,7 @@ public class DefaultDockerClientUnitTest {
   }
 
   @Test
+  @SuppressWarnings("deprecated")
   public void buildThrowsIfRegistryAuthandRegistryAuthSupplierAreBothSpecified()
       throws DockerCertificateException {
     thrown.expect(IllegalStateException.class);
@@ -206,5 +232,72 @@ public class DefaultDockerClientUnitTest {
         .registryAuth(RegistryAuth.builder().identityToken("hello").build())
         .registryAuthSupplier(new GoogleContainerRegistryAuthSupplier())
         .build();
+  }
+
+  @Test
+  public void testBuildPassesMultipleRegistryConfigs() throws Exception {
+    final RegistryConfigs registryConfigs = RegistryConfigs.create(ImmutableMap.of(
+        "server1", RegistryAuth.builder()
+            .serverAddress("server1")
+            .username("u1")
+            .password("p1")
+            .email("e1")
+            .build(),
+
+        "server2", RegistryAuth.builder()
+            .serverAddress("server2")
+            .username("u2")
+            .password("p2")
+            .email("e2")
+            .build()
+    ));
+
+    final RegistryAuthSupplier authSupplier = mock(RegistryAuthSupplier.class);
+    when(authSupplier.authForBuild()).thenReturn(registryConfigs);
+
+    final DefaultDockerClient client = builder.registryAuthSupplier(authSupplier)
+        .build();
+
+    // build() calls /version to check what format of header to send
+    server.enqueue(new MockResponse()
+        .setResponseCode(200)
+        .addHeader("Content-Type", "application/json")
+        .setBody(
+            createObjectNode()
+                .put("ApiVersion", "1.20")
+                .put("Arch", "foobar")
+                .put("GitCommit", "foobar")
+                .put("GoVersion", "foobar")
+                .put("KernelVersion", "foobar")
+                .put("Os", "foobar")
+                .put("Version", "1.20")
+                .toString()
+        )
+    );
+
+    // TODO (mbrown): what to return for build response?
+    server.enqueue(new MockResponse()
+        .setResponseCode(200)
+    );
+
+    final Path path = Paths.get(Resources.getResource("dockerDirectory").toURI());
+
+    client.build(path);
+
+    final RecordedRequest versionRequest = takeRequestImmediately();
+    assertThat(versionRequest.getMethod(), is("GET"));
+    assertThat(versionRequest.getPath(), is("/version"));
+
+    final RecordedRequest buildRequest = takeRequestImmediately();
+    assertThat(buildRequest.getMethod(), is("POST"));
+    assertThat(buildRequest.getPath(), is("/build"));
+
+    final String registryConfigHeader = buildRequest.getHeader("X-Registry-Config");
+    assertThat(registryConfigHeader, is(not(nullValue())));
+
+    // check that the JSON in the header is equivalent to what we mocked out above from
+    // the registryAuthSupplier
+    final JsonNode headerJsonNode = toJson(BaseEncoding.base64().decode(registryConfigHeader));
+    assertThat(headerJsonNode, is(toJson(registryConfigs.configs())));
   }
 }

--- a/src/test/java/com/spotify/docker/client/NoOpRegistryAuthSupplierTest.java
+++ b/src/test/java/com/spotify/docker/client/NoOpRegistryAuthSupplierTest.java
@@ -33,7 +33,8 @@ public class NoOpRegistryAuthSupplierTest {
   @Test
   public void authForReturnsWrappedAuthRegistry() throws DockerException {
     RegistryAuth registryAuth = mock(RegistryAuth.class);
-    NoOpRegistryAuthSupplier noOpRegistryAuthSupplier = new NoOpRegistryAuthSupplier(registryAuth);
+    NoOpRegistryAuthSupplier noOpRegistryAuthSupplier = new NoOpRegistryAuthSupplier(registryAuth,
+        null);
     assertEquals(registryAuth, noOpRegistryAuthSupplier.authFor("doesn't matter"));
   }
 
@@ -41,6 +42,6 @@ public class NoOpRegistryAuthSupplierTest {
   public void authForReturnsNullForEmptyConstructor() throws DockerException {
     NoOpRegistryAuthSupplier noOpRegistryAuthSupplier = new NoOpRegistryAuthSupplier();
     assertNull(noOpRegistryAuthSupplier.authFor("any"));
+    assertNull(noOpRegistryAuthSupplier.authForBuild());
   }
-
 }

--- a/src/test/java/com/spotify/docker/client/NoOpRegistryAuthSupplierTest.java
+++ b/src/test/java/com/spotify/docker/client/NoOpRegistryAuthSupplierTest.java
@@ -1,0 +1,46 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.RegistryAuth;
+import org.junit.Test;
+
+public class NoOpRegistryAuthSupplierTest {
+
+  @Test
+  public void authForReturnsWrappedAuthRegistry() throws DockerException {
+    RegistryAuth registryAuth = mock(RegistryAuth.class);
+    NoOpRegistryAuthSupplier noOpRegistryAuthSupplier = new NoOpRegistryAuthSupplier(registryAuth);
+    assertEquals(registryAuth, noOpRegistryAuthSupplier.authFor("doesn't matter"));
+  }
+
+  @Test
+  public void authForReturnsNullForEmptyConstructor() throws DockerException {
+    NoOpRegistryAuthSupplier noOpRegistryAuthSupplier = new NoOpRegistryAuthSupplier();
+    assertNull(noOpRegistryAuthSupplier.authFor("any"));
+  }
+
+}

--- a/src/test/java/com/spotify/docker/client/gcr/GoogleContainerRegistryAuthSupplierTest.java
+++ b/src/test/java/com/spotify/docker/client/gcr/GoogleContainerRegistryAuthSupplierTest.java
@@ -1,0 +1,82 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.gcr;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.spotify.docker.client.DockerConfigReader;
+import com.spotify.docker.client.gcr.GoogleContainerRegistryAuthSupplier;
+import com.spotify.docker.client.gcr.GoogleContainerRegistryCredRefresher;
+import com.spotify.docker.client.messages.RegistryAuth;
+import java.nio.file.Path;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+public class GoogleContainerRegistryAuthSupplierTest {
+
+  @Test
+  public void authForRefreshesCredsBeforeReadingConfigFile() throws Exception {
+    DockerConfigReader dockerCfgReader = mock(DockerConfigReader.class);
+    GoogleContainerRegistryCredRefresher googleContainerRegistryCredRefresher =
+        mock(GoogleContainerRegistryCredRefresher.class);
+    Path path = mock(Path.class);
+    InOrder inOrder = inOrder(googleContainerRegistryCredRefresher, dockerCfgReader);
+
+    GoogleContainerRegistryAuthSupplier googleContainerRegistryAuthSupplier =
+        new GoogleContainerRegistryAuthSupplier(
+            dockerCfgReader, googleContainerRegistryCredRefresher, path);
+
+    googleContainerRegistryAuthSupplier.authFor("us.gcr.io/awesome-project/example-image");
+    inOrder.verify(googleContainerRegistryCredRefresher).refresh();
+    inOrder.verify(dockerCfgReader).fromComfig(any(Path.class), anyString());
+  }
+
+  @Test
+  public void authForReturnsRegisteryAuthThatMatchesRegisteryName() throws Exception {
+    DockerConfigReader dockerCfgReader = mock(DockerConfigReader.class);
+    GoogleContainerRegistryCredRefresher googleContainerRegistryCredRefresher =
+        mock(GoogleContainerRegistryCredRefresher.class);
+    Path path = mock(Path.class);
+
+    RegistryAuth expected =
+        RegistryAuth.builder().email("no@no.com").identityToken("authorific").build();
+
+    when(dockerCfgReader.fromComfig(any(Path.class), eq("https://us.gcr.io"))).thenReturn(expected);
+
+    GoogleContainerRegistryAuthSupplier googleContainerRegistryAuthSupplier =
+        new GoogleContainerRegistryAuthSupplier(
+            dockerCfgReader, googleContainerRegistryCredRefresher, path);
+
+    RegistryAuth registryAuth = googleContainerRegistryAuthSupplier
+        .authFor("us.gcr.io/awesome-project/example-image");
+
+    assertEquals(expected.email(), registryAuth.email());
+    assertEquals(expected.identityToken(), registryAuth.identityToken());
+
+  }
+
+}

--- a/src/test/java/com/spotify/docker/client/gcr/GoogleContainerRegistryAuthSupplierTest.java
+++ b/src/test/java/com/spotify/docker/client/gcr/GoogleContainerRegistryAuthSupplierTest.java
@@ -29,8 +29,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.spotify.docker.client.DockerConfigReader;
-import com.spotify.docker.client.gcr.GoogleContainerRegistryAuthSupplier;
-import com.spotify.docker.client.gcr.GoogleContainerRegistryCredRefresher;
 import com.spotify.docker.client.messages.RegistryAuth;
 import java.nio.file.Path;
 import org.junit.Test;
@@ -52,11 +50,11 @@ public class GoogleContainerRegistryAuthSupplierTest {
 
     googleContainerRegistryAuthSupplier.authFor("us.gcr.io/awesome-project/example-image");
     inOrder.verify(googleContainerRegistryCredRefresher).refresh();
-    inOrder.verify(dockerCfgReader).fromComfig(any(Path.class), anyString());
+    inOrder.verify(dockerCfgReader).fromConfig(any(Path.class), anyString());
   }
 
   @Test
-  public void authForReturnsRegisteryAuthThatMatchesRegisteryName() throws Exception {
+  public void authForReturnsRegistryAuthThatMatchesRegistryName() throws Exception {
     DockerConfigReader dockerCfgReader = mock(DockerConfigReader.class);
     GoogleContainerRegistryCredRefresher googleContainerRegistryCredRefresher =
         mock(GoogleContainerRegistryCredRefresher.class);
@@ -65,7 +63,7 @@ public class GoogleContainerRegistryAuthSupplierTest {
     RegistryAuth expected =
         RegistryAuth.builder().email("no@no.com").identityToken("authorific").build();
 
-    when(dockerCfgReader.fromComfig(any(Path.class), eq("https://us.gcr.io"))).thenReturn(expected);
+    when(dockerCfgReader.fromConfig(any(Path.class), eq("https://us.gcr.io"))).thenReturn(expected);
 
     GoogleContainerRegistryAuthSupplier googleContainerRegistryAuthSupplier =
         new GoogleContainerRegistryAuthSupplier(

--- a/src/test/java/com/spotify/docker/client/gcr/GoogleContainerRegistryCredRefresherTest.java
+++ b/src/test/java/com/spotify/docker/client/gcr/GoogleContainerRegistryCredRefresherTest.java
@@ -1,0 +1,80 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.gcr;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.spotify.docker.client.gcr.GCloudProcess;
+import com.spotify.docker.client.gcr.GoogleContainerRegistryCredRefresher;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class GoogleContainerRegistryCredRefresherTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+
+  @Test
+  public void refreshShellsOutToGCloudCli() throws IOException, InterruptedException {
+    Process process = mock(Process.class);
+    when(process.waitFor()).thenReturn(0);
+
+    GCloudProcess gcloudProcess = mock(GCloudProcess.class);
+    when(gcloudProcess.runGcloudDocker()).thenReturn(process);
+
+    GoogleContainerRegistryCredRefresher googleContainerRegistryCredRefresher =
+        new GoogleContainerRegistryCredRefresher(gcloudProcess);
+
+    googleContainerRegistryCredRefresher.refresh();
+    verify(gcloudProcess).runGcloudDocker();
+
+  }
+
+  @Test
+  public void refreshThrowsIfSuccessCodeIsntReturnedFromCommand()
+      throws InterruptedException, IOException {
+    thrown.expect(IOException.class);
+    thrown.expectMessage("ERROR: (gcloud.docker)");
+
+    GCloudProcess gcloudProcess = mock(GCloudProcess.class);
+
+    Process failedProc = mock(Process.class);
+    when(failedProc.waitFor()).thenReturn(1);
+    when(failedProc.getErrorStream())
+        .thenReturn(
+            new ByteArrayInputStream("ERROR: (gcloud.docker)".getBytes(StandardCharsets.UTF_8)));
+
+    when(gcloudProcess.runGcloudDocker()).thenReturn(failedProc);
+
+    GoogleContainerRegistryCredRefresher googleContainerRegistryCredRefresher =
+        new GoogleContainerRegistryCredRefresher(gcloudProcess);
+
+    googleContainerRegistryCredRefresher.refresh();;
+  }
+
+}

--- a/src/test/java/com/spotify/docker/client/gcr/GoogleContainerRegistryCredRefresherTest.java
+++ b/src/test/java/com/spotify/docker/client/gcr/GoogleContainerRegistryCredRefresherTest.java
@@ -24,8 +24,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.spotify.docker.client.gcr.GCloudProcess;
-import com.spotify.docker.client.gcr.GoogleContainerRegistryCredRefresher;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -74,7 +72,7 @@ public class GoogleContainerRegistryCredRefresherTest {
     GoogleContainerRegistryCredRefresher googleContainerRegistryCredRefresher =
         new GoogleContainerRegistryCredRefresher(gcloudProcess);
 
-    googleContainerRegistryCredRefresher.refresh();;
+    googleContainerRegistryCredRefresher.refresh();
   }
 
 }


### PR DESCRIPTION
This completes #749 - David and I worked on this together in-person.

The new `RegistryAuthSupplier` interface replaces the existing `RegistryAuth` support in DefaultDockerClient so that users can customize the authentication behavior much more closely. On each operation that requires authentication, DefaultDockerClient will invoke the appropriate method on the RegistryAuthSupplier instance, allowing the implementation to supply up-to-date authentication information/tokens.

This change is inspired by our attempts to integrate with Google Container Registry, where `~/.docker/config.json` file contains short-lived access tokens that expire shortly after creation. This means that a long-lived DefaultDockerClient instance cannot store static RegistryAuth information from construction-time.

Also included is an implementation of RegistryAuthSupplier that refreshes the access tokens supplied by `gcloud docker -a` prior to each `authFor(..)` operation, as well as an implementation of RegistryAuthSupplier that returns static data.

Closes #740.