### PR TITLE
remove com.spotify:logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.12</version>
+      <version>1.7.22</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -190,10 +190,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.spotify</groupId>
-      <artifactId>logging</artifactId>
-      <version>2.1.1</version>
-      <scope>test</scope>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.jimfs</groupId>


### PR DESCRIPTION
the library is not actually used in tests - I think 1ce1cdb (where it
was added) really meant to use logback directly.