### PR TITLE
Upgrade guava to 20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Not yet released
 - Add Event types: plugin, node, service, and secret ([825][])
 - Add Event filters: plugin and scope ([825][])
 - Small fixes to code and tests for docker 17.06.0 ([825][])
+- Upgrade Google Guava to 20.0 ([792][])
 
 [825]: https://github.com/spotify/docker-client/pull/825
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>18.0</version>
+      <version>20.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -2613,7 +2613,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     } else {
       final String stripped = endpoint.replaceAll(".*://", "");
       final HostAndPort hostAndPort = HostAndPort.fromString(stripped);
-      final String hostText = hostAndPort.getHostText();
+      final String hostText = hostAndPort.getHost();
       final String scheme = certs.isPresent() ? "https" : "http";
 
       final int port = hostAndPort.getPortOrDefault(DockerHost.defaultPort());

--- a/src/main/java/com/spotify/docker/client/DockerHost.java
+++ b/src/main/java/com/spotify/docker/client/DockerHost.java
@@ -81,7 +81,7 @@ public class DockerHost {
     } else {
       final String stripped = endpoint.replaceAll(".*://", "");
       final HostAndPort hostAndPort = HostAndPort.fromString(stripped);
-      final String hostText = hostAndPort.getHostText();
+      final String hostText = hostAndPort.getHost();
       final String scheme = isNullOrEmpty(certPath) ? "http" : "https";
 
       this.port = hostAndPort.getPortOrDefault(defaultPort());


### PR DESCRIPTION
This upgrades the `guava` dependency to the latest Java 7 compatible version, allowing the usage of recent `guava` libraries in projects using `docker-client`. The version currently used (`18.0`) is 3 years old.

After merge `docker-client` **needs** guava >= `20.0`, see [here](https://github.com/google/guava/wiki/Release20#commonnet).

Further upgrades depend on https://github.com/spotify/docker-client/issues/756 :wink: 

