### PR TITLE
FEATURE: Implemented an updateNode method for the docker API

### DIFF
--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -33,6 +33,7 @@ import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.exceptions.ExecNotFoundException;
 import com.spotify.docker.client.exceptions.ImageNotFoundException;
 import com.spotify.docker.client.exceptions.NetworkNotFoundException;
+import com.spotify.docker.client.exceptions.NodeNotFoundException;
 import com.spotify.docker.client.exceptions.NonSwarmNodeException;
 import com.spotify.docker.client.exceptions.NotFoundException;
 import com.spotify.docker.client.exceptions.PermissionException;
@@ -67,6 +68,7 @@ import com.spotify.docker.client.messages.Volume;
 import com.spotify.docker.client.messages.VolumeList;
 import com.spotify.docker.client.messages.swarm.Node;
 import com.spotify.docker.client.messages.swarm.NodeInfo;
+import com.spotify.docker.client.messages.swarm.NodeSpec;
 import com.spotify.docker.client.messages.swarm.Secret;
 import com.spotify.docker.client.messages.swarm.SecretCreateResponse;
 import com.spotify.docker.client.messages.swarm.SecretSpec;
@@ -78,7 +80,6 @@ import com.spotify.docker.client.messages.swarm.SwarmJoin;
 import com.spotify.docker.client.messages.swarm.SwarmSpec;
 import com.spotify.docker.client.messages.swarm.Task;
 import com.spotify.docker.client.messages.swarm.UnlockKey;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -2861,4 +2862,19 @@ public interface DockerClient extends Closeable {
    * @since Docker 1.12, API Version 1.24
    */
   NodeInfo inspectNode(final String nodeId) throws DockerException, InterruptedException;
+
+  /**
+   * Update a swarm node. Only available in Docker API &gt;= 1.24.
+   *
+   * @param nodeId The id of the node to update
+   * @param version The version number of the node object being updated.
+   *                This is required to avoid conflicting writes
+   * @throws NodeNotFoundException If the node doesn't exist (404)
+   * @throws NonSwarmNodeException If the node is not part of a swarm (503)
+   * @throws DockerException If a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   * @since Docker 1.12, API version 1.24
+   */
+  void updateNode(final String nodeId, final Long version, final NodeSpec nodeSpec)
+      throws DockerException, InterruptedException;
 }

--- a/src/main/java/com/spotify/docker/client/messages/swarm/NodeSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/NodeSpec.java
@@ -28,9 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
-
 import java.util.Map;
-
 import javax.annotation.Nullable;
 
 @AutoValue
@@ -51,13 +49,45 @@ public abstract class NodeSpec {
   @JsonProperty("Availability")
   public abstract String availability();
 
-  @JsonCreator
-  static NodeSpec create(@JsonProperty("Name") final String image,
-      @JsonProperty("Labels") final Map<String, String> labels,
-      @JsonProperty("Role") final String dir, @JsonProperty("Availability") final String user) {
-    final ImmutableMap<String, String> labelsT = labels == null ? null
-        : ImmutableMap.copyOf(labels);
-    return new AutoValue_NodeSpec(image, labelsT, dir, user);
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder name(String name);
+
+    abstract ImmutableMap.Builder<String, String> labelsBuilder();
+
+    public Builder addLabel(final String label, final String value) {
+      labelsBuilder().put(label, value);
+      return this;
+    }
+
+    public abstract Builder labels(Map<String, String> labels);
+
+    public abstract Builder role(String role);
+
+    public abstract Builder availability(String availability);
+
+    public abstract NodeSpec build();
   }
 
+  public static NodeSpec.Builder builder() {
+    return new AutoValue_NodeSpec.Builder();
+  }
+
+  public static NodeSpec.Builder builder(final NodeSpec source) {
+    return new AutoValue_NodeSpec.Builder(source);
+  }
+
+  @JsonCreator
+  static NodeSpec create(@JsonProperty("Name") final String name,
+                         @JsonProperty("Labels") final Map<String, String> labels,
+                         @JsonProperty("Role") final String role,
+                         @JsonProperty("Availability") final String availability) {
+    final Builder builder = builder()
+        .name(name)
+        .labels(labels)
+        .role(role)
+        .availability(availability);
+
+    return builder.build();
+  }
 }

--- a/src/test/resources/fixtures/1.28/listNodes.json
+++ b/src/test/resources/fixtures/1.28/listNodes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "ID": "24ifsmvkjbyhk",
+    "Version": {
+      "Index": 8
+    },
+    "CreatedAt": "2016-06-07T20:31:11.853781916Z",
+    "UpdatedAt": "2016-06-07T20:31:11.999868824Z",
+    "Spec": {
+      "Name": "my-node",
+      "Role": "manager",
+      "Availability": "active",
+      "Labels": {
+        "foo": "bar"
+      }
+    },
+    "Description": {
+      "Hostname": "bf3067039e47",
+      "Platform": {
+        "Architecture": "x86_64",
+        "OS": "linux"
+      },
+      "Resources": {
+        "NanoCPUs": 4000000000,
+        "MemoryBytes": 8272408576
+      },
+      "Engine": {
+        "EngineVersion": "17.04.0",
+        "Labels": {
+          "foo": "bar"
+        },
+        "Plugins": [
+          {
+            "Type": "Volume",
+            "Name": "local"
+          },
+          {
+            "Type": "Network",
+            "Name": "bridge"
+          },
+          {
+            "Type": "Network",
+            "Name": "null"
+          },
+          {
+            "Type": "Network",
+            "Name": "overlay"
+          }
+        ]
+      }
+    },
+    "Status": {
+      "State": "ready",
+      "Addr": "172.17.0.2"
+    },
+    "ManagerStatus": {
+      "Leader": true,
+      "Reachability": "reachable",
+      "Addr": "172.17.0.2:2377"
+    }
+  }
+]

--- a/src/test/resources/fixtures/1.28/nodeSpec.json
+++ b/src/test/resources/fixtures/1.28/nodeSpec.json
@@ -1,0 +1,8 @@
+{
+  "Availability": "active",
+  "Name": "node-name",
+  "Role": "manager",
+  "Labels": {
+    "foo": "bar"
+  }
+}


### PR DESCRIPTION
I have need for being able to updateNode for the docker-api and this PR implements this functionality.

A few things are replicated from the inspectNode PR #774 for unit testing, and an exception class because that hasn't been merged yet. I thought it would be better to just create a different branch off of master for this additional functionality meanwhile.

I modified the existing NodeSpec class to have a Builder to enable the creation of object for use with the updateNode method on the DefaultDockerClient.