### PR TITLE
Add support for runtime property in HostConfig 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 8.13.0
+
+Not yet released
+
+- Make ContainExit.exitCode(), HealthLog.exitCode() and ExecState.exitCode() return a Long instead
+ of Integer.
+- Add support for `runtime` in HostConfig
+
 ## 8.12.0
 
 Released August 26 2018

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>docker-client</artifactId>
-  <version>8.12.1-SNAPSHOT</version>
+  <version>9.0.0</version>
   <packaging>jar</packaging>
   <name>docker-client</name>
   <description>A docker client</description>

--- a/src/main/java/com/spotify/docker/client/messages/ContainerExit.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerExit.java
@@ -34,10 +34,10 @@ import com.google.auto.value.AutoValue;
 public abstract class ContainerExit {
 
   @JsonProperty("StatusCode")
-  public abstract Integer statusCode();
+  public abstract Long statusCode();
 
   @JsonCreator
-  public static ContainerExit create(@JsonProperty("StatusCode") final Integer statusCode) {
+  public static ContainerExit create(@JsonProperty("StatusCode") final Long statusCode) {
     return new AutoValue_ContainerExit(statusCode);
   }
 }

--- a/src/main/java/com/spotify/docker/client/messages/ContainerState.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerState.java
@@ -103,7 +103,7 @@ public abstract class ContainerState {
     public abstract Date end();
 
     @JsonProperty("ExitCode")
-    public abstract Integer exitCode();
+    public abstract Long exitCode();
 
     @JsonProperty("Output")
     public abstract String output();
@@ -112,7 +112,7 @@ public abstract class ContainerState {
     static HealthLog create(
         @JsonProperty("Start") final Date start,
         @JsonProperty("End") final Date end,
-        @JsonProperty("ExitCode") final Integer exitCode,
+        @JsonProperty("ExitCode") final Long exitCode,
         @JsonProperty("Output") final String output) {
       return new AutoValue_ContainerState_HealthLog(start, end, exitCode, output);
     }

--- a/src/main/java/com/spotify/docker/client/messages/ExecState.java
+++ b/src/main/java/com/spotify/docker/client/messages/ExecState.java
@@ -45,7 +45,7 @@ public abstract class ExecState {
 
   @Nullable
   @JsonProperty("ExitCode")
-  public abstract Integer exitCode();
+  public abstract Long exitCode();
 
   @JsonProperty("ProcessConfig")
   public abstract ProcessConfig processConfig();
@@ -71,7 +71,7 @@ public abstract class ExecState {
   static ExecState create(
       @JsonProperty("ID") final String id,
       @JsonProperty("Running") final Boolean running,
-      @JsonProperty("ExitCode") final Integer exitCode,
+      @JsonProperty("ExitCode") final Long exitCode,
       @JsonProperty("ProcessConfig") final ProcessConfig processConfig,
       @JsonProperty("OpenStdin") final Boolean openStdin,
       @JsonProperty("OpenStdout") final Boolean openStdout,

--- a/src/main/java/com/spotify/docker/client/messages/HostConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/HostConfig.java
@@ -240,6 +240,11 @@ public abstract class HostConfig {
   @JsonProperty("StorageOpt")
   public abstract ImmutableMap<String, String> storageOpt();
 
+  @Nullable
+  @JsonProperty("Runtime")
+  public abstract String runtime();
+
+
   @JsonCreator
   static HostConfig create(
       @JsonProperty("Binds") final List<String> binds,
@@ -288,6 +293,7 @@ public abstract class HostConfig {
       @JsonProperty("PidsLimit") final Integer pidsLimit,
       @JsonProperty("Tmpfs") final Map<String, String> tmpfs,
       @JsonProperty("ReadonlyRootfs") final Boolean readonlyRootfs,
+      @JsonProperty("Runtime") final String runtime,
       @JsonProperty("StorageOpt") final Map<String, String> storageOpt) {
     return builder()
         .binds(binds)
@@ -337,6 +343,7 @@ public abstract class HostConfig {
         .tmpfs(tmpfs)
         .readonlyRootfs(readonlyRootfs)
         .storageOpt(storageOpt)
+        .runtime(runtime)
         .build();
   }
 
@@ -635,6 +642,8 @@ public abstract class HostConfig {
     public abstract Builder readonlyRootfs(Boolean readonlyRootfs);
     
     public abstract Builder storageOpt(Map<String, String> tmpfs);
+
+    public abstract Builder runtime(String runtime);
 
     // Validation of property values using AutoValue requires we split the build method into two.
     // AutoValue implements this package-private method.

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ContainerStatus.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ContainerStatus.java
@@ -44,13 +44,13 @@ public abstract class ContainerStatus {
 
   @Nullable
   @JsonProperty("ExitCode")
-  public abstract Integer exitCode();
+  public abstract Long exitCode();
 
   @JsonCreator
   static ContainerStatus create(
       @JsonProperty("ContainerID") final String containerId,
       @JsonProperty("PID") final Integer pid,
-      @JsonProperty("ExitCode") final Integer exitCode) {
+      @JsonProperty("ExitCode") final Long exitCode) {
     return new AutoValue_ContainerStatus(containerId, pid, exitCode);
   }
 }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -203,7 +203,6 @@ import com.spotify.docker.client.messages.swarm.OrchestrationConfig;
 import com.spotify.docker.client.messages.swarm.Placement;
 import com.spotify.docker.client.messages.swarm.PortConfig;
 import com.spotify.docker.client.messages.swarm.PortConfig.PortConfigPublishMode;
-import com.spotify.docker.client.messages.swarm.Preference;
 import com.spotify.docker.client.messages.swarm.RaftConfig;
 import com.spotify.docker.client.messages.swarm.ReplicatedService;
 import com.spotify.docker.client.messages.swarm.ResourceRequirements;
@@ -216,7 +215,6 @@ import com.spotify.docker.client.messages.swarm.SecretSpec;
 import com.spotify.docker.client.messages.swarm.Service;
 import com.spotify.docker.client.messages.swarm.ServiceMode;
 import com.spotify.docker.client.messages.swarm.ServiceSpec;
-import com.spotify.docker.client.messages.swarm.Spread;
 import com.spotify.docker.client.messages.swarm.Swarm;
 import com.spotify.docker.client.messages.swarm.SwarmInit;
 import com.spotify.docker.client.messages.swarm.SwarmSpec;
@@ -3611,7 +3609,7 @@ public class DefaultDockerClientTest {
     assertThat(notStarted.id(), is(execId));
     assertThat(notStarted.running(), is(false));
     if (dockerApiVersionLessThan("1.22")) {
-      assertThat(notStarted.exitCode(), is(0));
+      assertThat(notStarted.exitCode(), is(0L));
     } else {
       assertThat(notStarted.exitCode(), nullValue());
     }
@@ -3626,7 +3624,7 @@ public class DefaultDockerClientTest {
     final ExecState started = sut.execInspect(execId);
     assertThat(started.id(), is(execId));
     assertThat(started.running(), is(false));
-    assertThat(started.exitCode(), is(2));
+    assertThat(started.exitCode(), is(2L));
     assertThat(started.openStdin(), is(true));
     assertThat(started.openStderr(), is(true));
     assertThat(started.openStdout(), is(true));

--- a/src/test/java/com/spotify/docker/client/messages/ContainerStateTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/ContainerStateTest.java
@@ -63,7 +63,7 @@ public class ContainerStateTest {
     ContainerState.HealthLog log = health.log().get(0);
     assertThat(log.start(), is(new Date(1412236801547L)));
     assertThat(log.end(), is(new Date(1412236802697L)));
-    assertThat(log.exitCode(), is(1));
+    assertThat(log.exitCode(), is(1L));
     assertThat(log.output(), is("output"));
   }
 


### PR DESCRIPTION
This PR:
- Changes the exitCode type from Integer to Long
- Adds runtime property to HostConfig to support setting runtimes such as `nvidia`

