### PR TITLE
Allow attach a not started container

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -1521,11 +1521,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   public LogStream attachContainer(final String containerId,
                                    final AttachParameter... params) throws DockerException,
                                                                            InterruptedException {
-    final ContainerInfo containerInfo = inspectContainer(containerId);
-    if (!containerInfo.state().running()) {
-      throw new IllegalStateException("Container " + containerId + " is not running.");
-    }
-
+    checkNotNull(containerId, "containerId");
     WebTarget resource = noTimeoutResource().path("containers").path(containerId).path("attach");
 
     for (final AttachParameter param : params) {

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -3068,29 +3068,6 @@ public class DefaultDockerClientTest {
   }
 
   @Test
-  public void testAttachExitedContainer() throws Exception {
-    sut.pull(BUSYBOX_LATEST);
-
-    final String volumeContainer = randomName();
-
-    final ContainerConfig volumeConfig = ContainerConfig.builder()
-        .image(BUSYBOX_LATEST)
-        .cmd("ls", "-la")
-        .build();
-    final ContainerCreation container = sut.createContainer(volumeConfig, volumeContainer);
-    sut.startContainer(volumeContainer);
-
-    exception.expect(IllegalStateException.class);
-    exception.expectMessage(containsString("is not running"));
-
-    await().until(containerIsRunning(sut, container.id()), is(false));
-
-    sut.attachContainer(volumeContainer,
-        AttachParameter.LOGS, AttachParameter.STDOUT,
-        AttachParameter.STDERR, AttachParameter.STREAM);
-  }
-
-  @Test
   public void testLogNoTimeout() throws Exception {
     final String volumeContainer = createSleepingContainer();
     final StringBuffer result = new StringBuffer();


### PR DESCRIPTION
Currently, when attaching a container, we require the container status is running. However, as #905 described, we don't need to check container status. 

Closes #905 