### PR TITLE
Security Upgrade: Bouncy Castle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Please poke us if you feel you're being neglected, and we'll do our best to get 
 
 ## Related Tools You May Find Useful
 
-If you like this project, you might also like [docker-maven-plugin][2], [helios][3], [docker-gc][4],
+If you like this project, you might also like [dockerfile-maven][2], [helios][3], [docker-gc][4],
 [helios-skydns][5], and [helios-consul][6].
 
 
@@ -51,7 +51,7 @@ they end up testing both how docker-client behaves and how the docker daemon
 itself behaves.
 
   [1]: https://github.com/spotify/docker-client#testing
-  [2]: https://github.com/spotify/docker-maven-plugin
+  [2]: https://github.com/spotify/dockerfile-maven
   [3]: https://github.com/spotify/helios
   [4]: https://github.com/spotify/docker-gc
   [5]: https://github.com/spotify/helios-skydns

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.52</version>
+      <version>1.59</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
@@ -342,7 +342,7 @@
             <relocation>
               <pattern>org.glassfish</pattern>
               <shadedPattern>com.spotify.docker.client.shaded.org.glassfish</shadedPattern>
-            </relocation> 
+            </relocation>
             <relocation>
               <pattern>com.fasterxml.jackson</pattern>
               <shadedPattern>com.spotify.docker.client.shaded.com.fasterxml.jackson</shadedPattern>

--- a/pom.xml
+++ b/pom.xml
@@ -89,17 +89,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.8.8</version>
+      <version>2.9.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-guava</artifactId>
-      <version>2.8.8</version>
+      <version>2.9.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.8.8</version>
+      <version>2.9.4</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>


### PR DESCRIPTION
Upgrading Bouncy Castle cryptography APIs from version 1.52 (Mar 2015) to 1.59 (Jan 2018).