### PR TITLE
Fix serialization of sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Not yet released.
 
 - `ContainerConfig.exposedPorts` is serialized as a map of keys to empty map placeholders. `exposedPorts` had been serialized as keys -> `null`. (Fixes [893][])
-- Breaking API change: The method `ContainerConfig.volumes()` has changed signature from `ImmutableMap<String, Map> volmues()` (where the second `Map` was always empty) to `Set<String> volumes()`. This change simplifies the code internally. ([898][])
+- Breaking API change: The method `ContainerConfig.volumes()` has changed signature from `ImmutableMap<String, Map> volumes()` (where the second `Map` was always empty) to `ImmutableSet<String> volumes()`. This change simplifies the code internally. ([898][])
 
 [893]: https://github.com/spotify/docker-client/issues/893
 [898]: https://github.com/spotify/docker-client/issues/898

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 8.10.0
+
+Not yet released.
+
+- `ContainerConfig.exposedPorts` is serialized as a map of keys to empty map placeholders. `exposedPorts` had been serialized as keys -> `null`. (Fixes [893][])
+- Breaking API change: The method `ContainerConfig.volumes()` has changed signature from `ImmutableMap<String, Map> volmues()` (where the second `Map` was always empty) to `Set<String> volumes()`. This change simplifies the code internally. ([898][])
+
+[893]: https://github.com/spotify/docker-client/issues/893
+[898]: https://github.com/spotify/docker-client/issues/898
+
 ## 8.9.2
 
 Released November 15, 2017

--- a/src/main/java/com/spotify/docker/client/ObjectMapperProvider.java
+++ b/src/main/java/com/spotify/docker/client/ObjectMapperProvider.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -54,10 +55,10 @@ public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
 
   private static final Logger log = LoggerFactory.getLogger(ObjectMapperProvider.class);
 
-  private static final Function<? super Object, ?> VOID_VALUE = new Function<Object, Object>() {
+  private static final Function<? super Object, ?> EMPTY_MAP = new Function<Object, Object>() {
     @Override
     public Object apply(final Object input) {
-      return null;
+      return Collections.emptyMap();
     }
   };
 
@@ -95,7 +96,7 @@ public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
     @Override
     public void serialize(final Set value, final JsonGenerator jgen,
                           final SerializerProvider provider) throws IOException {
-      final Map map = (value == null) ? null : Maps.asMap(value, VOID_VALUE);
+      final Map map = (value == null) ? null : Maps.asMap(value, EMPTY_MAP);
       OBJECT_MAPPER.writeValue(jgen, map);
     }
   }
