### PR TITLE
add read fully with stop sign

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultLogStream.java
+++ b/src/main/java/com/spotify/docker/client/DefaultLogStream.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 
 class DefaultLogStream extends AbstractIterator<LogMessage> implements LogStream {
 
@@ -76,6 +77,18 @@ class DefaultLogStream extends AbstractIterator<LogMessage> implements LogStream
     final StringBuilder stringBuilder = new StringBuilder();
     while (hasNext()) {
       stringBuilder.append(UTF_8.decode(next().content()));
+    }
+    return stringBuilder.toString();
+  }
+
+  public String readFully(String stop) {
+    final StringBuilder stringBuilder = new StringBuilder();
+    while (hasNext()) {
+      CharBuffer decode = UTF_8.decode(next().content());
+      stringBuilder.append(decode);
+      if (decode.toString().contains(stop)) {
+        break;
+      }
     }
     return stringBuilder.toString();
   }

--- a/src/main/java/com/spotify/docker/client/LogReader.java
+++ b/src/main/java/com/spotify/docker/client/LogReader.java
@@ -20,9 +20,6 @@
 
 package com.spotify.docker.client;
 
-import static com.google.common.io.ByteStreams.copy;
-import static com.google.common.io.ByteStreams.nullOutputStream;
-
 import com.google.common.io.ByteStreams;
 import com.spotify.docker.client.LogMessage.Stream;
 
@@ -30,6 +27,8 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+
+import org.glassfish.jersey.message.internal.ReaderInterceptorExecutor;
 
 public class LogReader implements Closeable {
 
@@ -75,6 +74,7 @@ public class LogReader implements Closeable {
     // Jersey will close the stream and release the connection after we read all the data.
     // We cannot call the stream's close method because it an instance of UncloseableInputStream,
     // where close is a no-op.
-    copy(stream, nullOutputStream());
+    InputStream inputStream = ReaderInterceptorExecutor.closeableInputStream(stream);
+    inputStream.close();
   }
 }

--- a/src/main/java/com/spotify/docker/client/LogStream.java
+++ b/src/main/java/com/spotify/docker/client/LogStream.java
@@ -29,6 +29,8 @@ public interface LogStream extends Iterator<LogMessage>, Closeable {
 
   String readFully();
 
+  String readFully(String stop);
+
   /**
    * Attaches two {@link java.io.OutputStream}s to the {@link LogStream}.  Closes the streams after
    * use.

--- a/src/test/java/com/spotify/docker/client/DefaultLogStreamTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultLogStreamTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 public class DefaultLogStreamTest {
@@ -51,6 +52,23 @@ public class DefaultLogStreamTest {
 
     assertThat(stdout.toString(), is("hello\nworld!\n"));
     assertThat(stderr.toString(), is("oops\n"));
+  }
+  
+  @Test
+  public void testReadFullyWithStopWord() throws Exception {
+    when(reader.nextMessage()).thenReturn(
+            logMessage(LogMessage.Stream.STDOUT, "hello\n"),
+            logMessage(LogMessage.Stream.STDERR, "oops\n"),
+            logMessage(LogMessage.Stream.STDOUT, "world!\n"),
+            logMessage(LogMessage.Stream.STDOUT, "Stop world\n"),
+            logMessage(LogMessage.Stream.STDOUT, "Next!\n"),
+            logMessage(LogMessage.Stream.STDOUT, "Logs!\n")
+    );
+
+    String output = logStream.readFully("Stop world");
+
+    Assert.assertTrue(output.contains("Stop world"));
+    Assert.assertFalse(output.contains("Next"));
   }
 
   private static LogMessage logMessage(LogMessage.Stream stream, String msg) {


### PR DESCRIPTION
workaround for https://github.com/spotify/docker-client/issues/1133 added stop sign to readFully method, when stream line contains stop sign/stop string we stop to read 