### PR TITLE
Skip unit tests that require Docker Hub passwords

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -734,6 +734,9 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testAuth() throws Exception {
+    // The Docker Hub password is stored encrypted in Travis. So only run on Travis.
+    assumeTrue(TRAVIS);
+
     final int statusCode = sut.auth(registryAuth);
     assertThat(statusCode, equalTo(200));
   }
@@ -986,6 +989,9 @@ public class DefaultDockerClientTest {
 
   @Test
   public void testBuildImageIdWithAuth() throws Exception {
+    // The Docker Hub password is stored encrypted in Travis. So only run on Travis.
+    assumeTrue(TRAVIS);
+
     final Path dockerDirectory = getResource("dockerDirectory");
     final AtomicReference<String> imageIdFromMessage = new AtomicReference<>();
 


### PR DESCRIPTION
that are only stored encrypted in Travis.