### PR TITLE
travis: test on more recent 17.09

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,8 @@ env:
     - DOCKER_VERSION=1.12.6
     - DOCKER_VERSION=1.13.1
     - DOCKER_VERSION=17.03.1~ce
-    - DOCKER_VERSION=17.04.0~ce
-    - DOCKER_VERSION=17.05.0~ce
-    - DOCKER_VERSION=17.06.0~ce DOCKER_CE=1 UPLOAD_SONATYPE=1
+    - DOCKER_VERSION=17.06.0~ce DOCKER_CE=1
+    - DOCKER_VERSION=17.09.0~ce DOCKER_CE=1 UPLOAD_SONATYPE=1
 
 before_install:
   # check what version of docker is installed beforehand


### PR DESCRIPTION
instead of 17.04 and 17.05. Testing on quarterly releases
17.03 and .06 should be good enough for previous versions.
Testing on latest two releases will help keep this library
up to date with docker changes.