### PR TITLE
Correct execCreate() return type in docs' example

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -587,7 +587,7 @@ try (InputStream imagePayload = new BufferedInputStream(new FileInputStream(tarF
 ### Exec Create
 
 ```java
-final String execId = docker.execCreate(containerId, new String[]{"sh", "-c", "exit 2"});
+final String execId = docker.execCreate(containerId, new String[]{"sh", "-c", "exit 2"}).id();
 
 try (final LogStream stream = docker.execStart(execId)) {
   stream.readFully();


### PR DESCRIPTION
`execCreate()` returns `ExecCreation`, not a `String`