### PR TITLE
Add ability to query secrets using filter criteria

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -2602,7 +2602,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   @Override
   public List<Secret> listSecrets(final Secret.Criteria criteria)
       throws DockerException, InterruptedException {
-    assertApiVersionIsAbove("1.24");
+    assertApiVersionIsAbove("1.25");
 
     final Map<String, List<String>> filters = new HashMap<>();
 

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -2600,6 +2600,38 @@ public class DefaultDockerClient implements DockerClient, Closeable {
   }
 
   @Override
+  public List<Secret> listSecrets(final Secret.Criteria criteria)
+      throws DockerException, InterruptedException {
+    assertApiVersionIsAbove("1.24");
+
+    final Map<String, List<String>> filters = new HashMap<>();
+
+    if (criteria.secretId() != null) {
+      filters.put("id", Collections.singletonList(criteria.secretId()));
+    }
+    if (criteria.label() != null) {
+      filters.put("label", Collections.singletonList(criteria.label()));
+    }
+    if (criteria.name() != null) {
+      filters.put("name", Collections.singletonList(criteria.name()));
+    }
+
+    final WebTarget resource = resource().path("secrets")
+        .queryParam("filters", urlEncodeFilters(filters));
+
+    try {
+      return request(GET, SECRET_LIST, resource, resource.request(APPLICATION_JSON_TYPE));
+    } catch (DockerRequestException e) {
+      switch (e.status()) {
+        case 503:
+          throw new NonSwarmNodeException("node is not part of a swarm", e);
+        default:
+          throw e;
+      }
+    }
+  }
+
+  @Override
   public SecretCreateResponse createSecret(final SecretSpec secret)
       throws DockerException, InterruptedException {
     assertApiVersionIsAbove("1.25");

--- a/src/main/java/com/spotify/docker/client/DockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DockerClient.java
@@ -2812,6 +2812,17 @@ public interface DockerClient extends Closeable {
   List<Secret> listSecrets() throws DockerException, InterruptedException;
 
   /**
+   * List secrets.
+   * @param criteria Secret listing and filtering options
+   * @return a list of secrets.
+   * @throws DockerException      if a server error occurred (500)
+   * @throws InterruptedException if the thread is interrupted
+   * @since Docker 1.13, API version 1.25
+   */
+  List<Secret> listSecrets(final Secret.Criteria criteria)
+      throws DockerException, InterruptedException;
+
+  /**
    * Create a secret.
    * @param secret The spec for the secret.
    * @return {@link SecretCreateResponse}

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Secret.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Secret.java
@@ -30,6 +30,8 @@ import com.google.auto.value.AutoValue;
 
 import java.util.Date;
 
+import javax.annotation.Nullable;
+
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 public abstract class Secret {
@@ -49,6 +51,42 @@ public abstract class Secret {
   @JsonProperty("Spec")
   public abstract SecretSpec secretSpec();
   
+  @AutoValue
+  public abstract static class Criteria {
+    /**
+     * Filter by secret id.
+     */
+    @Nullable
+    public abstract String secretId();
+
+    /**
+     * Filter by label.
+     */
+    @Nullable
+    public abstract String label();
+
+    /**
+     * Filter by secret name.
+     */
+    @Nullable
+    public abstract String name();
+
+    public static Secret.Criteria.Builder builder() {
+      return new AutoValue_Secret_Criteria.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+      public abstract Secret.Criteria.Builder secretId(String nodeId);
+
+      public abstract Secret.Criteria.Builder label(String label);
+
+      public abstract Secret.Criteria.Builder name(String nodeName);
+
+      public abstract Secret.Criteria build();
+    }
+  }
+
   @JsonCreator
   static Secret create(
       @JsonProperty("ID") final String id,


### PR DESCRIPTION
Added `listSecrets(Criteria criteria)` to `DockerClient `and `DefaultDockerClient`. Essentially copied the code used by `listConfig` and `Config.Criteria`. I looked for unit test code for Secret and Config but didn't find any so I didn't include any tests. I have verified this functionality with my local swarm.