### PR TITLE
Fix docker info object to deserialise the networks path

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/Info.java
+++ b/src/main/java/com/spotify/docker/client/messages/Info.java
@@ -276,7 +276,7 @@ public abstract class Info {
     public abstract ImmutableList<String> volumes();
 
     /**
-     * Return the value of the `network` json path
+     * Return the value of the `network` json path.
      * todo this method should be renamed to network
      */
     @JsonProperty("Network")

--- a/src/main/java/com/spotify/docker/client/messages/Info.java
+++ b/src/main/java/com/spotify/docker/client/messages/Info.java
@@ -275,13 +275,17 @@ public abstract class Info {
     @JsonProperty("Volumes")
     public abstract ImmutableList<String> volumes();
 
-    @JsonProperty("Networks")
+    /**
+     * Return the value of the `network` json path
+     * todo this method should be renamed to network
+     */
+    @JsonProperty("Network")
     public abstract ImmutableList<String> networks();
 
     @JsonCreator
     static Plugins create(
         @JsonProperty("Volumes") final List<String> volumes,
-        @JsonProperty("Networks") final List<String> networks) {
+        @JsonProperty("Network") final List<String> networks) {
       final ImmutableList<String> volumesT =
           volumes == null ? ImmutableList.<String>of() : ImmutableList.copyOf(volumes);
       final ImmutableList<String> networksT =

--- a/src/test/java/com/spotify/docker/client/messages/DockerInfoTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/DockerInfoTest.java
@@ -1,30 +1,35 @@
 package com.spotify.docker.client.messages;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.client.util.NullValue;
-import com.spotify.docker.client.ObjectMapperProvider;
-import org.junit.Test;
-
 import static com.spotify.docker.FixtureUtil.fixture;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.docker.client.ObjectMapperProvider;
+import org.junit.Test;
 
 /**
  * Test cases around the deserialization of the docker info object.
  */
 public class DockerInfoTest {
 
-    private final ObjectMapper objectMapper = ObjectMapperProvider.objectMapper();
+  private final ObjectMapper objectMapper = ObjectMapperProvider.objectMapper();
 
-    /**
-     * Test that when we deserialize the docker info response we properly parse the Plugins.Network json path.
-     * @throws Exception when we fail to deserialize
-     */
-    @Test
-    public void dockerInfoNetworkDesirializerTest_1_23() throws Exception {
-        Info info = objectMapper.readValue(fixture("fixtures/1.23/docker_info.json"), Info.class);
-        assertThat(info.plugins(), is(not(nullValue())));
-        assertThat(info.plugins().networks(), is(not(nullValue())));
-        assertThat(info.plugins().networks().size() , is(greaterThan(0)));
-    }
+  /**
+   * Test that when we deserialize the docker info response we properly parse the Plugins.Network
+   * json path.
+   *
+   * @throws Exception when we fail to deserialize
+   */
+  @Test
+  public void dockerInfoNetworkDesirializerTest_1_23() throws Exception {
+    Info info = objectMapper.readValue(fixture("fixtures/1.23/docker_info.json"), Info.class);
+    assertThat(info.plugins(), is(not(nullValue())));
+    assertThat(info.plugins().networks(), is(not(nullValue())));
+    assertThat(info.plugins().networks().size(), is(greaterThan(0)));
+  }
 }

--- a/src/test/java/com/spotify/docker/client/messages/DockerInfoTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/DockerInfoTest.java
@@ -1,3 +1,23 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
 package com.spotify.docker.client.messages;
 
 import static com.spotify.docker.FixtureUtil.fixture;

--- a/src/test/java/com/spotify/docker/client/messages/DockerInfoTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/DockerInfoTest.java
@@ -1,0 +1,30 @@
+package com.spotify.docker.client.messages;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.util.NullValue;
+import com.spotify.docker.client.ObjectMapperProvider;
+import org.junit.Test;
+
+import static com.spotify.docker.FixtureUtil.fixture;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Test cases around the deserialization of the docker info object.
+ */
+public class DockerInfoTest {
+
+    private final ObjectMapper objectMapper = ObjectMapperProvider.objectMapper();
+
+    /**
+     * Test that when we deserialize the docker info response we properly parse the Plugins.Network json path.
+     * @throws Exception when we fail to deserialize
+     */
+    @Test
+    public void dockerInfoNetworkDesirializerTest_1_23() throws Exception {
+        Info info = objectMapper.readValue(fixture("fixtures/1.23/docker_info.json"), Info.class);
+        assertThat(info.plugins(), is(not(nullValue())));
+        assertThat(info.plugins().networks(), is(not(nullValue())));
+        assertThat(info.plugins().networks().size() , is(greaterThan(0)));
+    }
+}

--- a/src/test/resources/fixtures/1.23/docker_info.json
+++ b/src/test/resources/fixtures/1.23/docker_info.json
@@ -1,0 +1,89 @@
+{
+  "ID": "XQOF:PUHX:27AO:3WUP:BKXN:PS4P:J56A:SEMQ:5EMQ:SV6U:4RL7:TBXE",
+  "Containers": 2,
+  "ContainersRunning": 2,
+  "ContainersPaused": 0,
+  "ContainersStopped": 1,
+  "Images": 2,
+  "Driver": "aufs",
+  "DriverStatus": [
+    [
+      "Root Dir",
+      "/var/lib/docker"
+    ],
+    [
+      "Backing Filesystem",
+      "extfs"
+    ],
+    [
+      "Dirs",
+      "2"
+    ],
+    [
+      "Dirperm1 Supported",
+      "true"
+    ]
+  ],
+  "SystemStatus": null,
+  "Plugins": {
+    "Volume": [
+      "local"
+    ],
+    "Network": [
+      "bridge",
+      "null",
+      "host"
+    ],
+    "Authorization": null
+  },
+  "MemoryLimit": true,
+  "SwapLimit": true,
+  "KernelMemory": true,
+  "CpuCfsPeriod": true,
+  "CpuCfsQuota": true,
+  "CPUShares": true,
+  "CPUSet": true,
+  "IPv4Forwarding": true,
+  "BridgeNfIptables": true,
+  "BridgeNfIp6tables": true,
+  "Debug": false,
+  "NFd": 78,
+  "OomKillDisable": true,
+  "NGoroutines": 148,
+  "SystemTime": "2018-07-02T12:28:27.911846858Z",
+  "ExecutionDriver": "",
+  "LoggingDriver": "json-file",
+  "CgroupDriver": "cgroupfs",
+  "NEventsListener": 0,
+  "KernelVersion": "4.4.0-1048-aws",
+  "OperatingSystem": "Ubuntu 16.04.3 LTS",
+  "OSType": "linux",
+  "Architecture": "x86_64",
+  "IndexServerAddress": "https://index.docker.io/v1/",
+  "RegistryConfig": {
+    "InsecureRegistryCIDRs": [
+      "127.0.0.0/8"
+    ],
+    "IndexConfigs": {
+      "docker.io": {
+        "Name": "docker.io",
+        "Mirrors": null,
+        "Secure": true,
+        "Official": true
+      }
+    },
+    "Mirrors": null
+  },
+  "NCPU": 2,
+  "MemTotal": 16040345600,
+  "DockerRootDir": "/var/lib/docker",
+  "HttpProxy": "",
+  "HttpsProxy": "",
+  "NoProxy": "",
+  "Name": "ip-192-168-44-10",
+  "Labels": null,
+  "ExperimentalBuild": false,
+  "ServerVersion": "1.11.2",
+  "ClusterStore": "",
+  "ClusterAdvertise": ""
+}


### PR DESCRIPTION
- Add a new fixture for the docker info response
- Add tests for the path of the network of docker info 
- Fix typo in the JSON field name for the network

Fixes: #1044 