### PR TITLE
Fix RegistryAuth JSON properties

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/RegistryAuth.java
+++ b/src/main/java/com/spotify/docker/client/messages/RegistryAuth.java
@@ -40,26 +40,26 @@ import org.glassfish.jersey.internal.util.Base64;
 public abstract class RegistryAuth {
 
   @Nullable
-  @JsonProperty("Username")
+  @JsonProperty("username")
   public abstract String username();
 
   @Nullable
-  @JsonProperty("Password")
+  @JsonProperty("password")
   public abstract String password();
 
   /**
    * Unused but must be a well-formed email address (e.g. 1234@5678.com).
    */
   @Nullable
-  @JsonProperty("Email")
+  @JsonProperty("email")
   public abstract String email();
 
   @Nullable
-  @JsonProperty("ServerAddress")
+  @JsonProperty("serveraddress")
   public abstract String serverAddress();
 
   @Nullable
-  @JsonProperty("IdentityToken")
+  @JsonProperty("identitytoken")
   public abstract String identityToken();
 
   @Override
@@ -67,8 +67,8 @@ public abstract class RegistryAuth {
     return MoreObjects.toStringHelper(RegistryAuth.class)
         .add("username", username())
         // don't log the password or email
-        .add("serverAddress", serverAddress())
-        .add("identityToken", identityToken())
+        .add("serveraddress", serverAddress())
+        .add("identitytoken", identityToken())
         .toString();
   }
 
@@ -137,11 +137,11 @@ public abstract class RegistryAuth {
   }
 
   @JsonCreator
-  public static RegistryAuth create(@JsonProperty("username") String username,
-                                    @JsonProperty("password") String password,
+  public static RegistryAuth create(@JsonProperty("username") final String username,
+                                    @JsonProperty("password") final String password,
                                     @JsonProperty("email") final String email,
-                                    @JsonProperty("serverAddress") final String serverAddress,
-                                    @JsonProperty("identityToken") final String identityToken,
+                                    @JsonProperty("serveraddress") final String serveraddress,
+                                    @JsonProperty("identitytoken") final String identitytoken,
                                     @JsonProperty("auth") final String auth) {
 
     final Builder builder;
@@ -154,13 +154,13 @@ public abstract class RegistryAuth {
     }
     return builder
         .email(email)
-        .serverAddress(serverAddress)
-        .identityToken(identityToken)
+        .serverAddress(serveraddress)
+        .identityToken(identitytoken)
         .build();
   }
 
   /** Construct a Builder based upon the "auth" field of the docker client config file. */
-  public static Builder forAuth(String auth) {
+  public static Builder forAuth(final String auth) {
     // split with limit=2 to catch case where password contains a colon
     final String[] authParams = Base64.decodeAsString(auth).split(":", 2);
 

--- a/src/test/java/com/spotify/docker/client/messages/RegistryAuthTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/RegistryAuthTest.java
@@ -20,13 +20,30 @@
 
 package com.spotify.docker.client.messages;
 
+import static com.spotify.docker.FixtureUtil.fixture;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.BaseEncoding;
+import com.spotify.docker.client.ObjectMapperProvider;
 import org.junit.Test;
 
 public class RegistryAuthTest {
+
+  private static final ObjectMapper objectMapper = ObjectMapperProvider.objectMapper();
+
+  @Test
+  public void testDeserializingFromJson() throws Exception {
+    final RegistryAuth registryAuth =
+        objectMapper.readValue(fixture("fixtures/registryAuth.json"), RegistryAuth.class);
+    assertThat(registryAuth.username(), equalTo("hannibal"));
+    assertThat(registryAuth.password(), equalTo("xxxx"));
+    assertThat(registryAuth.email(), equalTo("hannibal@a-team.com"));
+    assertThat(registryAuth.serverAddress(), equalTo("https://index.docker.io/v1/"));
+    assertThat(registryAuth.identityToken(), equalTo("foobar"));
+  }
 
   @Test
   public void testForAuth() {

--- a/src/test/resources/dockerConfig/identityTokenConfig.json
+++ b/src/test/resources/dockerConfig/identityTokenConfig.json
@@ -2,7 +2,7 @@
   "auths": {
     "docker.customdomain.com": {
       "email": "dockerman@hub.com",
-      "identityToken": "52ce5fd5-eb60-42bf-931f-5eeec128211a"
+      "identitytoken": "52ce5fd5-eb60-42bf-931f-5eeec128211a"
     }
   }
 }

--- a/src/test/resources/fixtures/registryAuth.json
+++ b/src/test/resources/fixtures/registryAuth.json
@@ -1,0 +1,7 @@
+{
+  "username": "hannibal",
+  "password": "xxxx",
+  "email": "hannibal@a-team.com",
+  "serveraddress": "https://index.docker.io/v1/",
+  "identitytoken": "foobar"
+}


### PR DESCRIPTION
`RegistryAuth` keys should all be lowercase.
See https://docs.docker.com/engine/api/v1.25/#section/Authentication.

Fixes #648