### PR TITLE
Fixed bug in a unit test which caused test to block indefinitely

### DIFF
--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -237,6 +237,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -1039,9 +1040,10 @@ public class DefaultDockerClientTest {
           sut.removeImage(imageName);
         } catch (DockerException ignored) {
         }
-        final String dockerDirectory = Resources.getResource("dockerDirectorySleeping").getPath();
+        final URL dockerDirectoryUrl = Resources.getResource("dockerDirectorySleeping");
+        final Path dockerDirectory = Paths.get(dockerDirectoryUrl.toURI());
 
-        sut.build(Paths.get(dockerDirectory), imageName, message -> {
+        sut.build(dockerDirectory, imageName, message -> {
           if (!started.isDone()) {
             started.set(true);
           }
@@ -1049,6 +1051,9 @@ public class DefaultDockerClientTest {
       } catch (InterruptedException e) {
         interrupted.set(true);
         throw e;
+      } catch (Throwable t) {
+        started.setException(t);
+        throw t;
       }
       return null;
     });


### PR DESCRIPTION
The test DefaultDockerClientTest.testBuildInterruption() was lacking an
Exception catch-all. Without it, the spawned thread would not complete
the 'started' future and the test would block forever waiting for it to
complete.

This would happen on Windows systems due to a bug also fixed by this
commit. The code was using URL.getPath() to initialize a Path. This
is not safe on Windows systems due to the drive letter (eg 'C:'). The
fix uses standard NIO APIs to produce a Path from the URL. This is
done in a platform agnostic manner.