### PR TITLE
Fix flaky DefaultDockerClientTest.testListTaskWithCriteria()

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -137,6 +137,7 @@ import com.spotify.docker.client.exceptions.ImageNotFoundException;
 import com.spotify.docker.client.exceptions.ImagePushFailedException;
 import com.spotify.docker.client.exceptions.NetworkNotFoundException;
 import com.spotify.docker.client.exceptions.NotFoundException;
+import com.spotify.docker.client.exceptions.TaskNotFoundException;
 import com.spotify.docker.client.exceptions.UnsupportedApiVersionException;
 import com.spotify.docker.client.exceptions.VolumeNotFoundException;
 import com.spotify.docker.client.messages.AttachedNetwork;
@@ -5856,7 +5857,11 @@ public class DefaultDockerClientTest {
                                      final DockerClient client) {
     return new Callable<String>() {
       public String call() throws Exception {
-        return client.inspectTask(taskId).status().state();
+        try {
+          return client.inspectTask(taskId).status().state();
+        } catch (final TaskNotFoundException e) {
+          return "not found";
+        }
       }
     };
   }


### PR DESCRIPTION
This test was failing a lot on Travis CI because of a race condition.
Example of a test failure.
https://travis-ci.org/spotify/docker-client/jobs/436315580

Often times the task isn't present at the time `DockerClient.inspectTask()`
is called. Catch the exception and return "not found" if so.