### PR TITLE
Fix Issue #875 - windows named pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.14.5
+
+- Support for Windows 10 Docker named pipes ([875][])
+
 ## 8.14.0
 
 Released October 4 2018

--- a/src/main/java/com/spotify/docker/client/DockerHost.java
+++ b/src/main/java/com/spotify/docker/client/DockerHost.java
@@ -61,6 +61,7 @@ public class DockerHost {
   private static SystemDelegate systemDelegate = defaultSystemDelegate;
 
   private static final String DEFAULT_UNIX_ENDPOINT = "unix:///var/run/docker.sock";
+  private static final String DEFAULT_WINDOWS_ENDPOINT = "npipe:////./pipe/docker_engine";
   private static final String DEFAULT_ADDRESS = "localhost";
   private static final int DEFAULT_PORT = 2375;
 
@@ -187,6 +188,9 @@ public class DockerHost {
     final String os = osName.toLowerCase(Locale.ENGLISH);
     if (os.equalsIgnoreCase("linux") || os.contains("mac")) {
       return DEFAULT_UNIX_ENDPOINT;
+    } else if (System.getProperty("os.name").equalsIgnoreCase("Windows 10")) {
+      //from Docker doc: Windows 10 64bit: Pro, Enterprise or Education
+      return DEFAULT_WINDOWS_ENDPOINT;
     } else {
       return DEFAULT_ADDRESS + ":" + defaultPort();
     }
@@ -198,6 +202,10 @@ public class DockerHost {
 
   public static String defaultUnixEndpoint() {
     return DEFAULT_UNIX_ENDPOINT;
+  }
+
+  public static String defaultWindowsEndpoint() {
+    return DEFAULT_WINDOWS_ENDPOINT;
   }
 
   public static String defaultAddress() {

--- a/src/main/java/com/spotify/docker/client/npipe/NamedPipeSocket.java
+++ b/src/main/java/com/spotify/docker/client/npipe/NamedPipeSocket.java
@@ -1,0 +1,308 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.npipe;
+
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.RandomAccessFile;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SocketChannel;
+
+public class NamedPipeSocket extends Socket {
+
+  private final Object connectLock = new Object();
+  private volatile boolean inputShutdown;
+  private volatile boolean outputShutdown;
+
+  private String socketPath;
+  private volatile SocketAddress socketAddress;
+  private RandomAccessFile namedPipe;
+
+  private FileChannel channel;
+
+  NamedPipeSocket() throws IOException {
+  }
+
+  @Override
+  public void connect(SocketAddress endpoint) throws IOException {
+    connect(endpoint, 0);
+  }
+
+  @Override
+  public void connect(SocketAddress endpoint, int timeout) throws IOException {
+    if (timeout < 0) {
+      throw new IllegalArgumentException("Timeout may not be negative: " + timeout);
+    }
+
+    if (!(endpoint instanceof NpipeSocketAddress)) {
+      throw new IllegalArgumentException("Unsupported address type: " 
+        + endpoint.getClass().getName());
+    }
+
+    this.socketAddress = endpoint;
+    this.socketPath = ((NpipeSocketAddress) endpoint).path();
+
+    synchronized (connectLock) {
+      this.namedPipe = new RandomAccessFile(socketPath, "rw");
+      this.channel = this.namedPipe.getChannel();
+    }
+  }
+
+  @Override
+  public void bind(SocketAddress bindpoint) throws IOException {
+    throw new SocketException("Bind is not supported");
+  }
+
+  @Override
+  public InetAddress getInetAddress() {
+    return null;
+  }
+
+  @Override
+  public InetAddress getLocalAddress() {
+    return null;
+  }
+
+  @Override
+  public int getPort() {
+    return -1;
+  }
+
+  @Override
+  public int getLocalPort() {
+    return -1;
+  }
+
+  @Override
+  public SocketAddress getRemoteSocketAddress() {
+    return socketAddress;
+  }
+
+  @Override
+  public SocketAddress getLocalSocketAddress() {
+    return null;
+  }
+
+  @Override
+  public SocketChannel getChannel() {
+    return null;
+  }
+
+  @Override
+  public InputStream getInputStream() throws IOException {
+    if (!channel.isOpen()) {
+      throw new SocketException("Socket is closed");
+    }
+
+    if (inputShutdown) {
+      throw new SocketException("Socket input is shutdown");
+    }
+
+    return new FilterInputStream(Channels.newInputStream(channel)) {
+      @Override
+      public void close() throws IOException {
+        shutdownInput();
+      }
+    };
+  }
+
+  @Override
+  public OutputStream getOutputStream() throws IOException {
+    if (!channel.isOpen()) {
+      throw new SocketException("Socket is closed");
+    }
+
+    if (outputShutdown) {
+      throw new SocketException("Socket output is shutdown");
+    }
+
+    return new FilterOutputStream(Channels.newOutputStream(channel)) {   
+      @Override
+      public void close() throws IOException {
+        shutdownOutput();
+      }
+    };
+  }
+
+  @Override
+  public void sendUrgentData(int data) throws IOException {
+    throw new SocketException("Urgent data not supported");
+  }
+
+  @Override
+  public void setSoTimeout(int timeout) {
+  }
+
+  @Override
+  public int getSoTimeout() throws SocketException {
+    return 0;
+  }
+
+  @Override
+  public void setSendBufferSize(int size) throws SocketException {
+    if (size <= 0) {
+      throw new IllegalArgumentException("Send buffer size must be positive: " + size);
+    }
+
+    if (!channel.isOpen()) {
+      throw new SocketException("Socket is closed");
+    }
+
+    // just ignore
+  }
+
+  @Override
+  public synchronized int getSendBufferSize() throws SocketException {
+    if (!channel.isOpen()) {
+      throw new SocketException("Socket is closed");
+    }
+
+    throw new UnsupportedOperationException("Getting the send buffer size is not supported");
+  }
+
+  @Override
+  public synchronized void setReceiveBufferSize(int size) throws SocketException {
+    if (size <= 0) {
+      throw new IllegalArgumentException("Receive buffer size must be positive: " + size);
+    }
+
+    if (!channel.isOpen()) {
+      throw new SocketException("Socket is closed");
+    }
+
+    // just ignore
+  }
+
+  @Override
+  public synchronized int getReceiveBufferSize() throws SocketException {
+    if (!channel.isOpen()) {
+      throw new SocketException("Socket is closed");
+    }
+
+    throw new UnsupportedOperationException("Getting the receive buffer size is not supported");
+  }
+
+  @Override
+  public void setKeepAlive(boolean on) throws SocketException {
+  }
+
+  @Override
+  public boolean getKeepAlive() throws SocketException {
+    return true;
+  }
+
+  @Override
+  public void setTrafficClass(int tc) throws SocketException {
+    if (tc < 0 || tc > 255) {
+      throw new IllegalArgumentException("Traffic class is not in range 0 -- 255: " + tc);
+    }
+
+    if (isClosed()) {
+      throw new SocketException("Socket is closed");
+    }
+
+    // just ignore
+  }
+
+  @Override
+  public int getTrafficClass() throws SocketException {
+    throw new UnsupportedOperationException("Getting the traffic class is not supported");
+  }
+
+  @Override
+  public void setReuseAddress(boolean on) throws SocketException {
+    // just ignore
+  }
+
+  @Override
+  public boolean getReuseAddress() throws SocketException {
+    throw new UnsupportedOperationException("Getting the SO_REUSEADDR option is not supported");
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (isClosed()) {
+      return;
+    }
+    if (channel != null) {
+      channel.close();
+    }
+    inputShutdown = true;
+    outputShutdown = true;
+  }
+
+  @Override
+  public void shutdownInput() throws IOException {
+    inputShutdown = true;
+  }
+
+  @Override
+  public void shutdownOutput() throws IOException {
+    outputShutdown = true;
+  }
+
+  @Override
+  public String toString() {
+    if (isConnected()) {
+      return "WindowsPipe[addr=" + this.socketPath + ']';
+    }
+
+    return "WindowsPipe[unconnected]";
+  }
+
+  @Override
+  public boolean isConnected() {
+    return !isClosed();
+  }
+
+  @Override
+  public boolean isBound() {
+    return false;
+  }
+
+  @Override
+  public boolean isClosed() {
+    return channel != null && !channel.isOpen();
+  }
+
+  @Override
+  public boolean isInputShutdown() {
+    return inputShutdown;
+  }
+
+  @Override
+  public boolean isOutputShutdown() {
+    return outputShutdown;
+  }
+
+  @Override
+  public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
+    // no-op
+  }
+}

--- a/src/main/java/com/spotify/docker/client/npipe/NpipeConnectionSocketFactory.java
+++ b/src/main/java/com/spotify/docker/client/npipe/NpipeConnectionSocketFactory.java
@@ -1,0 +1,79 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.npipe;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.URI;
+
+import org.apache.http.HttpHost;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.protocol.HttpContext;
+
+/**
+ * Provides a ConnectionSocketFactory for connecting Apache HTTP clients to windows named pipe.
+ */
+@Contract(threading = ThreadingBehavior.IMMUTABLE_CONDITIONAL)
+public class NpipeConnectionSocketFactory implements ConnectionSocketFactory {
+
+  private File socketFile;
+
+  public NpipeConnectionSocketFactory(final URI socketUri) {
+    super();
+
+    final String filename = socketUri.toString()
+        .replaceAll("^npipe:///", "npipe://localhost/")
+        .replaceAll("^npipe://localhost", "");
+
+    this.socketFile = new File(filename);
+  }
+
+  public static URI sanitizeUri(final URI uri) {
+    if (uri.getScheme().equals("npipe")) {
+      return URI.create("npipe://localhost:80");
+    } else {
+      return uri;
+    }
+  }
+
+  @Override
+  public Socket createSocket(final HttpContext context) throws IOException {
+    return new NamedPipeSocket();
+  }
+
+  @Override
+  public Socket connectSocket(final int connectTimeout,
+                              final Socket socket,
+                              final HttpHost host,
+                              final InetSocketAddress remoteAddress,
+                              final InetSocketAddress localAddress,
+                              final HttpContext context) throws IOException {
+    if (!(socket instanceof NamedPipeSocket)) {
+      throw new AssertionError("Unexpected socket: " + socket);
+    }
+    socket.connect(new NpipeSocketAddress(socketFile), connectTimeout);
+    return socket;
+  }
+}

--- a/src/main/java/com/spotify/docker/client/npipe/NpipeSocketAddress.java
+++ b/src/main/java/com/spotify/docker/client/npipe/NpipeSocketAddress.java
@@ -1,0 +1,74 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client.npipe;
+
+import java.io.File;
+
+class NpipeSocketAddress extends java.net.SocketAddress {
+
+  private static final long serialVersionUID = 1L;
+
+  private String path;
+
+  NpipeSocketAddress(File path) {
+    this.path = path.getPath();
+  }
+
+  public String path() {
+    return path;
+  }
+
+  @Override
+  public String toString() {
+    return "NpipeSocketAddress{path=" + path + "}";
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((path == null) ? 0 : path.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    NpipeSocketAddress other = (NpipeSocketAddress) obj;
+    if (path == null) {
+      if (other.path != null) {
+        return false;
+      }
+    } else if (!path.equals(other.path)) {
+      return false;
+    }
+    return true;
+  }
+  
+}

--- a/src/test/java/com/spotify/docker/client/NpipeConnectionSocketFactoryTest.java
+++ b/src/test/java/com/spotify/docker/client/NpipeConnectionSocketFactoryTest.java
@@ -1,0 +1,84 @@
+/*-
+ * -\-\-
+ * docker-client
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.docker.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.spotify.docker.client.npipe.NamedPipeSocket;
+import com.spotify.docker.client.npipe.NpipeConnectionSocketFactory;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.URI;
+import java.nio.channels.SocketChannel;
+
+import javax.net.ssl.SSLSocket;
+
+import org.apache.http.HttpHost;
+import org.apache.http.protocol.HttpContext;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class NpipeConnectionSocketFactoryTest {
+
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
+
+  private NpipeConnectionSocketFactory sut;
+
+  @Before
+  public void setup() throws Exception {
+    sut = new NpipeConnectionSocketFactory(new URI("npipe://localhost"));
+  }
+
+  @Test
+  public void testSanitizeUri() throws Exception {
+    final URI npipeUri = NpipeConnectionSocketFactory.sanitizeUri(URI.create("npipe://localhost"));
+    assertThat(npipeUri, equalTo(URI.create("npipe://localhost:80")));
+
+    final URI nonNpipeUri = URI.create("http://127.0.0.1");
+    final URI uri = NpipeConnectionSocketFactory.sanitizeUri(nonNpipeUri);
+    assertThat(uri, equalTo(nonNpipeUri));
+  }
+
+  @Test
+  public void testConnectSocket() throws Exception {
+    final NamedPipeSocket npipeSocket = mock(NamedPipeSocket.class);
+    when(npipeSocket.getChannel()).thenReturn(mock(SocketChannel.class));
+    final Socket socket = sut.connectSocket(10, npipeSocket, HttpHost.create("http://foo.com"),
+        mock(InetSocketAddress.class), mock(InetSocketAddress.class), mock(HttpContext.class));
+    assertThat(socket, IsInstanceOf.instanceOf(NamedPipeSocket.class));
+    assertThat((NamedPipeSocket) socket, equalTo(npipeSocket));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testConnectSocketNotUnixSocket() throws Exception {
+    sut.connectSocket(10, mock(SSLSocket.class), HttpHost.create("http://foo.com"),
+        mock(InetSocketAddress.class), mock(InetSocketAddress.class), mock(HttpContext.class));
+  }
+
+}


### PR DESCRIPTION
This PR added support for Docker for Windows - https://docs.docker.com/docker-for-windows/install/ that supports only Windows 10 1607 Anniversary Update or later. This Docker in default configuration used Windows duplex named pipe.