### PR TITLE
Fix https json authFor.  Reader fromConfig throws IllegalArgumentAcce…

### DIFF
--- a/src/main/java/com/spotify/docker/client/auth/ConfigFileRegistryAuthSupplier.java
+++ b/src/main/java/com/spotify/docker/client/auth/ConfigFileRegistryAuthSupplier.java
@@ -77,8 +77,12 @@ public class ConfigFileRegistryAuthSupplier implements RegistryAuthSupplier {
       }
       return reader.fromConfig(path, ref.getRegistryName());
     } catch (IllegalArgumentException e) {
-      // no configuration for registry
-      return null;
+      log.debug("Failed first attempt to find auth for {}", ref.getRegistryUrl(), e);
+      try {
+        return reader.fromConfig(path, ref.getRegistryName());
+      } catch (IllegalArgumentException | IOException e2) {
+        throw new DockerException(e2);
+      }
     } catch (IOException e) {
       throw new DockerException(e);
     }

--- a/src/main/java/com/spotify/docker/client/auth/ConfigFileRegistryAuthSupplier.java
+++ b/src/main/java/com/spotify/docker/client/auth/ConfigFileRegistryAuthSupplier.java
@@ -83,7 +83,7 @@ public class ConfigFileRegistryAuthSupplier implements RegistryAuthSupplier {
       } catch (IllegalArgumentException e2) {
         log.debug("Failed second attempt to find auth for {}", ref.getRegistryName(), e2);
         return null;
-      } catch (IOExeption e2) {
+      } catch (IOException e2) {
         throw new DockerException(e2);
       }
     } catch (IOException e) {

--- a/src/main/java/com/spotify/docker/client/auth/ConfigFileRegistryAuthSupplier.java
+++ b/src/main/java/com/spotify/docker/client/auth/ConfigFileRegistryAuthSupplier.java
@@ -80,7 +80,10 @@ public class ConfigFileRegistryAuthSupplier implements RegistryAuthSupplier {
       log.debug("Failed first attempt to find auth for {}", ref.getRegistryUrl(), e);
       try {
         return reader.fromConfig(path, ref.getRegistryName());
-      } catch (IllegalArgumentException | IOException e2) {
+      } catch (IllegalArgumentException e2) {
+        log.debug("Failed second attempt to find auth for {}", ref.getRegistryName(), e2);
+        return null;
+      } catch (IOExeption e2) {
         throw new DockerException(e2);
       }
     } catch (IOException e) {


### PR DESCRIPTION
docker login creates a json auth config file without a scheme on the host.  There was code to handle this but it assumed the method would return null on failure.  The method fromConfig throws and IllegalArgumentException if it is unable to find the configuration.  I've update the method to handle the fallback case in the catch block.