### PR TITLE
Issue #1066: promoting jackson deps to 2.9.6 in order to fix CVE-2018-7489

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,17 +89,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.9.4</version>
+      <version>2.9.6</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-guava</artifactId>
-      <version>2.9.4</version>
+      <version>2.9.6</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.4</version>
+      <version>2.9.6</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>


### PR DESCRIPTION
Issue #1066: promoting jackson deps to 2.9.6 in order to fix the issue CVE-2018-7489

More details here: https://nvd.nist.gov/vuln/detail/CVE-2018-7489.

Related issue: [1066](https://github.com/spotify/docker-client/issues/1066)

Thanks!
Petas