### PR TITLE
Handle the ‘credentials not found in native keychain’ message.

### DIFF
--- a/src/main/java/com/spotify/docker/client/DockerConfigReader.java
+++ b/src/main/java/com/spotify/docker/client/DockerConfigReader.java
@@ -154,6 +154,12 @@ public class DockerConfigReader {
                                           process.getInputStream(), StandardCharsets.UTF_8)) {
           try (BufferedReader input = new BufferedReader(reader)) {
             String serverAuthDetails = input.readLine();
+            // ErrCredentialsNotFound standardizes the not found error, so every helper returns
+            // the same message and docker can handle it properly.
+            // https://github.com/docker/docker-credential-helpers/blob/19b711cc92fbaa47533646fa8adb457d199c99e1/credentials/error.go#L4-L6
+            if ("credentials not found in native keychain".equals(serverAuthDetails)) {
+              continue;
+            }
             JsonNode serverAuthNode = MAPPER.readTree(serverAuthDetails);
             RegistryAuthV2 serverAuth =
                 new RegistryAuthV2(serverAuthNode.get("Username").textValue(),


### PR DESCRIPTION
The credential helpers sometimes returns the message:

> credentials not found in native keychain

[Source](https://github.com/docker/docker-credential-helpers/blob/19b711cc92fbaa47533646fa8adb457d199c99e1/credentials/error.go#L4-L6)

The provided patch recognises this message and ignores such credential helper. Without it, docker-client fails on my system (macOS 10.13.5, Docker 18.03.1-ce-mac65, Credential Helper: 0.6.0) with following exception:

```
[INFO] --- dockerfile-maven-plugin:1.4.3:build (default) @ aem-ethos ---
[INFO] Building Docker context /Users/rekawek/granite/elastic-granite/docker-AEM-ethos/aem-ethos
[INFO]
[INFO] Image will be built as docker2-granite-release-local.dr-uw2.adobeitc.com/aem-ethos/author-nosamplecontent:latest
[INFO]
[WARNING] An attempt failed, will retry 1 more times
org.apache.maven.plugin.MojoExecutionException: Could not build image
    at com.spotify.plugin.dockerfile.BuildMojo.buildImage (BuildMojo.java:185)
    at com.spotify.plugin.dockerfile.BuildMojo.execute (BuildMojo.java:105)
    [...]
Caused by: com.spotify.docker.client.exceptions.DockerException: com.spotify.docker.client.shaded.com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'credentials': was expecting ('true', 'false' or 'null')
 at [Source: (String)"credentials not found in native keychain"; line: 1, column: 12]
    at com.spotify.docker.client.auth.ConfigFileRegistryAuthSupplier.authForBuild (ConfigFileRegistryAuthSupplier.java:108)
    at com.spotify.docker.client.auth.MultiRegistryAuthSupplier.authForBuild (MultiRegistryAuthSupplier.java:77)
    at com.spotify.docker.client.DefaultDockerClient.build (DefaultDockerClient.java:1425)
    at com.spotify.docker.client.DefaultDockerClient.build (DefaultDockerClient.java:1402)
    [...]
Caused by: com.spotify.docker.client.shaded.com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'credentials': was expecting ('true', 'false' or 'null')
 at [Source: (String)"credentials not found in native keychain"; line: 1, column: 12]
    at com.spotify.docker.client.shaded.com.fasterxml.jackson.core.JsonParser._constructError (JsonParser.java:1804)
    at com.spotify.docker.client.shaded.com.fasterxml.jackson.core.base.ParserMinimalBase._reportError (ParserMinimalBase.java:673)
    at com.spotify.docker.client.shaded.com.fasterxml.jackson.core.json.ReaderBasedJsonParser._reportInvalidToken (ReaderBasedJsonParser.java:2835)
    at com.spotify.docker.client.shaded.com.fasterxml.jackson.core.json.ReaderBasedJsonParser._handleOddValue (ReaderBasedJsonParser.java:1889)
    at com.spotify.docker.client.shaded.com.fasterxml.jackson.core.json.ReaderBasedJsonParser.nextToken (ReaderBasedJsonParser.java:747)
    at com.spotify.docker.client.shaded.com.fasterxml.jackson.databind.ObjectMapper._readTreeAndClose (ObjectMapper.java:4030)
    at com.spotify.docker.client.shaded.com.fasterxml.jackson.databind.ObjectMapper.readTree (ObjectMapper.java:2539)
    at com.spotify.docker.client.DockerConfigReader.parseDockerConfig (DockerConfigReader.java:157)
    at com.spotify.docker.client.DockerConfigReader.fromConfig (DockerConfigReader.java:64)
    at com.spotify.docker.client.auth.ConfigFileRegistryAuthSupplier.authForBuild (ConfigFileRegistryAuthSupplier.java:106)
    at com.spotify.docker.client.auth.MultiRegistryAuthSupplier.authForBuild (MultiRegistryAuthSupplier.java:77)
    at com.spotify.docker.client.DefaultDockerClient.build (DefaultDockerClient.java:1425)
    at com.spotify.docker.client.DefaultDockerClient.build (DefaultDockerClient.java:1402)
    at com.spotify.plugin.dockerfile.BuildMojo.buildImage (BuildMojo.java:178)
    at com.spotify.plugin.dockerfile.BuildMojo.execute (BuildMojo.java:105)
    [...]
```