### PR TITLE
Added spread over support in task template placement preference

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -89,6 +89,7 @@ import com.spotify.docker.client.messages.ContainerExit;
 import com.spotify.docker.client.messages.ContainerInfo;
 import com.spotify.docker.client.messages.ContainerStats;
 import com.spotify.docker.client.messages.ContainerUpdate;
+import com.spotify.docker.client.messages.ContainersDeleted;
 import com.spotify.docker.client.messages.ExecCreation;
 import com.spotify.docker.client.messages.ExecState;
 import com.spotify.docker.client.messages.HostConfig;
@@ -107,9 +108,11 @@ import com.spotify.docker.client.messages.RegistryConfigs;
 import com.spotify.docker.client.messages.RemovedImage;
 import com.spotify.docker.client.messages.ServiceCreateResponse;
 import com.spotify.docker.client.messages.TopResults;
+import com.spotify.docker.client.messages.UnusedImages;
 import com.spotify.docker.client.messages.Version;
 import com.spotify.docker.client.messages.Volume;
 import com.spotify.docker.client.messages.VolumeList;
+import com.spotify.docker.client.messages.VolumesDeleted;
 import com.spotify.docker.client.messages.swarm.Config;
 import com.spotify.docker.client.messages.swarm.ConfigCreateResponse;
 import com.spotify.docker.client.messages.swarm.ConfigSpec;
@@ -625,6 +628,14 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   }
 
   @Override
+  public UnusedImages removeUnusedImages()
+          throws DockerException, InterruptedException {
+    WebTarget resource = resource()
+            .path("images").path("prune");
+    return request(POST,UnusedImages.class,resource,resource.request(APPLICATION_JSON_TYPE));
+  }
+
+  @Override
   public ContainerCreation createContainer(final ContainerConfig config)
       throws DockerException, InterruptedException {
     return createContainer(config, null);
@@ -746,6 +757,13 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   }
 
   @Override
