### PR TITLE
Adapt to API changes in latest jnr-unixsocket.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.8</version>
+      <version>0.18</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>

--- a/src/main/java/com/spotify/docker/client/ApacheUnixSocket.java
+++ b/src/main/java/com/spotify/docker/client/ApacheUnixSocket.java
@@ -36,6 +36,7 @@ import java.util.Queue;
 
 import jnr.unixsocket.UnixSocketAddress;
 import jnr.unixsocket.UnixSocketChannel;
+import jnr.unixsocket.UnixSocketOptions;
 
 /**
  * Provides a socket that wraps an jnr.unixsocket.UnixSocketChannel and delays setting options until
@@ -196,14 +197,22 @@ public class ApacheUnixSocket extends Socket {
     setSocketOption(new SocketOptionSetter() {
       @Override
       public void run() throws SocketException {
-        inner.setSoTimeout(timeout);
+        try {
+          inner.setOption(UnixSocketOptions.SO_RCVTIMEO, Integer.valueOf(timeout));
+        } catch (IOException e) {
+          throw (SocketException)new SocketException().initCause(e);
+        }
       }
     });
   }
 
   @Override
   public synchronized int getSoTimeout() throws SocketException {
-    return inner.getSoTimeout();
+    try {
+      return inner.getOption(UnixSocketOptions.SO_RCVTIMEO).intValue();
+    } catch (IOException e) {
+      throw (SocketException)new SocketException().initCause(e);
+    }
   }
 
   @Override
@@ -231,14 +240,22 @@ public class ApacheUnixSocket extends Socket {
     setSocketOption(new SocketOptionSetter() {
       @Override
       public void run() throws SocketException {
-        inner.setKeepAlive(on);
+        try {
+          inner.setOption(UnixSocketOptions.SO_KEEPALIVE, Boolean.valueOf(on));
+        } catch (IOException e) {
+          throw (SocketException)new SocketException().initCause(e);
+        }
       }
     });
   }
 
   @Override
   public boolean getKeepAlive() throws SocketException {
-    return inner.getKeepAlive();
+    try {
+      return inner.getOption(UnixSocketOptions.SO_KEEPALIVE).booleanValue();
+    } catch (IOException e) {
+      throw (SocketException)new SocketException().initCause(e);
+    }
   }
 
   @Override


### PR DESCRIPTION
In the latest version of jnr-unixsocket, some getter/setter methods in
the UnixSocketChannel object went away. This change replaces usage of
those getters/setters with calls to getOption/setOption instead.
