### PR TITLE
Fixes for docker 17.06.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Not yet released
 
 - Rename `NoOpRegistryAuthSupplier` to `FixedRegistryAuthSupplier`
 - Fix RegistryAuth JSON properties; RegistryAuth keys should all be lowercase
+- Add Event types: plugin, node, service, and secret ([825][])
+- Add Event filters: plugin and scope ([825][])
+- Small fixes to code and tests for docker 17.06.0 ([825][])
+
+[825]: https://github.com/spotify/docker-client/pull/825
 
 ## 8.8.0
 
@@ -133,7 +138,7 @@ but never used the value were removed. These methods are:
 
 ### Fix thread-safety issues with DefaultDockerClient's connection pool
 
-See [#446](https://github.com/spotify/docker-client/issues/446) 
+See [#446](https://github.com/spotify/docker-client/issues/446)
 and [#744](https://github.com/spotify/docker-client/pulls/744).
 
 ## 7.0.0

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -2700,6 +2700,27 @@ public interface DockerClient extends Closeable {
     public static EventsParam label(final String label) {
       return label(label, null);
     }
+
+    /**
+     * Show events for a plugin.
+     * @param plugin A plugin name or id
+     * @return EventsParam
+     * @since API 1.30
+     */
+    public static EventsParam plugin(final String plugin) {
+      return filter("plugin", plugin);
+    }
+
+    /**
+     * Show events for a scope: "local" or "swarm"
+     * @param scope "local" or "swarm"
+     * @return EventsParam
+     * @since API 1.30
+     */
+    public static EventsParam scope(final String scope) {
+      return filter("scope", scope);
+    }
+
   }
 
   /**

--- a/src/main/java/com/spotify/docker/client/messages/Event.java
+++ b/src/main/java/com/spotify/docker/client/messages/Event.java
@@ -145,7 +145,11 @@ public abstract class Event {
     IMAGE("image"),
     VOLUME("volume"),
     NETWORK("network"),
-    DAEMON("daemon");
+    DAEMON("daemon"),
+    PLUGIN("plugin"),
+    NODE("node"),
+    SERVICE("service"),
+    SECRET("secret");
 
     private final String name;
 

--- a/src/main/java/com/spotify/docker/client/messages/swarm/EndpointVirtualIp.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/EndpointVirtualIp.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
+import javax.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
@@ -36,6 +37,7 @@ public abstract class EndpointVirtualIp {
   @JsonProperty("NetworkID")
   public abstract String networkId();
 
+  @Nullable
   @JsonProperty("Addr")
   public abstract String addr();
 

--- a/src/main/java/com/spotify/docker/client/messages/swarm/NetworkAttachment.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/NetworkAttachment.java
@@ -45,6 +45,10 @@ public abstract class NetworkAttachment {
   static NetworkAttachment create(
       @JsonProperty("Network") final Network network,
       @JsonProperty("Addresses") final List<String> addresses) {
-    return new AutoValue_NetworkAttachment(network, ImmutableList.copyOf(addresses));
+    final ImmutableList<String> addressesCopy =
+            addresses == null
+                    ? ImmutableList.<String>of()
+                    : ImmutableList.copyOf(addresses);
+    return new AutoValue_NetworkAttachment(network, addressesCopy);
   }
 }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -4894,6 +4894,8 @@ public class DefaultDockerClientTest {
   @Test
   public void testCreateServiceWithWarnings() throws Exception {
     requireDockerApiVersionAtLeast("1.25", "swarm support");
+    requireDockerApiVersionLessThan("1.30",
+            "warning on create service with bad image");
 
     final TaskSpec taskSpec = TaskSpec.builder()
         .containerSpec(ContainerSpec.builder()

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -2864,13 +2864,16 @@ public class DefaultDockerClientTest {
       assertThat(bindObjectMount.rw(), is(false));
       assertThat(bindObjectMount.mode(), is(equalTo("ro")));
 
-      if (dockerApiVersionAtLeast("1.25")) {
+      if (dockerApiVersionAtLeast("1.25") && dockerApiVersionLessThan("1.30")) {
+        // From version 1.25 to 1.29, the API behaved like this
         assertThat(bindObjectMount.name(), isEmptyOrNullString());
         assertThat(bindObjectMount.propagation(), isEmptyOrNullString());
-      } else if (dockerApiVersionAtLeast("1.22")) {
+      } else if (dockerApiVersionAtLeast("1.22") || dockerApiVersionAtLeast("1.30")) {
+        // From version 1.22 to 1.24, and from 1.30 up, the API behaves like this
         assertThat(bindObjectMount.name(), isEmptyOrNullString());
         assertThat(bindObjectMount.propagation(), is(equalTo("rprivate")));
       } else {
+        // Below version 1.22
         assertThat(bindObjectMount.name(), is(nullValue()));
         assertThat(bindObjectMount.propagation(), is(nullValue()));
       }
@@ -2899,13 +2902,16 @@ public class DefaultDockerClientTest {
       assertThat(bindStringMount.rw(), is(true));
       assertThat(bindStringMount.mode(), is(equalTo("")));
 
-      if (dockerApiVersionAtLeast("1.25")) {
+      if (dockerApiVersionAtLeast("1.25") && dockerApiVersionLessThan("1.30")) {
+        // From version 1.25 to 1.29, the API behaved like this
         assertThat(bindStringMount.name(), isEmptyOrNullString());
         assertThat(bindStringMount.propagation(), isEmptyOrNullString());
-      } else if (dockerApiVersionAtLeast("1.22")) {
+      } else if (dockerApiVersionAtLeast("1.22") || dockerApiVersionAtLeast("1.30")) {
+        // From version 1.22 to 1.24, and from 1.30 up, the API behaves like this
         assertThat(bindStringMount.name(), isEmptyOrNullString());
         assertThat(bindStringMount.propagation(), is(equalTo("rprivate")));
       } else {
+        // Below version 1.22
         assertThat(bindStringMount.name(), is(nullValue()));
         assertThat(bindStringMount.propagation(), is(nullValue()));
       }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -5136,9 +5136,8 @@ public class DefaultDockerClientTest {
     final Service service = sut.inspectService(response.id());
 
     assertThat(service.spec().name(), is(serviceName));
-    final Matcher<String> imageMatcher = dockerApiVersionLessThan("1.25") || dockerApiVersionAtLeast("1.30")
-            ? is("alpine") : startsWith("alpine:latest@sha256:");
-    assertThat(service.spec().taskTemplate().containerSpec().image(), imageMatcher);
+    assertThat(service.spec().taskTemplate().containerSpec().image(),
+            latestImageNameMatcher("alpine"));
     assertThat(service.spec().taskTemplate().containerSpec().hostname(), is(hostname));
     assertThat(service.spec().taskTemplate().containerSpec().hosts(), containsInAnyOrder(hosts));
     assertThat(service.spec().taskTemplate().containerSpec().secrets().size(),
@@ -5206,9 +5205,8 @@ public class DefaultDockerClientTest {
     final Service service = sut.inspectService(response.id());
 
     assertThat(service.spec().name(), is(serviceName));
-    final Matcher<String> imageMatcher = dockerApiVersionLessThan("1.25")
-                                         ? is("alpine") : startsWith("alpine:latest@sha256:");
-    assertThat(service.spec().taskTemplate().containerSpec().image(), imageMatcher);
+    assertThat(service.spec().taskTemplate().containerSpec().image(),
+            latestImageNameMatcher("alpine"));
     assertThat(service.spec().taskTemplate().containerSpec().command(),
                equalTo(Arrays.asList(commandLine)));
   }
@@ -5418,9 +5416,7 @@ public class DefaultDockerClientTest {
     final ContainerSpec containerSpecTemplate = taskSpecTemplate.containerSpec();
     final ContainerSpec containerSpecActual = taskSpecActual.containerSpec();
     assertThat(containerSpecActual.image(),
-            dockerApiVersionLessThan("1.25")
-                    ? is(containerSpecTemplate.image())
-                    : startsWith(containerSpecTemplate.image() + ":latest@sha256:"));
+            latestImageNameMatcher(containerSpecTemplate.image()));
     assertEquals(containerSpecTemplate.labels(), containerSpecActual.labels());
     assertEquals(containerSpecTemplate.command(), containerSpecActual.command());
     assertEquals(containerSpecTemplate.args(), containerSpecActual.args());
@@ -5726,5 +5722,10 @@ public class DefaultDockerClientTest {
                && publishModeMatcher.matches(portConfig.publishMode());
       }
     };
+  }
+
+  private Matcher<String> latestImageNameMatcher(final String imageName) throws Exception {
+    return dockerApiVersionLessThan("1.25") || dockerApiVersionAtLeast("1.30")
+            ? is(imageName) : startsWith(imageName + ":latest@sha256:");
   }
 }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -48,6 +48,7 @@ import static com.spotify.docker.client.DockerClient.LogsParam.stderr;
 import static com.spotify.docker.client.DockerClient.LogsParam.stdout;
 import static com.spotify.docker.client.DockerClient.LogsParam.tail;
 import static com.spotify.docker.client.DockerClient.LogsParam.timestamps;
+import static com.spotify.docker.client.DockerClient.RemoveContainerParam.forceKill;
 import static com.spotify.docker.client.VersionCompare.compareVersion;
 import static com.spotify.docker.client.messages.Event.Type.CONTAINER;
 import static com.spotify.docker.client.messages.Event.Type.IMAGE;
@@ -3714,6 +3715,10 @@ public class DefaultDockerClientTest {
     final List<Container> quxContainers =
         sut.listContainers(withLabel("foo", "qux"));
     assertThat(quxContainers.size(), equalTo(0));
+
+    // Clean up
+    sut.removeContainer(id, forceKill());
+    sut.removeContainer(id2, forceKill());
   }
 
   @Test

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -1030,8 +1030,8 @@ public class DefaultDockerClientTest {
     final AtomicBoolean usedCache = new AtomicBoolean(false);
     sut.build(dockerDirectory, "test", new ProgressHandler() {
       @Override
-      public void progress(ProgressMessage message) throws DockerException {
-        if (message.stream().contains(usingCache)) {
+      public void progress(final ProgressMessage message) throws DockerException {
+        if (message.stream() != null && message.stream().contains(usingCache)) {
           usedCache.set(true);
         }
       }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -3048,6 +3048,8 @@ public class DefaultDockerClientTest {
     sut.createContainer(volumeConfig, volumeContainer);
     sut.startContainer(volumeContainer);
 
+    Thread.sleep(1000L);
+
     final String logs;
     try (LogStream stream = sut.attachContainer(volumeContainer,
                                                 AttachParameter.LOGS, AttachParameter.STDOUT,

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -3307,6 +3307,9 @@ public class DefaultDockerClientTest {
     final String goodName = "aBc1.2-3_";
     sut.createContainer(config, goodName);
 
+    // Clean up so subsequent test runs do not fail. -JF
+    sut.removeContainer(goodName);
+
     // Bad names
     final String oneCharacter = "a";
     exception.expect(invalidContainerNameException(oneCharacter));


### PR DESCRIPTION
In fixing #822, I saw that a lot of tests were failing on docker `17.06.0`. I fixed all the errors in both tests and code so that the tests run cleanly on my machine. 

However, we can't test `17.06.0` on travis yet because it isn't in the [docker apt repo](https://apt.dockerproject.org/repo/).