### PR TITLE
Do not try to make a DefaultDockerClient using a URL with no scheme

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -386,6 +386,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
    */
   protected DefaultDockerClient(final Builder builder) {
     final URI originalUri = checkNotNull(builder.uri, "uri");
+    checkNotNull(originalUri.getScheme(), "url has null scheme");
     this.apiVersion = builder.apiVersion();
 
     if ((builder.dockerCertificatesStore != null) && !originalUri.getScheme().equals("https")) {


### PR DESCRIPTION
A `DefaultDockerClient` will fail to build if the `builder.uri` has a `null` scheme. This adds a check for that, so at least we can get a more helpful error message.