### PR TITLE
Fix DockerConfigReader when ~/.docker/config.json has no auths

### DIFF
--- a/src/main/java/com/spotify/docker/client/DockerConfigReader.java
+++ b/src/main/java/com/spotify/docker/client/DockerConfigReader.java
@@ -23,6 +23,7 @@ package com.spotify.docker.client;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -164,11 +165,15 @@ public class DockerConfigReader {
         }
       }
       return RegistryConfigs.create(registryAuthMap);
-
     } else if (authJson.has(AUTHS_ENTRY)) {
-      authJson = (ObjectNode)authJson.get(AUTHS_ENTRY);
+      return MAPPER.treeToValue(authJson.get(AUTHS_ENTRY), RegistryConfigs.class);
     }
-    return MAPPER.treeToValue(authJson, RegistryConfigs.class);
+
+    try {
+      return MAPPER.treeToValue(authJson, RegistryConfigs.class);
+    } catch (JsonProcessingException e) {
+      return RegistryConfigs.empty();
+    }
   }
 
   public Path defaultConfigPath() {

--- a/src/test/java/com/spotify/docker/client/DockerConfigReaderTest.java
+++ b/src/test/java/com/spotify/docker/client/DockerConfigReaderTest.java
@@ -295,4 +295,11 @@ public class DockerConfigReaderTest {
         hasEntry("https://narnia.mydock.io/v1/", MY_AUTH_CONFIG)
     ));
   }
+
+  @Test
+  public void testParseNoAuths() throws Exception {
+    final Path path = getTestFilePath("dockerConfig/noAuths.json");
+    final RegistryConfigs configs = reader.fromConfig(path);
+    assertThat(configs, equalTo(RegistryConfigs.empty()));
+  }
 }

--- a/src/test/resources/dockerConfig/noAuths.json
+++ b/src/test/resources/dockerConfig/noAuths.json
@@ -1,0 +1,7 @@
+{
+  "HttpHeaders": {
+    "User-Agent": "Docker-Client/18.04.0-ce (darwin)"
+  },
+  "credsStore": "osxkeychain",
+  "detachKeys": "ctrl-v,ctrl-q"
+}


### PR DESCRIPTION
Sometimes `~/.docker/config.json` might not have any auth entries.
DockerConfigReader currently throws an error if so.
Return an empty `RegistryConfigs` instead.

fixes #989