### PR TITLE
Fix InvalidPathException when match string includes * #778

### DIFF
--- a/src/main/java/com/spotify/docker/client/CompressedDirectory.java
+++ b/src/main/java/com/spotify/docker/client/CompressedDirectory.java
@@ -36,6 +36,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.SimpleFileVisitor;
@@ -424,7 +425,13 @@ class CompressedDirectory implements Closeable {
      */
     @Override
     public boolean matches(Path path) {
-      return path.startsWith(this.pattern) || this.matcher.matches(path);
+      boolean startsWith = false;
+      try {
+        startsWith = path.startsWith(this.pattern);
+      } catch (InvalidPathException e) {
+        // thrown "If the path string cannot be converted to a Path"
+      }
+      return startsWith || this.matcher.matches(path);
     }
 
     @Override

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -455,7 +455,8 @@ public class DefaultDockerClientTest {
   public void testBuildImageIdWithBuildargs() throws Exception {
     requireDockerApiVersionAtLeast("1.21", "build args");
 
-    final String dockerDirectory = Resources.getResource("dockerDirectoryWithBuildargs").getPath();
+    final String dockerDirectory = 
+        Paths.get(Resources.getResource("dockerDirectoryWithBuildargs").toURI()).toString();
     final String buildargs = "{\"testargument\":\"22-12-2015\"}";
     final BuildParam buildParam =
         BuildParam.create("buildargs", URLEncoder.encode(buildargs, "UTF-8"));
@@ -471,8 +472,8 @@ public class DefaultDockerClientTest {
     requireDockerApiVersionAtLeast("1.24", "health check");
 
     // Create image
-    final String dockerDirectory = Resources.getResource("dockerDirectoryWithHealthCheck")
-            .getPath();
+    final String dockerDirectory = 
+        Paths.get(Resources.getResource("dockerDirectoryWithHealthCheck").toURI()).toString();
     final String imageId = sut.build(
             Paths.get(dockerDirectory),
             "test-healthcheck"
@@ -893,7 +894,8 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testBuildImageId() throws Exception {
-    final String dockerDirectory = Resources.getResource("dockerDirectory").getPath();
+    final String dockerDirectory = 
+        Paths.get(Resources.getResource("dockerDirectory").toURI()).toString();
     final AtomicReference<String> imageIdFromMessage = new AtomicReference<>();
 
     final String returnedImageId = sut.build(
@@ -912,7 +914,8 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testBuildImageIdPathToDockerFile() throws Exception {
-    final String dockerDirectory = Resources.getResource("dockerDirectory").getPath();
+    final String dockerDirectory = 
+        Paths.get(Resources.getResource("dockerDirectory").toURI()).toString();
     final AtomicReference<String> imageIdFromMessage = new AtomicReference<>();
 
     final String returnedImageId = sut.build(
@@ -931,7 +934,8 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testBuildImageIdWithAuth() throws Exception {
-    final String dockerDirectory = Resources.getResource("dockerDirectory").getPath();
+    final String dockerDirectory = 
+        Paths.get(Resources.getResource("dockerDirectory").toURI()).toString();
     final AtomicReference<String> imageIdFromMessage = new AtomicReference<>();
 
     final DefaultDockerClient sut2 = DefaultDockerClient.fromEnv()
@@ -956,7 +960,7 @@ public class DefaultDockerClientTest {
   @Test
   public void testFailedBuildDoesNotLeakConn() throws Exception {
     final String dockerDirectory =
-        Resources.getResource("dockerDirectoryNonExistentImage").getPath();
+        Paths.get(Resources.getResource("dockerDirectoryNonExistentImage").toURI()).toString();
 
     log.info("Connection pool stats: " + getClientConnectionPoolStats(sut).toString());
 
@@ -978,7 +982,8 @@ public class DefaultDockerClientTest {
   @Test
   public void testBuildName() throws Exception {
     final String imageName = "test-build-name";
-    final String dockerDirectory = Resources.getResource("dockerDirectory").getPath();
+    final String dockerDirectory = 
+        Paths.get(Resources.getResource("dockerDirectory").toURI()).toString();
     final String imageId = sut.build(Paths.get(dockerDirectory), imageName);
     final ImageInfo info = sut.inspectImage(imageName);
     final String expectedId = dockerApiVersionLessThan("1.22") ? imageId : "sha256:" + imageId;
@@ -989,7 +994,8 @@ public class DefaultDockerClientTest {
   public void testBuildWithPull() throws Exception {
     requireDockerApiVersionAtLeast("1.19", "build with pull");
 
-    final String dockerDirectory = Resources.getResource("dockerDirectory").getPath();
+    final String dockerDirectory = 
+        Paths.get(Resources.getResource("dockerDirectory").toURI()).toString();
     final String pullMsg = "Pulling from";
 
     // Build once to make sure we have cached images.
@@ -1010,7 +1016,8 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testBuildNoCache() throws Exception {
-    final String dockerDirectory = Resources.getResource("dockerDirectory").getPath();
+    final String dockerDirectory = 
+        Paths.get(Resources.getResource("dockerDirectory").toURI()).toString();
     final String usingCache = "Using cache";
 
     // Build once to make sure we have cached images.
@@ -1039,7 +1046,8 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testBuildNoRm() throws Exception {
-    final String dockerDirectory = Resources.getResource("dockerDirectory").getPath();
+    final String dockerDirectory = 
+        Paths.get(Resources.getResource("dockerDirectory").toURI()).toString();
     final String removingContainers = "Removing intermediate container";
 
     // Test that intermediate containers are removed with FORCE_RM by parsing output. We must
@@ -1068,7 +1076,8 @@ public class DefaultDockerClientTest {
   public void testBuildNoTimeout() throws Exception {
     // The Dockerfile specifies a sleep of 10s during the build
     // Returned image id is last piece of output, so this confirms stream did not timeout
-    final String dockerDirectory = Resources.getResource("dockerDirectorySleeping").getPath();
+    final String dockerDirectory = 
+        Paths.get(Resources.getResource("dockerDirectorySleeping").toURI()).toString();
     final String returnedImageId = sut.build(
         Paths.get(dockerDirectory), "test", new ProgressHandler() {
           @Override
@@ -1243,7 +1252,8 @@ public class DefaultDockerClientTest {
     final ContainerCreation creation = sut.createContainer(config, name);
     final String containerId = creation.id();
 
-    final String dockerDirectory = Resources.getResource("dockerSslDirectory").getPath();
+    final String dockerDirectory = 
+        Paths.get(Resources.getResource("dockerSslDirectory").toURI()).toString();
     try {
       sut.copyToContainer(Paths.get(dockerDirectory), containerId, "/tmp");
     } catch (Exception e) {
@@ -1487,7 +1497,8 @@ public class DefaultDockerClientTest {
     // Start container
     sut.startContainer(id);
 
-    final String dockerDirectory = Resources.getResource("dockerSslDirectory").getPath();
+    final String dockerDirectory = 
+        Paths.get(Resources.getResource("dockerSslDirectory").toURI()).toString();
 
     // Copy files to container
     // Docker API should be at least v1.20 to support extracting an archive of files or folders
@@ -2517,7 +2528,8 @@ public class DefaultDockerClientTest {
     final String imageName = "test-docker-ssl";
     final String expose = "2376/tcp";
 
-    final String dockerDirectory = Resources.getResource("dockerSslDirectory").getPath();
+    final String dockerDirectory = 
+        Paths.get(Resources.getResource("dockerSslDirectory").toURI()).toString();
     sut.build(Paths.get(dockerDirectory), imageName);
 
     final HostConfig hostConfig = HostConfig.builder()
@@ -3709,7 +3721,7 @@ public class DefaultDockerClientTest {
     requireDockerApiVersionAtLeast("1.17", "image labels");
 
     final String dockerDirectory =
-        Resources.getResource("dockerDirectoryWithImageLabels").getPath();
+        Paths.get(Resources.getResource("dockerDirectoryWithImageLabels").toURI()).toString();
 
     // Create test images
     final String barDir = (new File(dockerDirectory, "barDir")).toString();

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -457,7 +457,7 @@ public class DefaultDockerClientTest {
     // Resources.getResources(...).getPath() does not work correctly on windows,
     // hence this workaround.  See: https://github.com/spotify/docker-client/pull/780
     // for details
-    return Paths.get(Resources.getResource("dockerDirectoryWithBuildargs").toURI());
+    return Paths.get(Resources.getResource(name).toURI());
   }
 
   @Test

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -235,7 +235,9 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -450,21 +452,23 @@ public class DefaultDockerClientTest {
   public void testPullPrivateRepoWithoutAuth() throws Exception {
     sut.pull(CIRROS_PRIVATE_LATEST);
   }
+  
+  private static final Path getResource(String name) throws URISyntaxException {
+    // Resources.getResources(...).getPath() does not work correctly on windows,
+    // hence this workaround.  See: https://github.com/spotify/docker-client/pull/780
+    // for details
+    return Paths.get(Resources.getResource("dockerDirectoryWithBuildargs").toURI());
+  }
 
   @Test
   public void testBuildImageIdWithBuildargs() throws Exception {
     requireDockerApiVersionAtLeast("1.21", "build args");
 
-    final String dockerDirectory = 
-        Paths.get(Resources.getResource("dockerDirectoryWithBuildargs").toURI()).toString();
+    final Path dockerDirectory = getResource("dockerDirectoryWithBuildargs");
     final String buildargs = "{\"testargument\":\"22-12-2015\"}";
     final BuildParam buildParam =
         BuildParam.create("buildargs", URLEncoder.encode(buildargs, "UTF-8"));
-    sut.build(
-        Paths.get(dockerDirectory),
-        "test-buildargs",
-        buildParam
-    );
+    sut.build(dockerDirectory, "test-buildargs", buildParam);
   }
 
   @Test
@@ -472,12 +476,8 @@ public class DefaultDockerClientTest {
     requireDockerApiVersionAtLeast("1.24", "health check");
 
     // Create image
-    final String dockerDirectory = 
-        Paths.get(Resources.getResource("dockerDirectoryWithHealthCheck").toURI()).toString();
-    final String imageId = sut.build(
-            Paths.get(dockerDirectory),
-            "test-healthcheck"
-            );
+    final Path dockerDirectory = getResource("dockerDirectoryWithHealthCheck");
+    final String imageId = sut.build(dockerDirectory, "test-healthcheck");
 
     // Inpect image to check healthcheck configuration
     final ImageInfo imageInfo = sut.inspectImage(imageId);
@@ -894,12 +894,11 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testBuildImageId() throws Exception {
-    final String dockerDirectory = 
-        Paths.get(Resources.getResource("dockerDirectory").toURI()).toString();
+    final Path dockerDirectory = getResource("dockerDirectory");
     final AtomicReference<String> imageIdFromMessage = new AtomicReference<>();
 
-    final String returnedImageId = sut.build(
-        Paths.get(dockerDirectory), "test", new ProgressHandler() {
+    final String returnedImageId = sut.build(dockerDirectory, "test", 
+        new ProgressHandler() {
           @Override
           public void progress(ProgressMessage message) throws DockerException {
             final String imageId = message.buildImageId();
@@ -914,12 +913,12 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testBuildImageIdPathToDockerFile() throws Exception {
-    final String dockerDirectory = 
-        Paths.get(Resources.getResource("dockerDirectory").toURI()).toString();
+    final Path dockerDirectory = getResource("dockerDirectory");
     final AtomicReference<String> imageIdFromMessage = new AtomicReference<>();
 
     final String returnedImageId = sut.build(
-        Paths.get(dockerDirectory), "test", "innerDir/innerDockerfile", new ProgressHandler() {
+        dockerDirectory, "test", "innerDir/innerDockerfile", 
+        new ProgressHandler() {
           @Override
           public void progress(ProgressMessage message) throws DockerException {
             final String imageId = message.buildImageId();
@@ -934,16 +933,15 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testBuildImageIdWithAuth() throws Exception {
-    final String dockerDirectory = 
-        Paths.get(Resources.getResource("dockerDirectory").toURI()).toString();
+    final Path dockerDirectory = getResource("dockerDirectory");
     final AtomicReference<String> imageIdFromMessage = new AtomicReference<>();
 
     final DefaultDockerClient sut2 = DefaultDockerClient.fromEnv()
         .registryAuth(registryAuth)
         .build();
 
-    final String returnedImageId = sut2.build(
-        Paths.get(dockerDirectory), "test", new ProgressHandler() {
+    final String returnedImageId = sut2.build(dockerDirectory, "test", 
+        new ProgressHandler() {
           @Override
           public void progress(ProgressMessage message) throws DockerException {
             final String imageId = message.buildImageId();
@@ -959,8 +957,7 @@ public class DefaultDockerClientTest {
   @SuppressWarnings("EmptyCatchBlock")
   @Test
   public void testFailedBuildDoesNotLeakConn() throws Exception {
-    final String dockerDirectory =
-        Paths.get(Resources.getResource("dockerDirectoryNonExistentImage").toURI()).toString();
+    final Path dockerDirectory = getResource("dockerDirectoryNonExistentImage");
 
     log.info("Connection pool stats: " + getClientConnectionPoolStats(sut).toString());
 
@@ -969,7 +966,7 @@ public class DefaultDockerClientTest {
     // I.e. check that we are not leaking connections.
     for (int i = 0; i < 10; i++) {
       try {
-        sut.build(Paths.get(dockerDirectory), "test");
+        sut.build(dockerDirectory, "test");
       } catch (DockerException ignored) {
       }
 
@@ -982,9 +979,8 @@ public class DefaultDockerClientTest {
   @Test
   public void testBuildName() throws Exception {
     final String imageName = "test-build-name";
-    final String dockerDirectory = 
-        Paths.get(Resources.getResource("dockerDirectory").toURI()).toString();
-    final String imageId = sut.build(Paths.get(dockerDirectory), imageName);
+    final Path dockerDirectory = getResource("dockerDirectory");
+    final String imageId = sut.build(dockerDirectory, imageName);
     final ImageInfo info = sut.inspectImage(imageName);
     final String expectedId = dockerApiVersionLessThan("1.22") ? imageId : "sha256:" + imageId;
     assertThat(info.id(), startsWith(expectedId));
@@ -994,16 +990,15 @@ public class DefaultDockerClientTest {
   public void testBuildWithPull() throws Exception {
     requireDockerApiVersionAtLeast("1.19", "build with pull");
 
-    final String dockerDirectory = 
-        Paths.get(Resources.getResource("dockerDirectory").toURI()).toString();
+    final Path dockerDirectory = getResource("dockerDirectory");
     final String pullMsg = "Pulling from";
 
     // Build once to make sure we have cached images.
-    sut.build(Paths.get(dockerDirectory));
+    sut.build(dockerDirectory);
 
     // Build again with PULL set, and verify we pulled the base image
     final AtomicBoolean pulled = new AtomicBoolean(false);
-    sut.build(Paths.get(dockerDirectory), "test", new ProgressHandler() {
+    sut.build(dockerDirectory, "test", new ProgressHandler() {
       @Override
       public void progress(ProgressMessage message) throws DockerException {
         if (!isNullOrEmpty(message.status()) && message.status().contains(pullMsg)) {
@@ -1016,16 +1011,15 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testBuildNoCache() throws Exception {
-    final String dockerDirectory = 
-        Paths.get(Resources.getResource("dockerDirectory").toURI()).toString();
+    final Path dockerDirectory = getResource("dockerDirectory");
     final String usingCache = "Using cache";
 
     // Build once to make sure we have cached images.
-    sut.build(Paths.get(dockerDirectory));
+    sut.build(dockerDirectory);
 
     // Build again and make sure we used cached image by parsing output.
     final AtomicBoolean usedCache = new AtomicBoolean(false);
-    sut.build(Paths.get(dockerDirectory), "test", new ProgressHandler() {
+    sut.build(dockerDirectory, "test", new ProgressHandler() {
       @Override
       public void progress(ProgressMessage message) throws DockerException {
         if (message.stream().contains(usingCache)) {
@@ -1036,7 +1030,7 @@ public class DefaultDockerClientTest {
     assertTrue(usedCache.get());
 
     // Build again with NO_CACHE set, and verify we don't use cache.
-    sut.build(Paths.get(dockerDirectory), "test", new ProgressHandler() {
+    sut.build(dockerDirectory, "test", new ProgressHandler() {
       @Override
       public void progress(ProgressMessage message) throws DockerException {
         assertThat(message.stream(), not(containsString(usingCache)));
@@ -1046,14 +1040,13 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testBuildNoRm() throws Exception {
-    final String dockerDirectory = 
-        Paths.get(Resources.getResource("dockerDirectory").toURI()).toString();
+    final Path dockerDirectory = getResource("dockerDirectory");
     final String removingContainers = "Removing intermediate container";
 
     // Test that intermediate containers are removed with FORCE_RM by parsing output. We must
     // set NO_CACHE so that docker will generate some containers to remove.
     final AtomicBoolean removedContainer = new AtomicBoolean(false);
-    sut.build(Paths.get(dockerDirectory), "test", new ProgressHandler() {
+    sut.build(dockerDirectory, "test", new ProgressHandler() {
       @Override
       public void progress(ProgressMessage message) throws DockerException {
         if (containsIgnoreCase(message.stream(), removingContainers)) {
@@ -1064,7 +1057,7 @@ public class DefaultDockerClientTest {
     assertTrue(removedContainer.get());
 
     // Set NO_RM and verify we don't get message that containers were removed.
-    sut.build(Paths.get(dockerDirectory), "test", new ProgressHandler() {
+    sut.build(dockerDirectory, "test", new ProgressHandler() {
       @Override
       public void progress(ProgressMessage message) throws DockerException {
         assertThat(message.stream(), not(containsString(removingContainers)));
@@ -1076,10 +1069,9 @@ public class DefaultDockerClientTest {
   public void testBuildNoTimeout() throws Exception {
     // The Dockerfile specifies a sleep of 10s during the build
     // Returned image id is last piece of output, so this confirms stream did not timeout
-    final String dockerDirectory = 
-        Paths.get(Resources.getResource("dockerDirectorySleeping").toURI()).toString();
+    final Path dockerDirectory = getResource("dockerDirectorySleeping");
     final String returnedImageId = sut.build(
-        Paths.get(dockerDirectory), "test", new ProgressHandler() {
+        dockerDirectory, "test", new ProgressHandler() {
           @Override
           public void progress(ProgressMessage message) throws DockerException {
             log.info(message.stream());
@@ -1252,10 +1244,9 @@ public class DefaultDockerClientTest {
     final ContainerCreation creation = sut.createContainer(config, name);
     final String containerId = creation.id();
 
-    final String dockerDirectory = 
-        Paths.get(Resources.getResource("dockerSslDirectory").toURI()).toString();
+    final Path dockerDirectory = getResource("dockerSslDirectory");
     try {
-      sut.copyToContainer(Paths.get(dockerDirectory), containerId, "/tmp");
+      sut.copyToContainer(dockerDirectory, containerId, "/tmp");
     } catch (Exception e) {
       fail("error to copy files to container");
     }
@@ -1497,15 +1488,14 @@ public class DefaultDockerClientTest {
     // Start container
     sut.startContainer(id);
 
-    final String dockerDirectory = 
-        Paths.get(Resources.getResource("dockerSslDirectory").toURI()).toString();
+    final Path dockerDirectory = getResource("dockerSslDirectory");
 
     // Copy files to container
     // Docker API should be at least v1.20 to support extracting an archive of files or folders
     // to a directory in a container
     if (dockerApiVersionAtLeast("1.20")) {
       try {
-        sut.copyToContainer(Paths.get(dockerDirectory), id, "/tmp");
+        sut.copyToContainer(dockerDirectory, id, "/tmp");
       } catch (Exception e) {
         fail("error copying files to container");
       }
@@ -1522,7 +1512,7 @@ public class DefaultDockerClientTest {
       }
 
       // Check that we got back what we put in
-      final File folder = new File(dockerDirectory);
+      final File folder = new File(dockerDirectory.toString());
       final File[] files = folder.listFiles();
       if (files != null) {
         for (final File file : files) {
@@ -2528,9 +2518,8 @@ public class DefaultDockerClientTest {
     final String imageName = "test-docker-ssl";
     final String expose = "2376/tcp";
 
-    final String dockerDirectory = 
-        Paths.get(Resources.getResource("dockerSslDirectory").toURI()).toString();
-    sut.build(Paths.get(dockerDirectory), imageName);
+    final Path dockerDirectory = getResource("dockerSslDirectory");
+    sut.build(dockerDirectory, imageName);
 
     final HostConfig hostConfig = HostConfig.builder()
         .privileged(true)
@@ -2561,7 +2550,7 @@ public class DefaultDockerClientTest {
     final String port = containerInfo.networkSettings().ports().get(expose).get(0).hostPort();
 
     // Try to connect using SSL and our known cert/key
-    final DockerCertificates certs = new DockerCertificates(Paths.get(dockerDirectory));
+    final DockerCertificates certs = new DockerCertificates(dockerDirectory);
     final DockerClient c = new DefaultDockerClient(URI.create(format("https://%s:%s", host, port)),
                                                    certs);
 
@@ -3720,17 +3709,14 @@ public class DefaultDockerClientTest {
   public void testImageLabels() throws Exception {
     requireDockerApiVersionAtLeast("1.17", "image labels");
 
-    final String dockerDirectory =
-        Paths.get(Resources.getResource("dockerDirectoryWithImageLabels").toURI()).toString();
+    final Path dockerDirectory = getResource("dockerDirectoryWithImageLabels");
 
     // Create test images
-    final String barDir = (new File(dockerDirectory, "barDir")).toString();
     final String barName = randomName();
-    final String barId = sut.build(Paths.get(barDir), barName);
+    final String barId = sut.build(dockerDirectory.resolve("barDir"), barName);
 
     final String bazName = randomName();
-    final String bazDir = (new File(dockerDirectory, "bazDir")).toString();
-    final String bazId = sut.build(Paths.get(bazDir), bazName);
+    final String bazId = sut.build(dockerDirectory.resolve("bazDir"), bazName);
 
     // Check that both test images are listed when we filter with a "name" label
     final List<Image> nameImages = sut.listImages(ListImagesParam.withLabel("name"));

--- a/src/test/java/com/spotify/docker/client/DockerCertificatesTest.java
+++ b/src/test/java/com/spotify/docker/client/DockerCertificatesTest.java
@@ -31,6 +31,7 @@ import com.google.common.io.Resources;
 import com.spotify.docker.client.DockerCertificates.SslContextFactory;
 import com.spotify.docker.client.exceptions.DockerCertificateException;
 
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyStore;
@@ -136,15 +137,15 @@ public class DockerCertificatesTest {
     assertNotNull(pkEntry.getPrivateKey());
   }
 
-  private Path getResourceFile(String path) {
-    return Paths.get(Resources.getResource(path).getPath());
+  private Path getResourceFile(String path) throws URISyntaxException {
+    return Paths.get(Resources.getResource(path).toURI());
   }
 
-  private Path getCertPath() {
+  private Path getCertPath() throws URISyntaxException {
     return getResourceFile("dockerSslDirectory");
   }
 
-  private Path getVariant(String filename) {
+  private Path getVariant(String filename) throws URISyntaxException {
     return getResourceFile("dockerSslVariants").resolve(filename);
   }
 }


### PR DESCRIPTION
This is an alternative to #779 which is a little safer in that it captures any invalid path (not just "*", and not just windows).  It also [fixed some java url wonkiness](https://stackoverflow.com/a/17870390/516433) that caused other unit tests to fail for illegal char in path.