### PR TITLE
Upgrade jackson deps to from 2.9.6 to latest 2.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,17 +89,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.9.6</version>
+      <version>2.9.8</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-guava</artifactId>
-      <version>2.9.6</version>
+      <version>2.9.8</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.6</version>
+      <version>2.9.8</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>


### PR DESCRIPTION
This patches a vulnerability in jackson-databind

* CVE-2018-19360
* CVE-2018-19362
* CVE-2018-19361
* CVE-2018-14718
* CVE-2018-14721
* CVE-2018-14719
* CVE-2018-14720

Upgrade the other jackson deps to the same latest version for consistency.