### PR TITLE
Fix broken TravisCI build 

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -22,6 +22,10 @@ case "$1" in
     # Remove old docker files that might prevent the installation and starting of other versions
     sudo rm -fr /var/lib/docker || :
 
+    # As instructed on http://docs.master.dockerproject.org/engine/installation/linux/ubuntulinux/
+    sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+    sudo sh -c "echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list"
+
     if [[ "$RC" == "true" ]]; then
         dist_version="$(lsb_release --codename | cut -f2)"
         sudo sh -c "echo deb [arch=$(dpkg --print-architecture)] https://apt.dockerproject.org/repo ubuntu-${dist_version} testing >> /etc/apt/sources.list.d/docker.list"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 language: java
 
 jdk:
-  - oraclejdk7
+  - openjdk7
 
 env:
   global:


### PR DESCRIPTION
This PR fixes two issues

1. oraclejdk7 is [currently broken][1] on Travis
2. docker-engine deb seems to only be available via the Docker PPA

  [1]: https://github.com/travis-ci/travis-ci/issues/7964