### PR TITLE
Pull, push, build and create interruption

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -273,6 +273,38 @@ public class DefaultDockerClient implements DockerClient, Closeable {
 
   }
 
+  
+  /**
+   * Hack: this {@link ProgressHandler} is meant to capture the image ID
+   * of an image being built.
+   */
+  private static class BuildProgressHandler implements ProgressHandler {
+
+    private final ProgressHandler delegate;
+
+    private String imageId;
+
+    private BuildProgressHandler(ProgressHandler delegate) {
+      this.delegate = delegate;
+    }
+
+    private String getImageId() {
+      Preconditions.checkState(imageId != null,
+                               "Could not acquire image ID or digest following build");
+      return imageId;
+    }
+
+    @Override
+    public void progress(ProgressMessage message) throws DockerException {
+      delegate.progress(message);
+      
+      final String id = message.buildImageId();
+      if (id != null) {
+        imageId = id;
+      }
+    }
+
+  }
   // ==========================================================================
 
   private static final String UNIX_SCHEME = "unix";
@@ -1394,6 +1426,8 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     // Convert auth to X-Registry-Config format
     final RegistryConfigs registryConfigs = registryAuthSupplier.authForBuild();
 
+    final BuildProgressHandler buildHandler = new BuildProgressHandler(handler);
+
     try (final CompressedDirectory compressedDirectory = CompressedDirectory.create(directory);
          final InputStream fileStream = Files.newInputStream(compressedDirectory.file());
          final ProgressStream build =
@@ -1403,17 +1437,11 @@ public class DefaultDockerClient implements DockerClient, Closeable {
                                  authRegistryHeader(registryConfigs)),
                      Entity.entity(fileStream, "application/tar"))) {
 
-      String imageId = null;
-      while (build.hasNextMessage(POST, resource.getUri())) {
-        final ProgressMessage message = build.nextMessage(POST, resource.getUri());
-        final String id = message.buildImageId();
-        if (id != null) {
-          imageId = id;
-        }
-        handler.progress(message);
-      }
-      return imageId;
+      build.tail(buildHandler, POST, resource.getUri());
+    } catch (IOException e) {
+      throw new DockerException(e);
     }
+    return buildHandler.getImageId();
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -150,7 +150,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.ws.rs.ProcessingException;
@@ -1191,13 +1195,10 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     final CreateProgressHandler createProgressHandler = new CreateProgressHandler(handler);
     final Entity<InputStream> entity = Entity.entity(imagePayload,
                                                      APPLICATION_OCTET_STREAM);
-    try (final ProgressStream load =
-             request(POST, ProgressStream.class, resource,
-                     resource.request(APPLICATION_JSON_TYPE), entity)) {
-      load.tail(createProgressHandler, POST, resource.getUri());
+    try {
+      requestAndTail(POST, createProgressHandler, resource,
+              resource.request(APPLICATION_JSON_TYPE), entity);
       tag(createProgressHandler.getImageId(), image, true);
-    } catch (IOException e) {
-      throw new DockerException(e);
     } finally {
       IOUtils.closeQuietly(imagePayload);
     }
@@ -1275,14 +1276,11 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       resource = resource.queryParam("tag", imageRef.getTag());
     }
 
