### PR TITLE
Update ISSUE_TEMPLATE.md to point questions to SO and user manual

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,13 @@
+<!-- This form is for bug reports and feature requests ONLY!
+
+If you're looking for help check
+[Stack Overflow](https://stackoverflow.com/questions/tagged/spotify-docker-client) and the
+[user manual](https://github.com/spotify/docker-client/blob/master/docs/user_manual.md).
+-->
+
+**Is this a BUG REPORT or FEATURE REQUEST?**:
+
+
 ## Description
 
 [Add feature/bug description here]


### PR DESCRIPTION
We get a lot of issues that are just questions on usage. Let's direct these
to StackOverflow and the user manual so issues can be reserved for bugs and
feature requests.