### PR TITLE
GCR: ignore exceptions when building images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 8.6.2 (not yet released)
+
+### Bugfixes
+- ContainerRegistryAuthSupplier should ignore exceptions in refreshing the
+  Access Token unless RegistryAuth info is needed for a GCR image ([773][])
+
+[773]: https://github.com/spotify/docker-client/pull/773
+
 ## 8.6.1
 
 Added NetworkConfig.Attachable.


### PR DESCRIPTION
Ignore exceptions refreshing the accessToken in
ContainerRegistryAuthSupplier when building the image or getting the
RegistryAuth to be used for swarm.

Since `authForBuild()` has no arguments, we currently try to return an
AccessToken to use _in case_ the image being built needs to pull from
gcr.io, but we should ignore failures in the case that the image being
built does not need to pull anything from gcr.io.

This way someone using ContainerRegistryAuthSupplier with credentials
that do not actually have access to GCR do not get exceptions when
building non-GCR images.

If the accessToken can't be fetched in `authForBuild` for a gcr.io
image, then the build will still fail but at a later point when the
docker daemon tries to pull the FROM image and throws an error about how
the image is "missing or access is denied".