### PR TITLE
ISSUE-793: Make ManagerStatus and ManagerStatus.Leader nullable

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -374,6 +374,7 @@ public abstract class ContainerConfig {
 
     /**
      * In nanoseconds.
+     * @since API 1.29
      */
     @Nullable
     @JsonProperty("StartPeriod")

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -384,6 +384,14 @@ public abstract class ContainerConfig {
             @JsonProperty("Test") final List<String> test,
             @JsonProperty("Interval") final Long interval,
             @JsonProperty("Timeout") final Long timeout,
+            @JsonProperty("Retries") final Integer retries) {
+      return create(test, interval, timeout, retries, null);
+    }
+
+    public static Healthcheck create(
+            @JsonProperty("Test") final List<String> test,
+            @JsonProperty("Interval") final Long interval,
+            @JsonProperty("Timeout") final Long timeout,
             @JsonProperty("Retries") final Integer retries,
             @JsonProperty("StartPeriod") final Long startPeriod) {
       final Builder builder = builder();

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -379,7 +379,6 @@ public abstract class ContainerConfig {
     @JsonProperty("StartPeriod")
     public abstract Long startPeriod();
 
-    @JsonCreator
     public static Healthcheck create(
             @JsonProperty("Test") final List<String> test,
             @JsonProperty("Interval") final Long interval,
@@ -388,6 +387,7 @@ public abstract class ContainerConfig {
       return create(test, interval, timeout, retries, null);
     }
 
+    @JsonCreator
     public static Healthcheck create(
             @JsonProperty("Test") final List<String> test,
             @JsonProperty("Interval") final Long interval,

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -372,12 +372,20 @@ public abstract class ContainerConfig {
     @JsonProperty("Retries")
     public abstract Integer retries();
 
+    /**
+     * In nanoseconds.
+     */
+    @Nullable
+    @JsonProperty("StartPeriod")
+    public abstract Long startPeriod();
+
     @JsonCreator
     public static Healthcheck create(
             @JsonProperty("Test") final List<String> test,
             @JsonProperty("Interval") final Long interval,
             @JsonProperty("Timeout") final Long timeout,
-            @JsonProperty("Retries") final Integer retries) {
+            @JsonProperty("Retries") final Integer retries,
+            @JsonProperty("StartPeriod") final Long startPeriod) {
       final Builder builder = builder();
 
       if (test != null) {
@@ -391,6 +399,9 @@ public abstract class ContainerConfig {
       }
       if (retries != null) {
         builder.retries(retries);
+      }
+      if (startPeriod != null) {
+        builder.startPeriod(startPeriod);
       }
       return builder.build();
     }
@@ -408,6 +419,8 @@ public abstract class ContainerConfig {
       public abstract Builder timeout(final Long timeout);
 
       public abstract Builder retries(final Integer retries);
+
+      public abstract Builder startPeriod(final Long startPeriod);
 
       public abstract Healthcheck build();
     }

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ManagerStatus.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ManagerStatus.java
@@ -28,11 +28,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
+import javax.annotation.Nullable;
+
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 public abstract class ManagerStatus {
 
+  @Nullable
   @JsonProperty("Leader")
   public abstract Boolean leader();
 

--- a/src/main/java/com/spotify/docker/client/messages/swarm/NodeInfo.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/NodeInfo.java
@@ -58,6 +58,7 @@ public abstract class NodeInfo {
   @JsonProperty("Status")
   public abstract NodeStatus status();
 
+  @Nullable
   @JsonProperty("ManagerStatus")
   public abstract ManagerStatus managerStatus();
 

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -5111,8 +5111,10 @@ public class DefaultDockerClientTest {
             equalTo(3L));
     assertThat(service.spec().taskTemplate().containerSpec().healthcheck().retries(),
             equalTo(3));
+    final Matcher<Long> startPeriodMatcher = dockerApiVersionLessThan("1.29")
+            ? nullValue(Long.class) : equalTo(15L);
     assertThat(service.spec().taskTemplate().containerSpec().healthcheck().startPeriod(),
-            equalTo(15L));
+            startPeriodMatcher);
   }
 
   @Test

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -2374,7 +2374,7 @@ public class DefaultDockerClientTest {
         .cmd("sleep", "5")
         // Generate some healthy_status events
         .healthcheck(Healthcheck.create(ImmutableList.of("CMD-SHELL", "true"),
-            1000000000L, 1000000000L, 3))
+            1000000000L, 1000000000L, 3, 1000000000L))
         .build();
 
     final long startTime = new Date().getTime() / 1000;
@@ -5075,7 +5075,7 @@ public class DefaultDockerClientTest {
                     .secrets(Arrays.asList(secretBind))
                     .hostname(hostname)
                     .hosts(Arrays.asList(hosts))
-                    .healthcheck(Healthcheck.create(Arrays.asList(healthcheckCmd), 30L, 3L, 3))
+                    .healthcheck(Healthcheck.create(Arrays.asList(healthcheckCmd), 30L, 3L, 3, 15L))
                     .command(commandLine).build())
             .build();
     final String serviceName = randomName();
@@ -5111,6 +5111,8 @@ public class DefaultDockerClientTest {
             equalTo(3L));
     assertThat(service.spec().taskTemplate().containerSpec().healthcheck().retries(),
             equalTo(3));
+    assertThat(service.spec().taskTemplate().containerSpec().healthcheck().startPeriod(),
+            equalTo(15L));
   }
 
   @Test


### PR DESCRIPTION
Fix NodeInfo.ManagerStatus and ManagerStatus.Leader. Both fields can be null.