### PR TITLE
Change the scope for logback-classic to test to avoid pulling in the jar for regular builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,7 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.2.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.jimfs</groupId>


### PR DESCRIPTION
@davidxia  pls review and merge as appropriate

As per https://www.slf4j.org/codes.html#multiple_bindings we should avoid dependency on any one implementation. The inclusion of logback-classic (which probably is meant to be a test scope dependency) was causing the following problem in my app:

SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/sanjay/.m2/repository/ch/qos/logback/logback-classic/1.2.1/logback-classic-1.2.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/cloudera/parcels/CDH-5.8.2-1.cdh5.8.2.p0.3/jars/slf4j-log4j12-1.7.5.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]

Needed my app to use the correct intended implementation