### PR TITLE
make ImageInfo.RootFS nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 8.8.5
+
+Not yet released
+
+- Allow `ImageInfo.RootFS` to be nullable. This field was added in Docker
+  Remote API 1.23 / Docker version 1.11. The field was added to the ImageInfo
+  class in docker-client 8.8.2. ([862][])
+
+[862]: https://github.com/spotify/docker-client/pull/862
+
 ## 8.8.4
 
 Released August 8, 2017

--- a/src/main/java/com/spotify/docker/client/messages/ImageInfo.java
+++ b/src/main/java/com/spotify/docker/client/messages/ImageInfo.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
 import java.util.Date;
+import javax.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
@@ -73,6 +74,7 @@ public abstract class ImageInfo {
   @JsonProperty("VirtualSize")
   public abstract Long virtualSize();
 
+  @Nullable
   @JsonProperty("RootFS")
   public abstract RootFs rootFs();
 

--- a/src/test/java/com/spotify/docker/client/messages/ImageInfoTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/ImageInfoTest.java
@@ -21,24 +21,31 @@
 package com.spotify.docker.client.messages;
 
 import static com.spotify.docker.FixtureUtil.fixture;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spotify.docker.client.ObjectMapperProvider;
-
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class ImageInfoTest {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   private ObjectMapper objectMapper = ObjectMapperProvider.objectMapper();
 
   @Test
   public void test1_24() throws Exception {
     objectMapper.readValue(fixture("fixtures/1.24/imageInfo.json"), ImageInfo.class);
+  }
+
+  /**
+   * Test that an ImageInfo message from 1.22 - before RootFs was introduced - can be deserialized.
+   */
+  @Test
+  public void test1_22() throws Exception {
+    final ImageInfo imageInfo =
+        objectMapper.readValue(fixture("fixtures/1.22/imageInfo.json"), ImageInfo.class);
+    assertThat(imageInfo.rootFs(), is(nullValue()));
   }
 
 }

--- a/src/test/resources/fixtures/1.22/imageInfo.json
+++ b/src/test/resources/fixtures/1.22/imageInfo.json
@@ -1,0 +1,67 @@
+{
+  "Id": "sha256:6f470f6fc044b7fdd48e3e1b63b8360c66ad8e99959e457e96db9093e66dca63",
+  "RepoTags": [
+    "busybox:buildroot-2013.08.1"
+  ],
+  "RepoDigests": [
+    "busybox@sha256:4eccca494e527311eb4a4ebee1f90d9362971d882bb22fd7ded46d517129b1ac"
+  ],
+  "Parent": "",
+  "Comment": "",
+  "Created": "2015-09-18T17:44:28.145855389Z",
+  "Container": "c86542e1a6d3b7b8354bcbcb97a50821aec58b96f7ae3ad0d8e1655477138eca",
+  "ContainerConfig": {
+    "Hostname": "34b4d68f8959",
+    "Domainname": "",
+    "User": "",
+    "AttachStdin": false,
+    "AttachStdout": false,
+    "AttachStderr": false,
+    "Tty": false,
+    "OpenStdin": false,
+    "StdinOnce": false,
+    "Env": null,
+    "Cmd": [
+      "/bin/sh",
+      "-c",
+      "#(nop) CMD [\"/bin/sh\"]"
+    ],
+    "Image": "77608b59d92f23a988df653ad660e91e04c72d20bfaf1a7f06ae6a6a79331482",
+    "Volumes": null,
+    "WorkingDir": "",
+    "Entrypoint": null,
+    "OnBuild": null,
+    "Labels": null
+  },
+  "DockerVersion": "1.8.2",
+  "Author": "Jérôme Petazzoni <jerome@docker.com>",
+  "Config": {
+    "Hostname": "34b4d68f8959",
+    "Domainname": "",
+    "User": "",
+    "AttachStdin": false,
+    "AttachStdout": false,
+    "AttachStderr": false,
+    "Tty": false,
+    "OpenStdin": false,
+    "StdinOnce": false,
+    "Env": null,
+    "Cmd": [
+      "/bin/sh"
+    ],
+    "Image": "77608b59d92f23a988df653ad660e91e04c72d20bfaf1a7f06ae6a6a79331482",
+    "Volumes": null,
+    "WorkingDir": "",
+    "Entrypoint": null,
+    "OnBuild": null,
+    "Labels": null
+  },
+  "Architecture": "amd64",
+  "Os": "linux",
+  "Size": 2489301,
+  "VirtualSize": 2489301,
+  "GraphDriver": {
+    "Name": "aufs",
+    "Data": null
+  }
+}


### PR DESCRIPTION
`RootFS` was added to the ImageInfo / inspectImage response in version
1.23 of the Docker Remote API (for Docker version 1.11). Earlier
versions of the API do not have this field present in ImageInfo.

We caught this because we run tests for spotify/helios on CircleCI which
uses Docker 1.10.