### PR TITLE
Support loading auth config for repos with no scheme in their URL

### DIFF
--- a/src/main/java/com/spotify/docker/client/DockerConfigReader.java
+++ b/src/main/java/com/spotify/docker/client/DockerConfigReader.java
@@ -36,6 +36,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,15 +90,17 @@ public class DockerConfigReader {
       return configs.get(serverAddress);
     }
 
-    // If the given server address didn't have a protocol try adding the 'https' protocol.
+    // If the given server address didn't have a protocol try adding a protocol to the address.
     // This handles cases where older versions of Docker included the protocol when writing
     // auth tokens to config.json.
     try {
       final URI serverAddressUri = new URI(serverAddress);
       if (serverAddressUri.getScheme() == null) {
-        final String addrWithProto = "https://" + serverAddress;
-        if (configs.containsKey(addrWithProto)) {
-          return configs.get(addrWithProto);
+        for (String proto : Arrays.asList("https://", "http://")) {
+          final String addrWithProto = proto + serverAddress;
+          if (configs.containsKey(addrWithProto)) {
+            return configs.get(addrWithProto);
+          }
         }
       }
     } catch (URISyntaxException e) {

--- a/src/test/java/com/spotify/docker/client/DockerConfigReaderTest.java
+++ b/src/test/java/com/spotify/docker/client/DockerConfigReaderTest.java
@@ -169,9 +169,13 @@ public class DockerConfigReaderTest {
     final RegistryAuth noProto = reader.fromConfig(path, "docker.example.com");
     assertThat(noProto.serverAddress(), equalTo("docker.example.com"));
 
-    // Server address doesn't have a protocol but the entry in the config file does
+    // Server address doesn't have a protocol but the entry in the config file does (https)
     final RegistryAuth httpsProto = reader.fromConfig(path, "repo.example.com");
     assertThat(httpsProto.serverAddress(), equalTo("https://repo.example.com"));
+
+    // Server address doesn't have a protocol but the entry in the config file does (http)
+    final RegistryAuth httpProto = reader.fromConfig(path, "local.example.com");
+    assertThat(httpProto.serverAddress(), equalTo("http://local.example.com"));
   }
 
   private static Path getTestFilePath(final String path) {

--- a/src/test/java/com/spotify/docker/client/DockerConfigReaderTest.java
+++ b/src/test/java/com/spotify/docker/client/DockerConfigReaderTest.java
@@ -47,6 +47,7 @@ import com.google.common.io.Resources;
 import com.spotify.docker.client.messages.RegistryAuth;
 import com.spotify.docker.client.messages.RegistryConfigs;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -158,6 +159,19 @@ public class DockerConfigReaderTest {
 
     final RegistryAuth dockerIoParsed = reader.fromConfig(path, "https://index.docker.io/v1/");
     assertThat(dockerIoParsed, equalTo(DOCKER_AUTH_CONFIG));
+  }
+
+  @Test
+  public void testFromDockerConfig_AddressProtocol() throws IOException {
+    final Path path = getTestFilePath("dockerConfig/protocolMissing.json");
+
+    // Server address matches exactly what's in the config file
+    final RegistryAuth noProto = reader.fromConfig(path, "docker.example.com");
+    assertThat(noProto.serverAddress(), equalTo("docker.example.com"));
+
+    // Server address doesn't have a protocol but the entry in the config file does
+    final RegistryAuth httpsProto = reader.fromConfig(path, "repo.example.com");
+    assertThat(httpsProto.serverAddress(), equalTo("https://repo.example.com"));
   }
 
   private static Path getTestFilePath(final String path) {

--- a/src/test/resources/dockerConfig/protocolMissing.json
+++ b/src/test/resources/dockerConfig/protocolMissing.json
@@ -5,6 +5,9 @@
     },
     "https://repo.example.com": {
       "auth": "ZG9ja2VybWFuOnN3NGd5MGxvCg=="
+    },
+    "http://local.example.com": {
+      "auth": "ZG9ja2VybWFuOnN3NGd5MGxvCg=="
     }
   }
 }

--- a/src/test/resources/dockerConfig/protocolMissing.json
+++ b/src/test/resources/dockerConfig/protocolMissing.json
@@ -1,0 +1,10 @@
+{
+  "auths": {
+    "docker.example.com": {
+      "auth": "ZG9ja2VybWFuOnN3NGd5MGxvCg=="
+    },
+    "https://repo.example.com": {
+      "auth": "ZG9ja2VybWFuOnN3NGd5MGxvCg=="
+    }
+  }
+}


### PR DESCRIPTION
Support loading auth configuration for repos when their `serverAddress`
is specified with no scheme component but their entry in the configuration
file includes a scheme component.

Older versions of Docker write authentication tokens to the configuration
file including their scheme ("https://") but newer onces do not. Thus
in order to allow people to use the newer format (looking up auth for
a repo that isn't prefixed with scheme) with an older configuration file
we try prefixing the `serverAddress` with "https://" or "http://" in some cases.

Fixes #804