### PR TITLE
Upgrade Jersey version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,19 +102,34 @@
       <version>2.8.8</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.8.8</version>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>2.22.2</version>
+      <version>2.26</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.connectors</groupId>
       <artifactId>jersey-apache-connector</artifactId>
-      <version>2.22.2</version>
+      <version>2.26</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.22.2</version>
+      <version>2.26</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+      <version>2.26</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-api</artifactId>
+      <version>2.5.0-b59</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Hi,

Would it be possible to upgrade Jersey/Glassfish version? Right now docker-client conflicts with applications using the most recent version of Jersey/Glassfish.

Upgrading Jersey to the most recent version requires aligning jackson-annotations to the same version as jackson-core (which is good practice anyway) and adding hk2 dependencies explicitly to your POM.

Thanks!