### PR TITLE
Updated the ContainerSpec to have support for Config bindings

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/swarm/ConfigBind.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ConfigBind.java
@@ -1,0 +1,70 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages.swarm;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public abstract class ConfigBind {
+  @JsonProperty("File")
+  public abstract ConfigFile file();
+
+  @JsonProperty("ConfigID")
+  public abstract String configId();
+
+  @JsonProperty("ConfigName")
+  public abstract String configName();
+
+  public static Builder builder() {
+    return new AutoValue_ConfigBind.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder file(ConfigFile file);
+
+    public abstract Builder configId(String configId);
+
+    public abstract Builder configName(String configName);
+
+    public abstract ConfigBind build();
+  }
+
+  @JsonCreator
+  static ConfigBind create(
+         @JsonProperty("File") ConfigFile file,
+         @JsonProperty("ConfigID") String configId,
+         @JsonProperty("ConfigName") String configName) {
+    return builder()
+        .file(file)
+        .configId(configId)
+        .configName(configName)
+        .build();
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ConfigFile.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ConfigFile.java
@@ -1,0 +1,81 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages.swarm;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public abstract class ConfigFile {
+  @JsonProperty("Name")
+  public abstract String name();
+
+  @Nullable
+  @JsonProperty("UID")
+  public abstract String uid();
+
+  @Nullable
+  @JsonProperty("GID")
+  public abstract String gid();
+
+  @Nullable
+  @JsonProperty("Mode")
+  public abstract Long mode();
+
+  public static Builder builder() {
+    return new AutoValue_ConfigFile.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder name(String name);
+
+    public abstract Builder uid(String uid);
+
+    public abstract Builder gid(String gid);
+
+    public abstract Builder mode(Long mode);
+
+    public abstract ConfigFile build();
+  }
+
+  @JsonCreator
+  static ConfigFile create(
+      @JsonProperty("Name") String name,
+      @JsonProperty("UID") String uid,
+      @JsonProperty("GID") String gid,
+      @JsonProperty("Mode") Long mode) {
+    return builder()
+        .name(name)
+        .uid(uid)
+        .gid(gid)
+        .mode(mode)
+        .build();
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ContainerSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ContainerSpec.java
@@ -111,6 +111,13 @@ public abstract class ContainerSpec {
   @JsonProperty("Secrets")
   public abstract ImmutableList<SecretBind> secrets();
 
+  /**
+   * @since API 1.30
+   */
+  @Nullable
+  @JsonProperty("Configs")
+  public abstract ImmutableList<ConfigBind> configs();
+
   @Nullable
   @JsonProperty("DNSConfig")
   public abstract DnsConfig dnsConfig();
@@ -339,6 +346,8 @@ public abstract class ContainerSpec {
 
     public abstract Builder secrets(List<SecretBind> secrets);
 
+    public abstract Builder configs(List<ConfigBind> configs);
+
     public abstract ContainerSpec build();
   }
 
@@ -363,7 +372,8 @@ public abstract class ContainerSpec {
       @JsonProperty("Healthcheck") final ContainerConfig.Healthcheck healthcheck,
       @JsonProperty("Hosts") final List<String> hosts,
       @JsonProperty("Secrets") final List<SecretBind> secrets,
-      @JsonProperty("DNSConfig") final DnsConfig dnsConfig) {
+      @JsonProperty("DNSConfig") final DnsConfig dnsConfig,
+      @JsonProperty("Configs") final List<ConfigBind> configs) {
     final Builder builder = builder()
         .image(image)
         .hostname(hostname)
@@ -389,6 +399,10 @@ public abstract class ContainerSpec {
 
     if (secrets != null) {
       builder.secrets(secrets);
+    }
+
+    if (configs != null) {
+      builder.configs(configs);
     }
 
     return builder.build();

--- a/src/test/resources/fixtures/1.30/createServiceResponse.json
+++ b/src/test/resources/fixtures/1.30/createServiceResponse.json
@@ -1,0 +1,3 @@
+{
+  "ID": "ak7w3gjqoa3kuz8xcpnyy0pvl"
+}


### PR DESCRIPTION
This PR updates the existing ContainerSpec value object to have support for the specification of config bindings for docker API >= 1.30