### PR TITLE
Fix containerAction. It was not considering queryParams

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -678,12 +678,12 @@ public class DefaultDockerClient implements DockerClient, Closeable {
                                final MultivaluedMap<String, String> queryParameters)
           throws DockerException, InterruptedException {
     try {
-      final WebTarget resource = resource()
+      WebTarget resource = resource()
               .path("containers").path(containerId).path(action);
 
       for (Map.Entry<String, List<String>> queryParameter : queryParameters.entrySet()) {
         for (String parameterValue : queryParameter.getValue()) {
-          resource.queryParam(queryParameter.getKey(), parameterValue);
+          resource = resource.queryParam(queryParameter.getKey(), parameterValue);
         }
       }
       request(POST, resource, resource.request());


### PR DESCRIPTION
While testing killContainer, ran into issue that "signal=SIGHUP" is not getting POST'ed in the URL queryParams. The below change fixes it.