### PR TITLE
Shading: Relocate com.github.jnr artifacts to avoid classpath issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,10 @@
               <pattern>org.objectweb.asm</pattern>
               <shadedPattern>com.spotify.docker.client.shaded.org.objectweb.asm</shadedPattern>
             </relocation>
+            <relocation>
+              <pattern>jnr</pattern>
+              <shadedPattern>com.spotify.docker.client.shaded.jnr</shadedPattern>
+            </relocation>
           </relocations>
           <shadedArtifactAttached>true</shadedArtifactAttached>
           <transformers>


### PR DESCRIPTION
Trying to fix a conflict with [cassandra-driver-core](https://search.maven.org/search?q=g:com.datastax.cassandra%20a:cassandra-driver-core) (which has a couple of dependencies to `com.github.jnr` artifacts) by relocating package `jnr` to `com.spotify.docker.client.shaded.jnr`.

As discussed at https://github.com/spotify/docker-client/pull/272#issuecomment-429827338.

I did try to run tests locally but I had failures even before my changes, probably because my Docker setup is a bit complicated with some custom network details. I'm guessing that by creating this PR the tests will be run automatically.