### PR TITLE
Small bugfix for temporary files.

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -939,10 +939,10 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   @Override
   public void copyToContainer(final Path directory, String containerId, String path)
       throws DockerException, InterruptedException, IOException {
-    final CompressedDirectory compressedDirectory = CompressedDirectory.create(directory);
-    final InputStream fileStream = Files.newInputStream(compressedDirectory.file());
-
-    copyToContainer(fileStream, containerId, path);
+    try (final CompressedDirectory compressedDirectory = CompressedDirectory.create(directory);
+         final InputStream fileStream = Files.newInputStream(compressedDirectory.file())) {
+      copyToContainer(fileStream, containerId, path);
+    }
   }
 
   @Override


### PR DESCRIPTION
I noticed growing number of docker-client-[something].tar.gz files in /tmp dir. Adding try-with-resources seems to fix the problem. 