### PR TITLE
added registry auth to update function

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -1844,11 +1844,19 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   @Override
   public void updateService(final String serviceId, final Long version, final ServiceSpec spec)
       throws DockerException, InterruptedException {
+    updateService(serviceId, version, spec, registryAuthSupplier.authForSwarm());
+  }
+  
+  @Override
+  public void updateService(final String serviceId, final Long version, final ServiceSpec spec,
+                                             final RegistryAuth config)
+      throws DockerException, InterruptedException {
     assertApiVersionIsAbove("1.24");
     try {
       WebTarget resource = resource().path("services").path(serviceId).path("update");
       resource = resource.queryParam("version", version);
-      request(POST, String.class, resource, resource.request(APPLICATION_JSON_TYPE),
+      request(POST, String.class, resource, resource.request(APPLICATION_JSON_TYPE)
+              .header("X-Registry-Auth", authHeader(config)),
               Entity.json(spec));
     } catch (DockerRequestException e) {
       switch (e.status()) {

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -1596,7 +1596,20 @@ public interface DockerClient extends Closeable {
    */
   void updateService(String serviceId, Long version, ServiceSpec spec)
           throws DockerException, InterruptedException;
-
+  
+  /**
+   * Update an existing service. Only available in Docker API &gt;= 1.24.
+   *
+   * @param serviceId the identifier of the service
+   * @param version the version of the service
+   * @param spec the new service spec
+   * @param registryAuth the registry authentication configuration
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  void updateService(String serviceId, Long version, ServiceSpec spec, RegistryAuth registryAuth)
+          throws DockerException, InterruptedException;
+  
   /**
    * List all services. Only available in Docker API &gt;= 1.24.
    *


### PR DESCRIPTION
if you need to update the password or credentials you have to send the new credentials with update, also important if ecr is your registry of choice because you need to update them every 12 hours