@@ -115,7 +116,7 @@ public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
     @Override
     public void serialize(final ImmutableSet value, final JsonGenerator jgen,
                           final SerializerProvider provider) throws IOException {
-      final Map map = (value == null) ? null : Maps.asMap(value, VOID_VALUE);
+      final Map map = (value == null) ? null : Maps.asMap(value, EMPTY_MAP);
       OBJECT_MAPPER.writeValue(jgen, map);
     }
   }

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -267,8 +267,25 @@ public abstract class ContainerConfig {
 
     public abstract Builder volumes(final String... volumes);
 
+    /**
+     * @deprecated As of 8.10.0, use {@link #volumes(Set)} or
+     *             {@link #volumes(String...)}.
+     */
+    @Deprecated
+    public Builder volumes(final Map<String, Map> volumes) {
+      this.volumes(volumes.keySet());
+      return this;
+    }
+
     public Builder addVolume(final String volume) {
       volumesBuilder().add(volume);
+      return this;
+    }
+
+    public Builder addVolumes(final String... volumes) {
+      for (final String volume : volumes) {
+        volumesBuilder().add(volume);
+      }
       return this;
     }
 

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -265,14 +265,7 @@ public abstract class ContainerConfig {
 
     public abstract Builder volumes(final Set<String> volumes);
 
-    public Builder volumes(final String... volumes) {
-      if (volumes != null) {
-        for (final String volume : volumes) {
-          addVolume(volume);
-        }
-      }
-      return this;
-    }
+    public abstract Builder volumes(final String... volumes);
 
     public Builder addVolume(final String volume) {
       volumesBuilder().add(volume);

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -101,7 +101,7 @@ public abstract class ContainerConfig {
   public abstract String image();
 
   /**
-   * @deprecated As of 8.9.1, use {@link #volumes()}.
+   * @deprecated As of 8.10.0, use {@link #volumes()}.
    */
   @Deprecated
   public Set<String> volumeNames() {

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -263,20 +263,6 @@ public abstract class ContainerConfig {
 
     abstract ImmutableSet.Builder<String> volumesBuilder();
 
-    public abstract Builder volumes(final Set<String> volumes);
-
-    public abstract Builder volumes(final String... volumes);
-
-    /**
-     * @deprecated As of 8.10.0, use {@link #volumes(Set)} or
-     *             {@link #volumes(String...)}.
-     */
-    @Deprecated
-    public Builder volumes(final Map<String, Map> volumes) {
-      this.volumes(volumes.keySet());
-      return this;
-    }
-
     public Builder addVolume(final String volume) {
       volumesBuilder().add(volume);
       return this;
@@ -288,6 +274,20 @@ public abstract class ContainerConfig {
       }
       return this;
     }
+
+    /**
+     * @deprecated As of 8.10.0, use {@link #volumes(Set)} or
+     *             {@link #volumes(String...)}.
+     */
+    @Deprecated
+    public Builder volumes(final Map<String, Map> volumes) {
+      this.volumes(volumes.keySet());
+      return this;
+    }
+
+    public abstract Builder volumes(final Set<String> volumes);
+
+    public abstract Builder volumes(final String... volumes);
 
     public abstract Builder workingDir(final String workingDir);
 

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -187,7 +187,7 @@ public abstract class ContainerConfig {
       @JsonProperty("StopSignal") final String stopSignal,
       @JsonProperty("Healthcheck") final Healthcheck healthcheck,
       @JsonProperty("NetworkingConfig") final NetworkingConfig networkingConfig) {
-    final Builder builder = builder()
+    return builder()
         .hostname(hostname)
         .domainname(domainname)
         .user(user)
@@ -204,34 +204,16 @@ public abstract class ContainerConfig {
         .hostConfig(hostConfig)
         .stopSignal(stopSignal)
         .networkingConfig(networkingConfig)
-        .volumes(volumes);
-
-    if (portSpecs != null) {
-      builder.portSpecs(portSpecs);
-    }
-    if (exposedPorts != null) {
-      builder.exposedPorts(exposedPorts);
-    }
-    if (env != null) {
-      builder.env(env);
-    }
-    if (cmd != null) {
-      builder.cmd(cmd);
-    }
-    if (entrypoint != null) {
-      builder.entrypoint(entrypoint);
-    }
-    if (onBuild != null) {
-      builder.onBuild(onBuild);
-    }
-    if (labels != null) {
-      builder.labels(labels);
-    }
-    if (healthcheck != null) {
-      builder.healthcheck(healthcheck);
-    }
-
-    return builder.build();
+        .volumes(volumes)
+        .portSpecs(portSpecs)
+        .exposedPorts(exposedPorts)
+        .env(env)
+        .cmd(cmd)
+        .entrypoint(entrypoint)
+        .onBuild(onBuild)
+        .labels(labels)
+        .healthcheck(healthcheck)
+        .build();
   }
 
   public abstract Builder toBuilder();

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -100,15 +100,17 @@ public abstract class ContainerConfig {
   @JsonProperty("Image")
   public abstract String image();
 
-  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH")
+  /**
+   * @deprecated As of 8.9.1, use {@link #volumes()}.
+   */
+  @Deprecated
   public Set<String> volumeNames() {
-    //noinspection ConstantConditions
-    return volumes() == null ? Collections.<String>emptySet() : volumes().keySet();
+    return volumes();
   }
 
   @Nullable
   @JsonProperty("Volumes")
-  public abstract ImmutableMap<String, Map> volumes();
+  public abstract ImmutableSet<String> volumes();
 
   @Nullable
   @JsonProperty("WorkingDir")
@@ -174,7 +176,7 @@ public abstract class ContainerConfig {
       @JsonProperty("Env") final List<String> env,
       @JsonProperty("Cmd") final List<String> cmd,
       @JsonProperty("Image") final String image,
-      @JsonProperty("Volumes") final Map<String, Map> volumes,
+      @JsonProperty("Volumes") final Set<String> volumes,
       @JsonProperty("WorkingDir") final String workingDir,
       @JsonProperty("Entrypoint") final List<String> entrypoint,
       @JsonProperty("NetworkDisabled") final Boolean networkDisabled,
@@ -201,7 +203,8 @@ public abstract class ContainerConfig {
         .macAddress(macAddress)
         .hostConfig(hostConfig)
         .stopSignal(stopSignal)
-        .networkingConfig(networkingConfig);
+        .networkingConfig(networkingConfig)
+        .volumes(volumes);
 
     if (portSpecs != null) {
       builder.portSpecs(portSpecs);
@@ -214,9 +217,6 @@ public abstract class ContainerConfig {
     }
     if (cmd != null) {
       builder.cmd(cmd);
-    }
-    if (volumes != null)  {
-      builder.volumes(volumes);
     }
     if (entrypoint != null) {
       builder.entrypoint(entrypoint);
@@ -279,45 +279,21 @@ public abstract class ContainerConfig {
 
     public abstract Builder image(final String image);
 
-    abstract ImmutableMap.Builder<String, Map> volumesBuilder();
+    abstract ImmutableSet.Builder<String> volumesBuilder();
+
+    public abstract Builder volumes(final Set<String> volumes);
+
+    public Builder volumes(final String... volumes) {
+      if (volumes != null) {
+        for (final String volume : volumes) {
+          addVolume(volume);
+        }
+      }
+      return this;
+    }
 
     public Builder addVolume(final String volume) {
-      volumesBuilder().put(volume, new HashMap());
-      return this;
-    }
-
-    public Builder addVolumes(final String... volumes) {
-      for (final String volume : volumes) {
-        volumesBuilder().put(volume, new HashMap());
-      }
-      return this;
-    }
-
-    public abstract Builder volumes(final Map<String, Map> volumes);
-
-    /**
-     * @deprecated  As of release 7.0.0, replaced by {@link #volumes(Map)}.
-     */
-    @Deprecated
-    public Builder volumes(final Set<String> volumes) {
-      if (volumes != null && !volumes.isEmpty()) {
-        final ImmutableMap.Builder<String, Map> volumesBuilder = ImmutableMap.builder();
-        for (final String volume : volumes) {
-          volumesBuilder.put(volume, new HashMap());
-        }
-        volumes(volumesBuilder.build());
-      }
-      return this;
-    }
-
-    /**
-     * @deprecated  As of release 7.0.0, replaced by {@link #volumes(Map)}.
-     */
-    @Deprecated
-    public Builder volumes(final String... volumes) {
-      if (volumes != null && volumes.length > 0) {
-        volumes(ImmutableSet.copyOf(volumes));
-      }
+      volumesBuilder().add(volume);
       return this;
     }
 

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -2733,7 +2733,7 @@ public class DefaultDockerClientTest {
     final String expectedLocalPath = "/local/path";
     assertThat(volumeContainer.volumes().values(), hasItem(containsString(expectedLocalPath)));
 
-    assertThat(volumeContainer.config().volumeNames(), hasItem("/foo"));
+    assertThat(volumeContainer.config().volumes(), hasItem("/foo"));
   }
 
   @Test
@@ -2990,7 +2990,7 @@ public class DefaultDockerClientTest {
       }
     }
 
-    assertThat(containerInfo.config().volumeNames(), hasItem(anonVolumeTo));
+    assertThat(containerInfo.config().volumes(), hasItem(anonVolumeTo));
   }
 
   @Test

--- a/src/test/java/com/spotify/docker/client/messages/ContainerConfigTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/ContainerConfigTest.java
@@ -21,6 +21,9 @@
 package com.spotify.docker.client.messages;
 
 import static com.spotify.docker.FixtureUtil.fixture;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spotify.docker.client.ObjectMapperProvider;
@@ -44,6 +47,20 @@ public class ContainerConfigTest {
   @Test
   public void test1_29() throws Exception {
     objectMapper.readValue(fixture("fixtures/1.29/containerConfig.json"), ContainerConfig.class);
+  }
+
+  @Test
+  public void test1_29_WithoutNullables() throws Exception {
+    final ContainerConfig config = objectMapper.readValue(
+        fixture("fixtures/1.29/containerConfigWithoutNullables.json"), ContainerConfig.class);
+    assertThat(config.portSpecs(), is(nullValue()));
+    assertThat(config.exposedPorts(), is(nullValue()));
+    assertThat(config.env(), is(nullValue()));
+    assertThat(config.cmd(), is(nullValue()));
+    assertThat(config.entrypoint(), is(nullValue()));
+    assertThat(config.onBuild(), is(nullValue()));
+    assertThat(config.labels(), is(nullValue()));
+    assertThat(config.healthcheck(), is(nullValue()));
   }
 
 }

--- a/src/test/resources/fixtures/1.29/containerConfigWithoutNullables.json
+++ b/src/test/resources/fixtures/1.29/containerConfigWithoutNullables.json
@@ -1,0 +1,24 @@
+{
+  "Hostname": "string",
+  "Domainname": "string",
+  "User": "string",
+  "AttachStdin": false,
+  "AttachStdout": true,
+  "AttachStderr": true,
+  "Tty": false,
+  "OpenStdin": false,
+  "StdinOnce": false,
+  "ArgsEscaped": true,
+  "Image": "string",
+  "Volumes": {
+    "additionalProperties": {}
+  },
+  "WorkingDir": "string",
+  "NetworkDisabled": true,
+  "MacAddress": "string",
+  "StopSignal": "SIGTERM",
+  "StopTimeout": 10,
+  "Shell": [
+    "string"
+  ]
+}


### PR DESCRIPTION
All `Set`s are now serialized as maps of keys to empty maps, rather than maps of keys to `null`.

This specific motivating case is `ContainerConfig.exposedPorts`, but every other `Set` in the model should have the same behavior. As far as I am aware we only use `Set`s to model docker's "map of keys to empty objects" API pattern. I infer they use this pattern as a workaround for a lack of a native set type in Go.

I also refactored `ContainerConfig.volumes` to be a `Set` rather than being a hard-coded `Map<String, Map>`. I had implemented `volumes` as the latter because I was unaware we were using a custom serializer for `Set` to reproduce docker's API pattern. Refactoring `volumes` to also be a `Set` simplifies the code but leaves the serialization the same.

While I was in `ContainerConfig`, I cleaned up all the `if (foo != null) { builder.foo(foo); }` statements for properties that are `@Nullable`. AutoValue doesn't care if you feed a `null` into those builder methods, so we don't need to check.

Fixes #893.