-    try (ProgressStream pull =
-             request(POST, ProgressStream.class, resource,
-                     resource
-                         .request(APPLICATION_JSON_TYPE)
-                         .header("X-Registry-Auth", authHeader(registryAuth)))) {
-      pull.tail(handler, POST, resource.getUri());
-    } catch (IOException e) {
-      throw new DockerException(e);
+    try {
+      requestAndTail(POST, handler, resource,
+              resource
+                  .request(APPLICATION_JSON_TYPE)
+                  .header("X-Registry-Auth", authHeader(registryAuth)));
     } catch (DockerRequestException e) {
       switch (e.status()) {
         case 404:
@@ -1323,13 +1321,10 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       resource = resource.queryParam("tag", imageRef.getTag());
     }
 
-    try (ProgressStream push =
-             request(POST, ProgressStream.class, resource,
-                     resource.request(APPLICATION_JSON_TYPE)
-                         .header("X-Registry-Auth", authHeader(registryAuth)))) {
-      push.tail(handler, POST, resource.getUri());
-    } catch (IOException e) {
-      throw new DockerException(e);
+    try {
+      requestAndTail(POST, handler, resource,
+              resource.request(APPLICATION_JSON_TYPE)
+                  .header("X-Registry-Auth", authHeader(registryAuth)));
     } catch (DockerRequestException e) {
       switch (e.status()) {
         case 404:
@@ -1429,19 +1424,16 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     final BuildProgressHandler buildHandler = new BuildProgressHandler(handler);
 
     try (final CompressedDirectory compressedDirectory = CompressedDirectory.create(directory);
-         final InputStream fileStream = Files.newInputStream(compressedDirectory.file());
-         final ProgressStream build =
-             request(POST, ProgressStream.class, resource,
+         final InputStream fileStream = Files.newInputStream(compressedDirectory.file())) {
+        
+      requestAndTail(POST, buildHandler, resource,
                      resource.request(APPLICATION_JSON_TYPE)
                          .header("X-Registry-Config",
                                  authRegistryHeader(registryConfigs)),
-                     Entity.entity(fileStream, "application/tar"))) {
+                     Entity.entity(fileStream, "application/tar"));
 
-      build.tail(buildHandler, POST, resource.getUri());
-    } catch (IOException e) {
-      throw new DockerException(e);
+      return buildHandler.getImageId();
     }
-    return buildHandler.getImageId();
   }
 
   @Override
@@ -2679,6 +2671,73 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     } catch (ExecutionException | MultiException e) {
       throw propagate(method, resource, e);
     }
+  }
+
+  private static class ResponseTailReader implements Callable<Void> {
+    private final ProgressStream stream;
+    private final ProgressHandler handler;
+    private final String method;
+    private final WebTarget resource;
+
+    public ResponseTailReader(ProgressStream stream, ProgressHandler handler,
+                              String method, WebTarget resource) {
+      this.stream = stream;
+      this.handler = handler;
+      this.method = method;
+      this.resource = resource;
+    }
+
+    @Override
+    public Void call() throws DockerException, InterruptedException, IOException {
+      stream.tail(handler, method, resource.getUri());
+      return null;
+    }
+  }
+
+  private void tailResponse(final String method, final Response response,
+                            final ProgressHandler handler, final WebTarget resource)
+        throws DockerException, InterruptedException {
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      final ProgressStream stream = response.readEntity(ProgressStream.class);
+      final Future<?> future = executor.submit(
+              new ResponseTailReader(stream, handler, method, resource));
+      future.get();
+    } catch (ExecutionException e) {
+      final Throwable cause = e.getCause();
+      if (cause instanceof DockerException) {
+        throw (DockerException)cause;
+      } else {
+        throw new DockerException(cause);
+      }
+    } finally {
+      executor.shutdownNow();
+      try {
+        response.close();
+      } catch (ProcessingException e) {
+        // ignore, thrown by jnr-unixsocket when httpcomponent try to read after close
+        // the socket is closed before this exception
+      }
+    }
+  }
+
+  private void requestAndTail(final String method, final ProgressHandler handler,
+                               final WebTarget resource, final Invocation.Builder request,
+                               final Entity<?> entity)
+      throws DockerException, InterruptedException {
+    Response response = request(method, Response.class, resource, request, entity);
+    tailResponse(method, response, handler, resource);
+  }
+  
+  private void requestAndTail(final String method, final ProgressHandler handler,
+                              final WebTarget resource, final Invocation.Builder request)
+      throws DockerException, InterruptedException {
+    Response response = request(method, Response.class, resource, request);
+    if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
+      throw new DockerRequestException(method, resource.getUri(), response.getStatus(),
+                message(response), null);
+    }
+    tailResponse(method, response, handler, resource);
   }
 
   private Invocation.Builder headers(final Invocation.Builder request) {

--- a/src/main/java/com/spotify/docker/client/ProgressStream.java
+++ b/src/main/java/com/spotify/docker/client/ProgressStream.java
@@ -69,8 +69,11 @@ class ProgressStream implements Closeable {
   }
 
   public void tail(ProgressHandler handler, final String method, final URI uri)
-      throws DockerException {
+      throws DockerException, InterruptedException {
     while (hasNextMessage(method, uri)) {
+      if (Thread.interrupted()) {
+        throw new InterruptedException();
+      }
       handler.progress(nextMessage(method, uri));
     }
   }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -444,6 +444,52 @@ public class DefaultDockerClientTest {
     sut.pull(BUSYBOX_BUILDROOT_2013_08_1);
   }
 
+  @SuppressWarnings("emptyCatchBlock")
+  @Test
+  public void testPullInterruption() throws Exception {
+    // Wait for container on a thread
+    final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    final SettableFuture<Boolean> started = SettableFuture.create();
+    final SettableFuture<Boolean> interrupted = SettableFuture.create();
+
+    final Future<?> exitFuture = executorService.submit(new Callable<ContainerExit>() {
+      @Override
+      public ContainerExit call() throws Exception {
+        try {
+          try {
+            sut.removeImage(BUSYBOX_BUILDROOT_2013_08_1);
+          } catch (DockerException ignored) {
+          }
+          sut.pull(BUSYBOX_BUILDROOT_2013_08_1, new ProgressHandler() {
+            @Override
+            public void progress(ProgressMessage message) throws DockerException {
+              if (!started.isDone()) {
+                started.set(true);
+              }
+            }
+          });
+          return null;
+        } catch (InterruptedException e) {
+          interrupted.set(true);
+          throw e;
+        }
+      }
+    });
+
+    // Interrupt waiting thread
+    started.get();
+    executorService.shutdownNow();
+    try {
+      exitFuture.get();
+      fail();
+    } catch (ExecutionException e) {
+      assertThat(e.getCause(), instanceOf(InterruptedException.class));
+    }
+
+    // Verify that the thread was interrupted
+    assertThat(interrupted.get(), is(true));
+  }
+
   @Test(expected = ImageNotFoundException.class)
   public void testPullBadImage() throws Exception {
     // The Docker daemon on CircleCI won't throw ImageNotFoundException for some reason...
@@ -994,6 +1040,62 @@ public class DefaultDockerClientTest {
     final ImageInfo info = sut.inspectImage(imageName);
     final String expectedId = dockerApiVersionLessThan("1.22") ? imageId : "sha256:" + imageId;
     assertThat(info.id(), startsWith(expectedId));
+  }
+
+  @SuppressWarnings("emptyCatchBlock")
+  @Test
+  public void testBuildInterruption() throws Exception {
+    // Wait for container on a thread
+    final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    final SettableFuture<Boolean> started = SettableFuture.create();
+    final SettableFuture<Boolean> interrupted = SettableFuture.create();
+
+    final String imageName = "test-build-name";
+    
+    final Future<?> buildFuture = executorService.submit(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        try {
+          try {
+            sut.removeImage(imageName);
+          } catch (DockerException ignored) {
+          }
+          final String dockerDirectory = Resources.getResource("dockerDirectorySleeping").getPath();
+          
+          sut.build(Paths.get(dockerDirectory), imageName, new ProgressHandler() {
+            @Override
+            public void progress(ProgressMessage message) throws DockerException {
+              if (!started.isDone()) {
+                started.set(true);
+              }
+            }
+          });
+        } catch (InterruptedException e) {
+          interrupted.set(true);
+          throw e;
+        }
+        return null;
+      }
+    });
+
+    // Interrupt waiting thread
+    started.get();
+    executorService.shutdownNow();
+    try {
+      buildFuture.get();
+      fail();
+    } catch (ExecutionException e) {
+      assertThat(e.getCause(), instanceOf(InterruptedException.class));
+    }
+
+    try {
+      sut.inspectImage(imageName);
+      fail();
+    } catch (ImageNotFoundException e) {
+    }
+    
+    // Verify that the thread was interrupted
+    assertThat(interrupted.get(), is(true));
   }
 
   @Test

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientUnitTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientUnitTest.java
@@ -292,9 +292,12 @@ public class DefaultDockerClientUnitTest {
     // build() calls /version to check what format of header to send
     enqueueServerApiVersion("1.20");
 
-    // TODO (mbrown): what to return for build response?
     server.enqueue(new MockResponse()
-        .setResponseCode(200)
+            .setResponseCode(200)
+            .addHeader("Content-Type", "application/json")
+            .setBody(
+                fixture("fixtures/1.22/build.json")
+            )
     );
 
     final Path path = Paths.get(Resources.getResource("dockerDirectory").toURI());

--- a/src/test/resources/fixtures/1.22/build.json
+++ b/src/test/resources/fixtures/1.22/build.json
@@ -1,0 +1,1 @@
+{"stream": "Successfully built randomimageid"}


### PR DESCRIPTION
The Docker engine allows the client to cancel these requests by dropping the connection. (see https://docs.docker.com/engine/api/v1.25/)

This PR is a rebased version of https://github.com/spotify/docker-client/pull/703