### PR TITLE
Change maven-compiler-plugin source and target from 1.7 to 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 language: java
 
 jdk:
-  - openjdk7
+  - oraclejdk8
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 8.14.0
+
+Not yet released
+
+- Change maven-compiler-plugin source and target from 1.7 to 1.8 to prepare for Java 8.
+  JAR should still be compatible with JRE 1.7.
+
 ## 8.13.0
 
 Released August 29 2018

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ If you're looking for how to build and develop it, keep reading.
 
 ## Prerequisites
 
-docker-client should be buildable on any platform with Docker 1.6+, JDK7+, and a recent version of
+docker-client should be buildable on any platform with Docker 1.6+, JDK8+, and a recent version of
 Maven 3.
 
 ### A note on using Docker for Mac

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>docker-client</artifactId>
-  <version>8.13.2-SNAPSHOT</version>
+  <version>8.14.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>docker-client</name>
   <description>A docker client</description>
@@ -245,8 +245,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Change maven-compiler-plugin source and target from 1.7 to 1.8

to prepare for Java 8.
JAR should still be compatible with JRE 1.7.

Set Travis CI JDK to `oraclejdk8`.

fixes #756