### PR TITLE
JNI error on upgrade from 8.14.5-shaded to 8.15.0-shaded (#1134)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,9 @@
               <include>org.apache.httpcomponents:httpcore</include>
               <include>asm:asm</include>
             </includes>
+			<excludes>
+              <exclude>com.github.jnr:jffi</exclude>
+            </excludes>
           </artifactSet>
           <relocations>
             <relocation>
@@ -394,8 +397,12 @@
               <shadedPattern>com.spotify.docker.client.shaded.org.jvnet</shadedPattern>
             </relocation>
             <relocation>
-              <pattern>com.kenai</pattern>
-              <shadedPattern>com.spotify.docker.client.shaded.com.kenai</shadedPattern>
+              <pattern>com.kenai.constantine</pattern>
+              <shadedPattern>com.spotify.docker.client.shaded.com.kenai.constantine</shadedPattern>
+            </relocation>
+			<relocation>
+              <pattern>com.kenai.jnr</pattern>
+              <shadedPattern>com.spotify.docker.client.shaded.com.kenai.jnr</shadedPattern>
             </relocation>
             <relocation>
               <pattern>mozilla</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
               <include>org.apache.httpcomponents:httpcore</include>
               <include>asm:asm</include>
             </includes>
-			<excludes>
+            <excludes>
               <exclude>com.github.jnr:jffi</exclude>
             </excludes>
           </artifactSet>
@@ -400,7 +400,7 @@
               <pattern>com.kenai.constantine</pattern>
               <shadedPattern>com.spotify.docker.client.shaded.com.kenai.constantine</shadedPattern>
             </relocation>
-			<relocation>
+            <relocation>
               <pattern>com.kenai.jnr</pattern>
               <shadedPattern>com.spotify.docker.client.shaded.com.kenai.jnr</shadedPattern>
             </relocation>


### PR DESCRIPTION
Do not include com.github.jnr:jffi with native implementations in it, because they are not renamed properly.