### PR TITLE
Use FixtureUtil.fixture() everywhere

### DIFF
--- a/src/test/java/com/spotify/docker/client/messages/ContainerStateTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/ContainerStateTest.java
@@ -20,6 +20,7 @@
 
 package com.spotify.docker.client.messages;
 
+import static com.spotify.docker.FixtureUtil.fixture;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -94,10 +95,5 @@ public class ContainerStateTest {
   public void testLoadInvalidJson() throws Exception {
     expectedException.expect(JsonParseException.class);
     objectMapper.readValue(fixture("fixtures/invalid.json"), ContainerState.class);
-
-  }
-
-  private static String fixture(String filename) throws IOException {
-    return Resources.toString(Resources.getResource(filename), Charsets.UTF_8).trim();
   }
 }

--- a/src/test/java/com/spotify/docker/client/messages/HostConfigTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/HostConfigTest.java
@@ -20,6 +20,7 @@
 
 package com.spotify.docker.client.messages;
 
+import static com.spotify.docker.FixtureUtil.fixture;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
@@ -67,10 +68,6 @@ public class HostConfigTest {
         .readValue(fixture("fixtures/hostConfig/restartPolicyOnFailure.json"),
                    HostConfig.class);
     assertThat(hostConfig.restartPolicy(), is(HostConfig.RestartPolicy.onFailure(5)));
-  }
-
-  private static String fixture(String filename) throws IOException {
-    return Resources.toString(Resources.getResource(filename), Charsets.UTF_8).trim();
   }
 
   @Test


### PR DESCRIPTION
and remove redundant implementations.