### PR TITLE
Read configuration file from directory supplied in DOCKER_HOST

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -23,7 +23,6 @@
 
 package com.spotify.docker.client;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Optional.fromNullable;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -50,8 +49,10 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicates;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.CharStreams;
@@ -145,6 +146,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2929,8 +2931,11 @@ public class DefaultDockerClient implements DockerClient, Closeable {
    */
   public static Builder fromEnv() throws DockerCertificateException {
     final String endpoint = DockerHost.endpointFromEnv();
-    final Path dockerCertPath = Paths.get(firstNonNull(DockerHost.certPathFromEnv(),
-                                                       DockerHost.defaultCertPath()));
+    final Path dockerCertPath = Paths.get(Iterables.find(
+        Arrays.asList(DockerHost.certPathFromEnv(),
+            DockerHost.configPathFromEnv(),
+            DockerHost.defaultCertPath()),
+        Predicates.notNull()));
 
     final Builder builder = new Builder();
 

--- a/src/main/java/com/spotify/docker/client/DockerConfigReader.java
+++ b/src/main/java/com/spotify/docker/client/DockerConfigReader.java
@@ -253,6 +253,11 @@ public class DockerConfigReader {
   }
 
   public Path defaultConfigPath() {
+    if (DockerHost.configPathFromEnv() != null) {
+      final Path dockerConfig = Paths.get(DockerHost.configPathFromEnv(), "config.json");
+      LOG.debug("Using config path from DOCKER_CONFIG: {}", dockerConfig);
+      return dockerConfig;
+    }
     final String home = System.getProperty("user.home");
     final Path dockerConfig = Paths.get(home, ".docker", "config.json");
     final Path dockerCfg = Paths.get(home, ".dockercfg");

--- a/src/main/java/com/spotify/docker/client/DockerHost.java
+++ b/src/main/java/com/spotify/docker/client/DockerHost.java
@@ -237,6 +237,10 @@ public class DockerHost {
     return systemDelegate.getenv("DOCKER_CERT_PATH");
   }
 
+  static String configPathFromEnv() {
+    return systemDelegate.getenv("DOCKER_CONFIG");
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)

--- a/src/test/java/com/spotify/docker/client/DockerConfigReaderTest.java
+++ b/src/test/java/com/spotify/docker/client/DockerConfigReaderTest.java
@@ -328,4 +328,24 @@ public class DockerConfigReaderTest {
         .build();
     assertThat(reader.authForAllRegistries(path), is(registryConfigs));
   }
+
+  @Test
+  public void testConfigFromEnv() throws IOException {
+    DockerHost.SystemDelegate systemDelegate = mock(DockerHost.SystemDelegate.class);
+    when(systemDelegate.getenv("DOCKER_CONFIG"))
+      .thenReturn("src/test/resources/dockerConfigFromEnv");
+    when(systemDelegate.getProperty("os.name")).thenReturn(System.getProperty("os.name"));
+    DockerHost.setSystemDelegate(systemDelegate);
+    try {
+      DockerConfigReader dockerConfigReader = new DockerConfigReader();
+      Path path = dockerConfigReader.defaultConfigPath();
+      assertThat(path.toString().replace("\\", "/"), 
+          equalTo("src/test/resources/dockerConfigFromEnv/config.json"));
+
+      final RegistryAuth registryAuth = dockerConfigReader.anyRegistryAuth();
+      assertThat(registryAuth, equalTo(DOCKER_AUTH_CONFIG));
+    } finally {
+      DockerHost.restoreSystemDelegate();
+    }
+  }
 }

--- a/src/test/java/com/spotify/docker/client/DockerHostTest.java
+++ b/src/test/java/com/spotify/docker/client/DockerHostTest.java
@@ -69,6 +69,13 @@ public class DockerHostTest {
   }
 
   @Test
+  public void testConfigFromEnv() {
+    when(systemDelegate.getenv("DOCKER_CONFIG")).thenReturn("foodir");
+    DockerHost.setSystemDelegate(systemDelegate);
+    assertThat(DockerHost.configPathFromEnv(), equalTo("foodir"));
+  }
+
+  @Test
   public void testDefaultUnixEndpoint() throws Exception {
     assertThat(DockerHost.defaultUnixEndpoint(), equalTo("unix:///var/run/docker.sock"));
   }

--- a/src/test/resources/dockerConfigFromEnv/config.json
+++ b/src/test/resources/dockerConfigFromEnv/config.json
@@ -1,0 +1,8 @@
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "ZG9ja2VybWFuOnN3NGd5MGxvCg==",
+      "email": "dockerman@hub.com"
+    }
+  }
+}


### PR DESCRIPTION
This is related to an issue when using dockerfile-maven and Jenkins (https://github.com/spotify/dockerfile-maven/issues/191)
If the environment variable DOCKER_HOST is defined, docker.config and certificates should be loaded from this directory.
