### PR TITLE
added field „Attachable“ to NetworkConfig

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/NetworkConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkConfig.java
@@ -63,6 +63,10 @@ public abstract class NetworkConfig {
   public abstract Boolean enableIPv6();
 
   @Nullable
+  @JsonProperty("Attachable")
+  public abstract Boolean attachable();
+
+  @Nullable
   @JsonProperty("Labels")
   public abstract ImmutableMap<String, String> labels();
 
@@ -94,6 +98,8 @@ public abstract class NetworkConfig {
     public abstract Builder internal(Boolean internal);
     
     public abstract Builder enableIPv6(Boolean ipv6);
+
+    public abstract Builder attachable(Boolean attachable);
 
     public abstract Builder labels(Map<String, String> labels);
     


### PR DESCRIPTION
NetworkConfig is missing the field "Attachable" though it is part of v1.26 of the docker API (https://docs.docker.com/engine/api/v1.26/#operation/NetworkCreate). 

I added the field to be able to create attachable networks.