### PR TITLE
Add the boolean parameter 'Force' to DockerClient#disconnectFromNetwork and fix issue on exceptions being swalled

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -2230,7 +2230,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   @Override
   public void connectToNetwork(String containerId, String networkId)
       throws DockerException, InterruptedException {
-    manageNetworkConnection(containerId, "connect", networkId);
+    connectToNetwork(networkId, NetworkConnection.builder().containerId(containerId).build());
   }
 
   @Override
@@ -2239,7 +2239,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     final WebTarget resource = resource().path("networks").path(networkId).path("connect");
 
     try {
-      request(POST, Response.class, resource, resource.request(APPLICATION_JSON_TYPE),
+      request(POST, String.class, resource, resource.request(APPLICATION_JSON_TYPE),
               Entity.json(networkConnection));
     } catch (DockerRequestException e) {
       switch (e.status()) {
@@ -2256,18 +2256,20 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   @Override
   public void disconnectFromNetwork(String containerId, String networkId)
       throws DockerException, InterruptedException {
-    manageNetworkConnection(containerId, "disconnect", networkId);
+    disconnectFromNetwork(containerId, networkId, false);
   }
 
-  private void manageNetworkConnection(String containerId, String methodname, String networkId)
-      throws DockerException, InterruptedException {
-    final WebTarget resource = resource().path("networks").path(networkId).path(methodname);
+  @Override
+  public void disconnectFromNetwork(String containerId, String networkId, boolean force)
+          throws DockerException, InterruptedException {
+    final WebTarget resource = resource().path("networks").path(networkId).path("disconnect");
 
-    final Map<String, String> request = new HashMap<>();
+    final Map<String, Object> request = new HashMap<>();
     request.put("Container", containerId);
+    request.put("Force", force);
 
     try {
-      request(POST, Response.class, resource, resource.request(APPLICATION_JSON_TYPE),
+      request(POST, String.class, resource, resource.request(APPLICATION_JSON_TYPE),
               Entity.json(request));
     } catch (DockerRequestException e) {
       switch (e.status()) {
@@ -2844,5 +2846,4 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       return new DefaultDockerClient(this);
     }
   }
-
 }

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -1948,6 +1948,19 @@ public interface DockerClient extends Closeable {
       throws DockerException, InterruptedException;
 
   /**
+   * Disconnects a docker container to a network.
+   *
+   * @param containerId The id of the container to disconnect.
+   * @param networkId   The id of the network to disconnect.
+   * @param force       Force the container to disconnect from the network.
+   * @throws NotFoundException if either container or network is not found (404)
+   * @throws DockerException            if a server error occurred (500)
+   * @throws InterruptedException       If the thread is interrupted
+   */
+  void disconnectFromNetwork(String containerId, String networkId, boolean force)
+          throws DockerException, InterruptedException;
+
+  /**
    * Closes any and all underlying connections to docker, and release resources.
    */
   @Override

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -4062,62 +4062,6 @@ public class DefaultDockerClientTest {
   }
 
   @Test
-  public void testNetworksConnectContainerWithoutForcefulDisconnectNetwork() throws Exception {
-    requireDockerApiVersionAtLeast("1.21", "createNetwork and listNetworks");
-    assumeFalse(CIRCLECI);
-
-    sut.pull(BUSYBOX_LATEST);
-    final String networkName = randomName();
-    final String containerName = randomName();
-    final NetworkCreation networkCreation =
-            sut.createNetwork(NetworkConfig.builder().name(networkName).build());
-    assertThat(networkCreation.id(), is(notNullValue()));
-    final ContainerConfig containerConfig =
-        ContainerConfig.builder().image(BUSYBOX_LATEST).cmd("sh", "-c", "while :; do sleep 1; done")
-        .build();
-    final ContainerCreation containerCreation = sut.createContainer(containerConfig, containerName);
-    assertThat(containerCreation.id(), is(notNullValue()));
-    sut.startContainer(containerCreation.id());
-    sut.connectToNetwork(containerCreation.id(), networkCreation.id());
-
-    Network network = sut.inspectNetwork(networkCreation.id());
-    assertThat(network.containers().size(), equalTo(1));
-    final Network.Container container = network.containers().get(containerCreation.id());
-    assertThat(container, notNullValue());
-    if (dockerApiVersionAtLeast("1.22")) {
-      assertThat(container.name(), notNullValue());
-    }
-    assertThat(container.macAddress(), notNullValue());
-    assertThat(container.ipv4Address(), notNullValue());
-    assertThat(container.ipv6Address(), notNullValue());
-
-    final ContainerInfo containerInfo = sut.inspectContainer(containerCreation.id());
-    assertThat(containerInfo.networkSettings().networks().size(), is(2));
-    final AttachedNetwork attachedNetwork =
-            containerInfo.networkSettings().networks().get(networkName);
-    assertThat(attachedNetwork, is(notNullValue()));
-    if (dockerApiVersionAtLeast("1.22")) {
-      assertThat(attachedNetwork.networkId(), is(notNullValue()));
-    }
-    assertThat(attachedNetwork.endpointId(), is(notNullValue()));
-    assertThat(attachedNetwork.gateway(), is(notNullValue()));
-    assertThat(attachedNetwork.ipAddress(), is(notNullValue()));
-    assertThat(attachedNetwork.ipPrefixLen(), is(notNullValue()));
-    assertThat(attachedNetwork.macAddress(), is(notNullValue()));
-    assertThat(attachedNetwork.ipv6Gateway(), is(notNullValue()));
-    assertThat(attachedNetwork.globalIPv6Address(), is(notNullValue()));
-    assertThat(attachedNetwork.globalIPv6PrefixLen(), greaterThanOrEqualTo(0));
-    sut.disconnectFromNetwork(containerCreation.id(), networkCreation.id(), true);
-    network = sut.inspectNetwork(networkCreation.id());
-    assertThat(network.containers().size(), equalTo(0));
-
-    sut.stopContainer(containerCreation.id(), 1);
-    sut.removeContainer(containerCreation.id());
-    sut.removeNetwork(networkCreation.id());
-
-  }
-
-  @Test
   public void testNetworksConnectContainerWithEndpointConfig() throws Exception {
     requireDockerApiVersionAtLeast("1.22", "createNetwork and listNetworks");
 


### PR DESCRIPTION
Add the boolean parameter 'Force' to DockerClient#disconnectFromNetwork at [Docker Networks](https://docs.docker.com/engine/api/v1.30/#operation/NetworkDisconnect).

Refactored accordingly due to the introduction of the new parameter.

Fix issue at DockerClient#disconnectFromNetwork and DockerClient#connectToNetwork that led to an request error (HTTP 4xx, 5xx) to be swalled and no exception has been thrown.
This was happening since the request was using Response.class and JerseyInvocation#translate would just report the error via Response.class whenever this class is used to carry the response data. If a different class other then Response.class is given, then Jersey will thrown an exception.