+  public ContainersDeleted removeStoppedContainers()
+          throws DockerException, InterruptedException {
+    WebTarget resource = resource().path("containers").path("prune");
+    return request(POST,ContainersDeleted.class,resource,resource.request(APPLICATION_JSON_TYPE));
+  }
+
+  @Override
   public void stopContainer(final String containerId, final int secondsToWaitBeforeKilling)
       throws DockerException, InterruptedException {
     try {
@@ -796,6 +814,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       throws DockerException, InterruptedException {
     removeContainer(containerId, RemoveContainerParam.removeVolumes(removeVolumes));
   }
+
 
   @Override
   public void removeContainer(final String containerId, final RemoveContainerParam... params)
@@ -2528,6 +2547,13 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     WebTarget resource = resource().path("volumes");
     resource = addParameters(resource, params);
     return request(GET, VolumeList.class, resource, resource.request(APPLICATION_JSON_TYPE));
+  }
+
+  @Override
+  public VolumesDeleted removeUnusedVolumes()
+          throws DockerException, InterruptedException {
+    final WebTarget resource = resource().path("volumes").path("prune");
+    return request(POST,VolumesDeleted.class,resource,resource.request(APPLICATION_JSON_TYPE));
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -47,6 +47,7 @@ import com.spotify.docker.client.messages.ContainerExit;
 import com.spotify.docker.client.messages.ContainerInfo;
 import com.spotify.docker.client.messages.ContainerStats;
 import com.spotify.docker.client.messages.ContainerUpdate;
+import com.spotify.docker.client.messages.ContainersDeleted;
 import com.spotify.docker.client.messages.Event;
 import com.spotify.docker.client.messages.ExecCreation;
 import com.spotify.docker.client.messages.ExecState;
@@ -64,9 +65,11 @@ import com.spotify.docker.client.messages.RegistryAuth;
 import com.spotify.docker.client.messages.RemovedImage;
 import com.spotify.docker.client.messages.ServiceCreateResponse;
 import com.spotify.docker.client.messages.TopResults;
+import com.spotify.docker.client.messages.UnusedImages;
 import com.spotify.docker.client.messages.Version;
 import com.spotify.docker.client.messages.Volume;
 import com.spotify.docker.client.messages.VolumeList;
+import com.spotify.docker.client.messages.VolumesDeleted;
 import com.spotify.docker.client.messages.swarm.Config;
 import com.spotify.docker.client.messages.swarm.ConfigCreateResponse;
 import com.spotify.docker.client.messages.swarm.ConfigSpec;
@@ -163,6 +166,16 @@ public interface DockerClient extends Closeable {
    * @throws InterruptedException If the thread is interrupted
    */
   List<Image> listImages(ListImagesParam... params) throws DockerException, InterruptedException;
+
+  /**
+   * Remove unused images.
+   *
+   * @return List of unused removed images.
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   * @since Docker 1.13, API version 1.25
+   */
+  UnusedImages removeUnusedImages() throws DockerException, InterruptedException;
 
   /**
    * Inspect a docker container.
@@ -1168,6 +1181,16 @@ public interface DockerClient extends Closeable {
       return name;
     }
   }
+
+  /**
+   * Remove stopped containers.
+   *
+   * @return List of removed container id and space reclaimed.
+   * @throws DockerException      If a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   * @since Docker 1.13, API version 1.25
+   */
+  ContainersDeleted removeStoppedContainers() throws DockerException, InterruptedException;
 
   /**
    * Remove a docker container.
@@ -2790,6 +2813,16 @@ public interface DockerClient extends Closeable {
   void removeVolume(String volumeName) throws DockerException, InterruptedException;
 
   VolumeList listVolumes(ListVolumesParam... params) throws DockerException, InterruptedException;
+
+  /**
+   * Remove unused volumes.
+   *
+   * @return list of removed volumes with space reclaimed
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException if the thread is interrupted
+   * @since Docker 1.13, API version 1.25
+   */
+  VolumesDeleted removeUnusedVolumes() throws DockerException, InterruptedException;
 
   /**
    * List secrets.

--- a/src/main/java/com/spotify/docker/client/messages/ContainersDeleted.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainersDeleted.java
@@ -1,0 +1,55 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public abstract class ContainersDeleted {
+
+  @Nullable
+  @JsonProperty("ContainersDeleted")
+  public abstract ImmutableList<String> containersDeleted();
+
+  @JsonProperty("SpaceReclaimed")
+  public abstract Long spaceReclaimed();
+
+  @JsonCreator
+  static  ContainersDeleted create(
+      @JsonProperty("ContainersDeleted") final List<String> containersDeleted,
+      @JsonProperty("SpaceReclaimed") final Long spaceReclaimed) {
+    final ImmutableList<String> containersDeletedCopy =
+        containersDeleted == null
+                ? ImmutableList.<String>of()
+                : ImmutableList.copyOf(containersDeleted);
+    return new AutoValue_ContainersDeleted(containersDeletedCopy , spaceReclaimed);
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/ImageDeleted.java
+++ b/src/main/java/com/spotify/docker/client/messages/ImageDeleted.java
@@ -1,0 +1,54 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages;
+
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import javax.annotation.Nullable;
+
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public  abstract class ImageDeleted {
+
+  @Nullable
+  @JsonProperty("Untagged")
+  public abstract String untagged();
+
+  @Nullable
+  @JsonProperty("Deleted")
+  public abstract String deleted();
+
+  @JsonCreator
+  static ImageDeleted create(
+          @JsonProperty("Untagged") final String untagged,
+          @JsonProperty("Deleted") final String deleted) {
+    return new AutoValue_ImageDeleted(untagged, deleted);
+  }
+
+}

--- a/src/main/java/com/spotify/docker/client/messages/UnusedImages.java
+++ b/src/main/java/com/spotify/docker/client/messages/UnusedImages.java
@@ -1,0 +1,57 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages;
+
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public abstract class UnusedImages {
+
+  @Nullable
+  @JsonProperty("ImagesDeleted")
+  public abstract ImmutableList<ImageDeleted> imagesDeleted();
+
+  @JsonProperty("SpaceReclaimed")
+  public abstract Long spaceReclaimed();
+
+
+  @JsonCreator
+  static UnusedImages create(
+        @JsonProperty("ImagesDeleted") final List<ImageDeleted> imagesDeleted,
+        @JsonProperty("SpaceReclaimed") final Long spaceReclaimed) {
+    final ImmutableList<ImageDeleted> imagesDeletedCopy =
+            imagesDeleted == null
+                    ? ImmutableList.<ImageDeleted>of()
+                    : ImmutableList.copyOf(imagesDeleted);
+    return new AutoValue_UnusedImages(imagesDeletedCopy , spaceReclaimed);
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/VolumesDeleted.java
+++ b/src/main/java/com/spotify/docker/client/messages/VolumesDeleted.java
@@ -1,0 +1,56 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public abstract class VolumesDeleted {
+
+  @Nullable
+  @JsonProperty("VolumesDeleted")
+  public abstract ImmutableList<String> volumesDeleted();
+
+  @JsonProperty("SpaceReclaimed")
+  public abstract Long spaceReclaimed();
+
+  @JsonCreator
+  static VolumesDeleted create(
+      @JsonProperty("VolumesDeleted") final List<String> volumesDeleted,
+      @JsonProperty("SpaceReclaimed") final Long spaceReclaimed) {
+    final ImmutableList<String> volumesDeletedCopy =
+            volumesDeleted == null
+                ? ImmutableList.<String>of()
+                : ImmutableList.copyOf(volumesDeleted);
+    return new AutoValue_VolumesDeleted(volumesDeletedCopy , spaceReclaimed);
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/PlacementPreference.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/PlacementPreference.java
@@ -1,0 +1,61 @@
+/*-
+* -\-\-
+ * * docker-client
+ * *
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * *
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+*/
+
+package com.spotify.docker.client.messages.swarm;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+public abstract class PlacementPreference {
+
+  public static PlacementPreference.Builder builder() {
+    return new AutoValue_PlacementPreference.Builder();
+  }
+
+  @JsonProperty("Spread")
+  public abstract SpreadOver spread();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract PlacementPreference.Builder spread(SpreadOver spread);
+
+    public abstract PlacementPreference build();
+  }
+
+  @JsonCreator
+  static PlacementPreference create(
+          @JsonProperty("Spread") final SpreadOver spread) {
+    return builder()
+            .spread(spread)
+            .build();
+  }
+
+}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/SpreadOver.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/SpreadOver.java
@@ -27,60 +27,35 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
 
-import java.util.List;
-
-import javax.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
-public abstract class Placement {
+public abstract class SpreadOver {
 
-  @Nullable
-  @JsonProperty("Constraints")
-  public abstract ImmutableList<String> constraints();
+  @JsonProperty("SpreadDescriptor")
+  public abstract String spreadDescriptor();
 
-  @Nullable
-  @JsonProperty("Preferences")
-  public abstract ImmutableList<PlacementPreference> preferences();
-
-  public static Placement.Builder builder() {
-    return new AutoValue_Placement.Builder();
+  public static SpreadOver.Builder builder() {
+    return new AutoValue_SpreadOver.Builder();
   }
 
   @AutoValue.Builder
   public abstract static class Builder {
 
-    public abstract Placement.Builder  constraints(List<String> constraints);
+    public abstract SpreadOver.Builder  spreadDescriptor(String spreadDescriptor);
 
-    public abstract Placement.Builder  constraints(String...constraints);
-
-    public abstract Placement.Builder  preferences(List<PlacementPreference> preferences);
-
-    public abstract Placement.Builder  preferences(PlacementPreference...preferences);
-
-    public abstract Placement build();
+    public abstract SpreadOver build();
   }
-
 
 
   @JsonCreator
-  static Placement create(
-          @JsonProperty("Constraints") final List<String> constraints,
-          @JsonProperty("Preferences") final List<PlacementPreference> preferences) {
+  static SpreadOver create(
+      @JsonProperty("SpreadDescriptor") final String spreadDescriptor) {
     return builder()
-            .constraints(constraints)
-            .preferences(preferences)
-            .build();
+        .spreadDescriptor(spreadDescriptor)
+        .build();
   }
-
-  public static Placement create(List<String> constraints) {
-    return builder()
-            .constraints(constraints)
-            .build();
-  }
-
 
 
 }

--- a/src/test/java/com/spotify/docker/client/messages/swarm/PlacementPrefTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/swarm/PlacementPrefTest.java
@@ -1,0 +1,43 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages.swarm;
+
+import static com.spotify.docker.FixtureUtil.fixture;
+import static org.junit.Assert.assertNotNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.docker.client.ObjectMapperProvider;
+import org.junit.Test;
+
+
+public class PlacementPrefTest {
+
+  private final ObjectMapper objectMapper = ObjectMapperProvider.objectMapper();
+
+  @Test
+  public void test1_28() throws Exception {
+    ServiceSpec spec = objectMapper.readValue(fixture("fixtures/1.28/serviceSpec.json"),
+            ServiceSpec.class);
+    assertNotNull(spec.taskTemplate()
+            .placement()
+            .preferences());
+  }
+}

--- a/src/test/resources/fixtures/1.28/serviceSpec.json
+++ b/src/test/resources/fixtures/1.28/serviceSpec.json
@@ -1,0 +1,32 @@
+{
+  "Name" : "test",
+  "Labels" : {},
+  "TaskTemplate" : {
+    "ContainerSpec" : {
+      "Image" : "image:latest",
+      "Labels" : {},
+      "Env" : [],
+      "Secrets" : [ ]
+    },
+    "Placement" : {
+      "Preferences":[
+        { "Spread":
+        { "SpreadDescriptor" :"node.labels.test" }
+        }
+      ]
+    },
+    "Networks" : [ {
+      "Target" : "yb0ad29co7uagva94zj3txeb1",
+      "Aliases" : [ "test-latest" ]
+    } ]
+  },
+  "Mode" : {
+    "Replicated" : {
+      "Replicas" : 2
+    }
+  },
+  "Networks" : [ {
+    "Target" : "yb0ad29co7uagva94zj3txeb1",
+    "Aliases" : [ "test-latest" ]
+  } ]
+}


### PR DESCRIPTION
Support of placement preference and spread over in Task template to provide a way to make the scheduler aware of factors such as topology and node label (since Docker API 1.28)
 
For retro compatibility with previous version, public static create(constraints) method has been kept. A unit test with spread over has been added.