### PR TITLE
added relocation for the org.glassfish dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,10 @@
               <shadedPattern>com.spotify.docker.client.shaded.javax.ws.rs</shadedPattern>
             </relocation>
             <relocation>
+              <pattern>org.glassfish</pattern>
+              <shadedPattern>com.spotify.docker.client.shaded.org.glassfish</shadedPattern>
+            </relocation> 
+            <relocation>
               <pattern>com.fasterxml.jackson</pattern>
               <shadedPattern>com.spotify.docker.client.shaded.com.fasterxml.jackson</shadedPattern>
             </relocation>


### PR DESCRIPTION
I ran into an issue with some clashing glassfish dependencies when using docker-client on a payara (glassfish) server. This change fixed it for me. Any reason why you added the org.glassfish pattern in the artifactSet of the shade plugin, but chose to not relocate it? If there is one feel free to ignore this pull request.