### PR TITLE
include asm and apache httpcomponents jar files for shading to avoid interop issues while using docker-client library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,9 @@
               <include>com.github.jnr:*</include>
               <include>org.ow2.asm:*</include>
               <include>com.google.guava:**</include>
+              <include>org.apache.httpcomponents:httpclient</include>
+              <include>org.apache.httpcomponents:httpcore</include>
+              <include>asm:asm</include>
             </includes>
           </artifactSet>
           <relocations>
@@ -343,6 +346,14 @@
             <relocation>
               <pattern>com.google.common</pattern>
               <shadedPattern>com.spotify.docker.client.shaded.com.google.common</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.http</pattern>
+              <shadedPattern>com.spotify.docker.client.shaded.org.apache.http</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.objectweb.asm</pattern>
+              <shadedPattern>com.spotify.docker.client.shaded.org.objectweb.asm</shadedPattern>
             </relocation>
           </relocations>
           <shadedArtifactAttached>true</shadedArtifactAttached>


### PR DESCRIPTION
@mattnworb could you review and merge if appropriate. The rationale for this is as follows: I am trying to use docker-client in my application which uses different versions of httpclient and asm jar files and I just could not make my app work with any common versions. So shading the 2 seems to be the best option. I have tested the change in my application 