### PR TITLE
c.s.d.c.m.HostConfig.Bind.Builder: add support for automatic SELinux labeling

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/HostConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/HostConfig.java
@@ -681,6 +681,9 @@ public abstract class HostConfig {
     @Nullable
     public abstract Boolean noCopy();
 
+    @Nullable
+    public abstract Boolean selinuxLabeling();
+
     public static Builder builder() {
       return new AutoValue_HostConfig_Bind.Builder().readOnly(false);
     }
@@ -702,6 +705,15 @@ public abstract class HostConfig {
       //noinspection ConstantConditions
       if (noCopy() != null && noCopy()) {
         options.add("nocopy");
+      }
+
+      if (selinuxLabeling() != null) {
+        // shared
+        if (Boolean.TRUE.equals(selinuxLabeling())) {
+          options.add("z");
+        } else {
+          options.add("Z");
+        }
       }
 
       final String optionsValue = Joiner.on(',').join(options);
@@ -761,6 +773,15 @@ public abstract class HostConfig {
       public abstract Builder readOnly(Boolean readOnly);
 
       public abstract Builder noCopy(Boolean noCopy);
+
+      /**
+       * Turn on automatic SELinux labeling of the host file or directory being
+       * mounted into the container.
+       * @param sharedContent True if this bind mount content is shared among multiple 
+       *     containers (mount option "z"); false if private and unshared (mount option "Z")
+       * @return {@link Builder}
+       */
+      public abstract Builder selinuxLabeling(Boolean sharedContent);
 
       public abstract Bind build();
     }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientUnitTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientUnitTest.java
@@ -969,7 +969,7 @@ public class DefaultDockerClientUnitTest {
         .from("noselinux")
         .to("noselinux")
         .build();
-	
+
     final Bind bindSharedSelinuxContent = HostConfig.Bind.builder()
         .from("shared")
         .to("shared")
@@ -979,7 +979,7 @@ public class DefaultDockerClientUnitTest {
     final Bind bindPrivateSelinuxContent = HostConfig.Bind.builder()
         .from("private")
         .to("private")
-        .selinuxLabeling(false)			
+        .selinuxLabeling(false)
         .build();
 
     final HostConfig hostConfig = HostConfig.builder()
@@ -993,20 +993,22 @@ public class DefaultDockerClientUnitTest {
     server.enqueue(new MockResponse());
 
     dockerClient.createContainer(containerConfig);
-	
+
     final RecordedRequest recordedRequest = takeRequestImmediately();
 
     final JsonNode requestJson = toJson(recordedRequest.getBody());
 
     final JsonNode binds = requestJson.get("HostConfig").get("Binds");
-	
-    assertThat(binds.isArray(), is(true));	
+
+    assertThat(binds.isArray(), is(true));
 
     Set<String> bindSet = childrenTextNodes((ArrayNode) binds);
     assertThat(bindSet, hasSize(3));
-	
-    assertThat(bindSet, hasItem(allOf(containsString("noselinux"), not(containsString("z")), not(containsString("Z")))));
-	assertThat(bindSet, hasItem(allOf(containsString("shared"), containsString("z"))));
+
+    assertThat(bindSet, hasItem(allOf(containsString("noselinux"),
+        not(containsString("z")), not(containsString("Z")))));
+
+    assertThat(bindSet, hasItem(allOf(containsString("shared"), containsString("z"))));
     assertThat(bindSet, hasItem(allOf(containsString("private"), containsString("Z"))));
   }
   

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientUnitTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientUnitTest.java
@@ -21,9 +21,12 @@
 package com.spotify.docker.client;
 
 import static com.spotify.docker.FixtureUtil.fixture;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -53,6 +56,7 @@ import com.spotify.docker.client.exceptions.NonSwarmNodeException;
 import com.spotify.docker.client.exceptions.NotFoundException;
 import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.HostConfig;
+import com.spotify.docker.client.messages.HostConfig.Bind;
 import com.spotify.docker.client.messages.RegistryAuth;
 import com.spotify.docker.client.messages.RegistryConfigs;
 import com.spotify.docker.client.messages.ServiceCreateResponse;
@@ -956,7 +960,56 @@ public class DefaultDockerClientUnitTest {
 
     dockerClient.listNodes();
   }
+  
+  @Test
+  public void testBindBuilderSelinuxLabeling() throws Exception {
+    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
 
+    final Bind bindNoSelinuxLabel = HostConfig.Bind.builder()
+        .from("noselinux")
+        .to("noselinux")
+        .build();
+	
+    final Bind bindSharedSelinuxContent = HostConfig.Bind.builder()
+        .from("shared")
+        .to("shared")
+        .selinuxLabeling(true)
+        .build();
+
+    final Bind bindPrivateSelinuxContent = HostConfig.Bind.builder()
+        .from("private")
+        .to("private")
+        .selinuxLabeling(false)			
+        .build();
+
+    final HostConfig hostConfig = HostConfig.builder()
+        .binds(bindNoSelinuxLabel, bindSharedSelinuxContent, bindPrivateSelinuxContent)
+        .build();
+
+    final ContainerConfig containerConfig = ContainerConfig.builder()
+        .hostConfig(hostConfig)
+        .build();
+
+    server.enqueue(new MockResponse());
+
+    dockerClient.createContainer(containerConfig);
+	
+    final RecordedRequest recordedRequest = takeRequestImmediately();
+
+    final JsonNode requestJson = toJson(recordedRequest.getBody());
+
+    final JsonNode binds = requestJson.get("HostConfig").get("Binds");
+	
+    assertThat(binds.isArray(), is(true));	
+
+    Set<String> bindSet = childrenTextNodes((ArrayNode) binds);
+    assertThat(bindSet, hasSize(3));
+	
+    assertThat(bindSet, hasItem(allOf(containsString("noselinux"), not(containsString("z")), not(containsString("Z")))));
+	assertThat(bindSet, hasItem(allOf(containsString("shared"), containsString("z"))));
+    assertThat(bindSet, hasItem(allOf(containsString("private"), containsString("Z"))));
+  }
+  
   private void enqueueServerApiResponse(final int statusCode, final String fileName)
       throws IOException {
     server.enqueue(new MockResponse()


### PR DESCRIPTION
As specified at https://docs.docker.com/engine/admin/volumes/bind-mounts/#configure-the-selinux-label
I am proposing builder method selinuxLabeling(boolean sharedContent). When shared is true lower case letter "z" is added to mount options. Otherwise, label is considered as unshared and upper case letter "Z" is used instead.