### PR TITLE
Bump jnr-unixsocket to support aarch64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.38.15</version>
+      <version>0.38.17</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.18</version>
+      <version>0.38.15</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>


### PR DESCRIPTION
Needed for dockerfile-maven plugin to to work on Apple M1 laptops

See https://github.com/jnr/jnr-unixsocket/issues/95