### PR TITLE
improve e.g. code in README by replace command with one that works

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ final ContainerInfo info = docker.inspectContainer(id);
 docker.startContainer(id);
 
 // Exec command inside running container with attached STDOUT and STDERR
-final String[] command = {"bash", "-c", "ls"};
+final String[] command = {"du", "-h", "-s"};
 final ExecCreation execCreation = docker.execCreate(
     id, command, DockerClient.ExecCreateParam.attachStdout(),
     DockerClient.ExecCreateParam.attachStderr());

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ final ContainerInfo info = docker.inspectContainer(id);
 docker.startContainer(id);
 
 // Exec command inside running container with attached STDOUT and STDERR
-final String[] command = {"du", "-h", "-s"};
+final String[] command = {"sh", "-c", "ls"};
 final ExecCreation execCreation = docker.execCreate(
     id, command, DockerClient.ExecCreateParam.attachStdout(),
     DockerClient.ExecCreateParam.attachStderr());


### PR DESCRIPTION
README example for running command inside running container yields:
```
2017-10-17 10:00:04.545 DEBUG main:TestDockerApi:107 - Output of 'ls' in container: oci runtime error: exec failed: container_linux.go:265: starting container process caused "exec: \"bash\": executable file not found in $PATH"
```
replace it with "du - h -s" which is a more interesting output and works..