### PR TITLE
Fix a NullPointerException when authentication with a a credHelper fails

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/RegistryConfigs.java
+++ b/src/main/java/com/spotify/docker/client/messages/RegistryConfigs.java
@@ -100,7 +100,9 @@ public abstract class RegistryConfigs {
     abstract ImmutableMap.Builder<String, RegistryAuth> configsBuilder();
 
     public Builder addConfig(final String server, final RegistryAuth registryAuth) {
-      configsBuilder().put(server, registryAuth);
+      if (registryAuth != null) {
+        configsBuilder().put(server, registryAuth);
+      }
       return this;
     }
 

--- a/src/test/java/com/spotify/docker/client/DockerConfigReaderTest.java
+++ b/src/test/java/com/spotify/docker/client/DockerConfigReaderTest.java
@@ -239,6 +239,7 @@ public class DockerConfigReaderTest {
 
     final String registry1 = "https://foo.io";
     final String registry2 = "https://adventure.zone";
+    final String registry3 = "https://beyond.zone";
     final DockerCredentialHelperAuth testAuth1 =
             DockerCredentialHelperAuth.create(
                     "cool user",
@@ -254,6 +255,7 @@ public class DockerConfigReaderTest {
 
     when(credentialHelperDelegate.get("a-cred-helper", registry1)).thenReturn(testAuth1);
     when(credentialHelperDelegate.get("magic-missile", registry2)).thenReturn(testAuth2);
+    when(credentialHelperDelegate.get("elusive-helper", registry3)).thenReturn(null);
 
     final RegistryConfigs expected = RegistryConfigs.builder()
             .addConfig(registry1, testAuth1.toRegistryAuth())

--- a/src/test/resources/dockerConfig/credHelpers.json
+++ b/src/test/resources/dockerConfig/credHelpers.json
@@ -1,7 +1,8 @@
 {
   "credHelpers": {
     "https://foo.io": "a-cred-helper",
-    "https://adventure.zone": "magic-missile"
+    "https://adventure.zone": "magic-missile",
+    "https://beyond.zone": "elusive-helper"
   },
   "credsStore": "fallback"
 }


### PR DESCRIPTION
## Symptoms

When docker is configured to authenticate to a private Google Container Registry (GCR for short), a credHelper of type `gcr` is added to `.docker/config.json`.

This renders this library unusable.
Simply running this code snippet:

```java
dockerClient = DefaultDockerClient.fromEnv().build();
dockerClient.build("/tmp", "superimage");
```

Throws the following NPE:

```
java.lang.NullPointerException: null value in entry: appengine.gcr.io=null
        at com.google.common.collect.CollectPreconditions.checkEntryNotNull(CollectPreconditions.java:34) ~[guava-20.0.jar:na]
        at com.google.common.collect.ImmutableMapEntry.<init>(ImmutableMapEntry.java:49) ~[guava-20.0.jar:na]
        at com.google.common.collect.ImmutableMap.entryOf(ImmutableMap.java:122) ~[guava-20.0.jar:na]
        at com.google.common.collect.ImmutableMap$Builder.put(ImmutableMap.java:198) ~[guava-20.0.jar:na]
        at com.spotify.docker.client.messages.RegistryConfigs$Builder.addConfig(RegistryConfigs.java:103) ~[docker-client-8.13.1.jar:8.13.1]
        at com.spotify.docker.client.DockerConfigReader.authForAllRegistries(DockerConfigReader.java:135) ~[docker-client-8.13.1.jar:8.13.1]
        at com.spotify.docker.client.auth.ConfigFileRegistryAuthSupplier.authForBuild(ConfigFileRegistryAuthSupplier.java:106) ~[docker-client-8.13.1.jar:8.13.1]
        at com.spotify.docker.client.DefaultDockerClient.build(DefaultDockerClient.java:1468) ~[docker-client-8.13.1.jar:8.13.1]
        at com.spotify.docker.client.DefaultDockerClient.build(DefaultDockerClient.java:1445) ~[docker-client-8.13.1.jar:8.13.1]
        at com.spotify.docker.client.DefaultDockerClient.build(DefaultDockerClient.java:1431) ~[docker-client-8.13.1.jar:8.13.1]
```

## Cause

`DockerConfigReader` tries to authenticate for all registries, including the GCR ones.

To do this, it repeatedly executes the command:

`docker-credential-${credHelper} get`

feeding it the registry url via stdin.

If the executed command returns `credentials not found in native keychain`, `null` is returned and later gets stored as a value in a Guava `ImmutableMap`, which throws the `NPE`.

The GCR credsHelper works differently, as it requires you to execute:

`docker-credential-gcr gcr-login`

Which opens a browser with the Google auth page.

## Proposed fix

If the authentication to a registry fails, skip it and do not try to store `null` as a value in the authentications map.