### PR TITLE
Support getting image information via /distribution

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -38,7 +38,6 @@ import static javax.ws.rs.HttpMethod.DELETE;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.HttpMethod.PUT;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
@@ -89,6 +88,7 @@ import com.spotify.docker.client.messages.ContainerExit;
 import com.spotify.docker.client.messages.ContainerInfo;
 import com.spotify.docker.client.messages.ContainerStats;
 import com.spotify.docker.client.messages.ContainerUpdate;
+import com.spotify.docker.client.messages.Distribution;
 import com.spotify.docker.client.messages.ExecCreation;
 import com.spotify.docker.client.messages.ExecState;
 import com.spotify.docker.client.messages.HostConfig;
@@ -324,6 +324,10 @@ public class DefaultDockerClient implements DockerClient, Closeable {
 
   private static final GenericType<List<Service>> SERVICE_LIST =
       new GenericType<List<Service>>() {
+      };
+
+  private  static final GenericType<Distribution> DISTRIBUTION =
+      new GenericType<Distribution>(){
       };
 
   private static final GenericType<List<Task>> TASK_LIST = new GenericType<List<Task>>() { };
@@ -746,6 +750,14 @@ public class DefaultDockerClient implements DockerClient, Closeable {
     queryParameters.add("signal", signal.getName());
 
     containerAction(containerId, "kill", queryParameters);
+  }
+
+  @Override
+  public Distribution getDistribution(String imageName)
+      throws DockerException, InterruptedException {
+    checkNotNull(imageName, "containerName");
+    final WebTarget resource = resource().path("distribution").path(imageName).path("json");
+    return request(GET, DISTRIBUTION, resource, resource.request(APPLICATION_JSON_TYPE));
   }
 
   @Override

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -47,6 +47,7 @@ import com.spotify.docker.client.messages.ContainerExit;
 import com.spotify.docker.client.messages.ContainerInfo;
 import com.spotify.docker.client.messages.ContainerStats;
 import com.spotify.docker.client.messages.ContainerUpdate;
+import com.spotify.docker.client.messages.Distribution;
 import com.spotify.docker.client.messages.Event;
 import com.spotify.docker.client.messages.ExecCreation;
 import com.spotify.docker.client.messages.ExecState;
@@ -972,6 +973,17 @@ public interface DockerClient extends Closeable {
    * @throws InterruptedException If the thread is interrupted
    */
   void killContainer(final String containerId, final Signal signal)
+      throws DockerException, InterruptedException;
+
+  /**
+   * Get the distribution of a container.
+   * @param imageName The name of the container.
+   * @throws ContainerNotFoundException
+   *                              if container is not found (404)
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException If the thread is interrupted
+   */
+  Distribution getDistribution(final String imageName)
       throws DockerException, InterruptedException;
 
   /**

--- a/src/main/java/com/spotify/docker/client/messages/Descriptor.java
+++ b/src/main/java/com/spotify/docker/client/messages/Descriptor.java
@@ -1,0 +1,57 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = ANY)
+public abstract class Descriptor {
+
+  @JsonProperty("MediaType")
+  public abstract String mediaType();
+
+  @JsonProperty("Digest")
+  public abstract String digest();
+
+  @JsonProperty("Size")
+  public abstract Long size();
+
+  @JsonProperty("URLs")
+  public abstract ImmutableList<String> urls();
+
+  @JsonCreator
+  static Descriptor create(
+            @JsonProperty("MediaType") String mediaType,
+            @JsonProperty("Digest") String digest,
+            @JsonProperty("Size") Long size,
+            @JsonProperty("URLs") ImmutableList<String> urls) {
+    return new AutoValue_Descriptor(mediaType, digest, size, urls);
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/Distribution.java
+++ b/src/main/java/com/spotify/docker/client/messages/Distribution.java
@@ -1,0 +1,67 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.DEFAULT;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import javax.annotation.Nullable;
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = DEFAULT)
+public abstract class Distribution {
+
+  @JsonProperty("Descriptor")
+  public abstract Descriptor descriptor();
+
+  @Nullable
+  @JsonProperty("Platforms")
+  public abstract ImmutableList<Platform> platforms();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder descriptor(Descriptor descriptor);
+
+    public abstract Builder platforms(ImmutableList<Platform> platforms);
+
+    public abstract Distribution build();
+  }
+
+  public static Builder builder() {
+    return new AutoValue_Distribution.Builder();
+  }
+
+  @JsonCreator
+  static Distribution create(
+          @JsonProperty("Descriptor") Descriptor descriptor,
+          @JsonProperty("Platforms") ImmutableList<Platform> platforms) {
+    return builder()
+            .descriptor(descriptor)
+            .platforms(platforms)
+            .build();
+  }
+}

--- a/src/main/java/com/spotify/docker/client/messages/Platform.java
+++ b/src/main/java/com/spotify/docker/client/messages/Platform.java
@@ -1,0 +1,67 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.DEFAULT;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+
+
+@AutoValue
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = DEFAULT)
+public abstract class Platform {
+
+  @JsonProperty("Architecture")
+  public abstract String architecture();
+
+  @JsonProperty("OS")
+  public abstract String os();
+
+  @JsonProperty("OSVersion")
+  public abstract String osVersion();
+
+  @JsonProperty("OSFeatures")
+  public abstract ImmutableList<String> osFeatures();
+
+  @JsonProperty("Variant")
+  public abstract String variant();
+
+  @JsonProperty("Features")
+  public abstract ImmutableList<String> features();
+
+  @JsonCreator
+  static Platform create(
+            @JsonProperty("Architecture") String architecture,
+            @JsonProperty("OS") String os,
+            @JsonProperty("OSVersion") String osVersion,
+            @JsonProperty("OSFeatures") ImmutableList<String> osFeatures,
+            @JsonProperty("Variant") String variant,
+            @JsonProperty("Features") ImmutableList<String> features) {
+    return new AutoValue_Platform(architecture, os, osVersion, osFeatures,
+                variant, features);
+  }
+}

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientUnitTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientUnitTest.java
@@ -55,6 +55,7 @@ import com.spotify.docker.client.exceptions.NodeNotFoundException;
 import com.spotify.docker.client.exceptions.NonSwarmNodeException;
 import com.spotify.docker.client.exceptions.NotFoundException;
 import com.spotify.docker.client.messages.ContainerConfig;
+import com.spotify.docker.client.messages.Distribution;
 import com.spotify.docker.client.messages.HostConfig;
 import com.spotify.docker.client.messages.HostConfig.Bind;
 import com.spotify.docker.client.messages.RegistryAuth;
@@ -1054,6 +1055,41 @@ public class DefaultDockerClientUnitTest {
     assertThat(volume.options(), is(ImmutableMap.of(
         "foo", "bar",
         "baz", "qux"
+    )));
+  }
+
+  @Test
+  public void testGetDistribution() throws Exception {
+    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+    server.enqueue(new MockResponse()
+        .setResponseCode(200)
+        .addHeader("Content-Type", "application/json")
+        .setBody(
+          fixture("fixtures/1.30/distribution.json")
+        )
+    );
+    final Distribution distribution = dockerClient.getDistribution("my-image");
+    assertThat(distribution, notNullValue());
+    assertThat(distribution.platforms().size(), is(1));
+    assertThat(distribution.platforms().get(0).architecture() , is("amd64"));
+    assertThat(distribution.platforms().get(0).os() , is("linux"));
+    assertThat(distribution.platforms().get(0).osVersion() , is(""));
+    assertThat(distribution.platforms().get(0).variant() , is(""));
+    assertThat(distribution.descriptor().size() , is(Long.valueOf(3987495)));
+    assertThat(distribution.descriptor().digest() , is(
+        "sha256:c0537ff6a5218ef531ece93d4984efc99bbf3f7497c0a7726c88e2bb7584dc96"));
+    assertThat(distribution.descriptor().mediaType() , is(
+        "application/vnd.docker.distribution.manifest.v2+json"
+    ));
+    assertThat(distribution.platforms().get(0).osFeatures() , is(ImmutableList.of(
+        "feature1", "feature2"
+    )));
+    assertThat(distribution.platforms().get(0).features() , is(ImmutableList.of(
+        "feature1", "feature2"
+    )));
+    assertThat(distribution.descriptor().urls() , is(ImmutableList.of(
+        "url1", "url2"
     )));
   }
 

--- a/src/test/java/com/spotify/docker/client/messages/DistributionTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/DistributionTest.java
@@ -1,0 +1,38 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.messages;
+
+import static com.spotify.docker.FixtureUtil.fixture;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.docker.client.ObjectMapperProvider;
+import org.junit.Test;
+
+
+public class DistributionTest {
+
+  private final ObjectMapper mapper = ObjectMapperProvider.objectMapper();
+
+  @Test
+  public void test1_30() throws Exception {
+    mapper.readValue(fixture("fixtures/1.30/distribution.json"), Distribution.class);
+  }
+}

--- a/src/test/resources/fixtures/1.30/distribution.json
+++ b/src/test/resources/fixtures/1.30/distribution.json
@@ -1,0 +1,27 @@
+{
+  "Descriptor": {
+    "MediaType": "application/vnd.docker.distribution.manifest.v2+json",
+    "Digest": "sha256:c0537ff6a5218ef531ece93d4984efc99bbf3f7497c0a7726c88e2bb7584dc96",
+    "Size": 3987495,
+    "URLs": [
+      "url1",
+      "url2"
+    ]
+  },
+  "Platforms": [
+    {
+      "Architecture": "amd64",
+      "OS": "linux",
+      "OSVersion": "",
+      "OSFeatures": [
+        "feature1",
+        "feature2"
+      ],
+      "Variant": "",
+      "Features": [
+        "feature1",
+        "feature2"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request add three new messages classes:

- `DIstribution`: https://docs.docker.com/engine/api/v1.30/#tag/Distributionv

- `Descriptor`: containing details on the distro

- `Platforms`: a list of platforms and their details.