### PR TITLE
ISSUE-793: Make ManagerStatus and ManagerStatus.Leader nullable

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/swarm/ManagerStatus.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ManagerStatus.java
@@ -28,11 +28,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
+import javax.annotation.Nullable;
+
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 public abstract class ManagerStatus {
 
+  @Nullable
   @JsonProperty("Leader")
   public abstract Boolean leader();
 

--- a/src/main/java/com/spotify/docker/client/messages/swarm/NodeInfo.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/NodeInfo.java
@@ -58,6 +58,7 @@ public abstract class NodeInfo {
   @JsonProperty("Status")
   public abstract NodeStatus status();
 
+  @Nullable
   @JsonProperty("ManagerStatus")
   public abstract ManagerStatus managerStatus();
 


### PR DESCRIPTION
Fix NodeInfo.ManagerStatus and ManagerStatus.Leader: both fields can be null.