### PR TITLE
RegistryAuth: handle case where password contains colon

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/RegistryAuth.java
+++ b/src/main/java/com/spotify/docker/client/messages/RegistryAuth.java
@@ -161,11 +161,13 @@ public abstract class RegistryAuth {
 
   /** Construct a Builder based upon the "auth" field of the docker client config file. */
   public static Builder forAuth(String auth) {
-    final String[] authParams = Base64.decodeAsString(auth).split(":");
+    // split with limit=2 to catch case where password contains a colon
+    final String[] authParams = Base64.decodeAsString(auth).split(":", 2);
 
     if (authParams.length != 2) {
       return builder();
     }
+
     return builder()
         .username(authParams[0].trim())
         .password(authParams[1].trim());

--- a/src/test/java/com/spotify/docker/client/messages/RegistryAuthTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/RegistryAuthTest.java
@@ -1,0 +1,52 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.io.BaseEncoding;
+import org.junit.Test;
+
+public class RegistryAuthTest {
+
+  @Test
+  public void testForAuth() {
+    final String username = "johndoe";
+    final String password = "pass123";
+    final String encoded = BaseEncoding.base64().encode((username + ":" + password).getBytes());
+
+    final RegistryAuth registryAuth = RegistryAuth.forAuth(encoded).build();
+    assertThat(registryAuth.username(), is(username));
+    assertThat(registryAuth.password(), is(password));
+  }
+
+  @Test
+  public void testForAuth_PasswordContainsColon() {
+    final String username = "johndoe";
+    final String password = "foo:bar";
+    final String encoded = BaseEncoding.base64().encode((username + ":" + password).getBytes());
+
+    final RegistryAuth registryAuth = RegistryAuth.forAuth(encoded).build();
+    assertThat(registryAuth.username(), is(username));
+    assertThat(registryAuth.password(), is(password));
+  }
+}

--- a/src/test/resources/dockerConfig/identityTokenConfig.json
+++ b/src/test/resources/dockerConfig/identityTokenConfig.json
@@ -1,7 +1,6 @@
 {
   "auths": {
     "docker.customdomain.com": {
-      "auth": "ZG9ja2VybWFuOg==",
       "email": "dockerman@hub.com",
       "identityToken": "52ce5fd5-eb60-42bf-931f-5eeec128211a"
     }


### PR DESCRIPTION
Fixes #764. This now matches [how docker-cli parses this field][0] from
~/.docker/config.json.

[0]: https://github.com/docker/cli/blob/db5620026dda9b8f5da519e382cf40ed22775e6d/cli/config/configfile/file.go#L184-L189