### PR TITLE
Relocate guava classes with maven shade plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,7 @@
               <include>org.glassfish.**</include>
               <include>com.github.jnr:*</include>
               <include>org.ow2.asm:*</include>
+              <include>com.google.guava:**</include>
             </includes>
           </artifactSet>
           <relocations>
@@ -337,6 +338,10 @@
             <relocation>
               <pattern>com.fasterxml.jackson</pattern>
               <shadedPattern>com.spotify.docker.client.shaded.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.guava</pattern>
+              <shadedPattern>com.spotify.docker.client.shaded.com.google.guava</shadedPattern>
             </relocation>
           </relocations>
           <shadedArtifactAttached>true</shadedArtifactAttached>

--- a/pom.xml
+++ b/pom.xml
@@ -340,8 +340,8 @@
               <shadedPattern>com.spotify.docker.client.shaded.com.fasterxml.jackson</shadedPattern>
             </relocation>
             <relocation>
-              <pattern>com.google.guava</pattern>
-              <shadedPattern>com.spotify.docker.client.shaded.com.google.guava</shadedPattern>
+              <pattern>com.google.common</pattern>
+              <shadedPattern>com.spotify.docker.client.shaded.com.google.common</shadedPattern>
             </relocation>
           </relocations>
           <shadedArtifactAttached>true</shadedArtifactAttached>


### PR DESCRIPTION
to avoid class conflicts with other guava versions.

Fixes #826