### PR TITLE
Upgrade org.apache.commons:commons-compress to fix vuln

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.9</version>
+      <version>1.18</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
See CVE-2018-11771 https://nvd.nist.gov/vuln/detail/CVE-2018-11771.